### PR TITLE
show hook source

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1341,7 +1341,7 @@ namespace DevHub {
 	 * @return array
 	 */
 	function get_post_types_with_source_code() {
-		return array( 'wp-parser-class', 'wp-parser-method', 'wp-parser-function' );
+		return array( 'wp-parser-class', 'wp-parser-method', 'wp-parser-function', 'wp-parser-hook' );
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1202,19 +1202,23 @@
 	.source-code-links {
 		margin-left: 2em;
 		margin-top: 1em;
-	}
 
-	.source-code-links span {
-		border-left: 1px solid #999;
-		margin-left: 1em;
-		padding-left: 1em;
-	}
+		span {
+			border-right: 1px solid #999;
+			margin-right: 1em;
+			padding-right: 1em;
 
-	.source-code-links span:first-child {
-		display: none;
-		border-left: 0;
-		margin-left: 1em;
-		padding-left: 0;
+			&:last-of-type {
+				border-right: none;
+			}
+
+			&:first-child {
+				display: none;
+				border-left: 0;
+				margin-left: 1em;
+				padding-left: 0;
+			}
+		}
 	}
 
 	.source-code-container {

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1610,9 +1610,9 @@ input {
 }
 
 .devhub-wrap .source-code-links span {
-  border-left: 1px solid #999;
-  margin-left: 1em;
-  padding-left: 1em;
+  border-right: 1px solid #999;
+  margin-right: 1em;
+  padding-right: 1em;
 }
 
 .devhub-wrap .source-code-links span:first-child {
@@ -1620,6 +1620,10 @@ input {
   border-left: 0;
   margin-left: 1em;
   padding-left: 0;
+}
+
+.devhub-wrap .source-code-links span:last-of-type {
+  border-right: none;
 }
 
 .devhub-wrap .source-code-container {


### PR DESCRIPTION
Fixes #27

This enables showing source for hooks.

Testing: This requires re-parsing the codebase after applying, or perhaps only running `wp devhub pre-cache-source`

| Before (See #27) | After |
| --- | --- |
| <img width="963" alt="Screen Shot 2022-05-30 at 1 09 16 pm" src="https://user-images.githubusercontent.com/767313/170910412-d97deb2a-dadc-479e-8c94-8ab1c6759f34.png">  | <img width="964" alt="Screen Shot 2022-05-30 at 2 28 17 pm" src="https://user-images.githubusercontent.com/767313/170917217-0a45a210-1c24-4b88-8ca5-b95487a615ff.png">  | 
