### PR TITLE
Add dedicated hook section

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1245,10 +1245,24 @@ namespace DevHub {
 	 * @return boolean
 	 */
 	function post_type_has_uses_info( $post_type = null ) {
-		$post_type             = $post_type ? $post_type : get_post_type();
-		$post_types_with_uses  = array( 'wp-parser-function', 'wp-parser-method', 'wp-parser-class' );
+		$post_type            = $post_type ? $post_type : get_post_type();
+		$post_types_with_uses = array( 'wp-parser-function', 'wp-parser-method', 'wp-parser-class' );
 
 		return in_array( $post_type, $post_types_with_uses );
+	}
+
+	/**
+	 * Does the post type support hooks information?
+	 *
+	 * @param string $post_type Optional. The post type name. If blank, assumes current post type.
+	 *
+	 * @return boolean
+	 */
+	function post_type_has_hooks_info( $post_type = null ) {
+		$post_type             = $post_type ? $post_type : get_post_type();
+		$post_types_with_hooks = array( 'wp-parser-function', 'wp-parser-method' );
+
+		return in_array( $post_type, $post_types_with_hooks );
 	}
 
 	/**
@@ -1272,15 +1286,42 @@ namespace DevHub {
 			) );
 			return $connected;
 		} elseif ( 'wp-parser-function' === $post_type ) {
-			$connection_types = array( 'functions_to_functions', 'functions_to_methods', 'functions_to_hooks' );
+			$connection_types = array( 'functions_to_functions', 'functions_to_methods' );
 		} else {
-			$connection_types = array( 'methods_to_functions', 'methods_to_methods', 'methods_to_hooks' );
+			$connection_types = array( 'methods_to_functions', 'methods_to_methods' );
 		}
 
 		$connected = new \WP_Query( array(
-			'post_type'           => array( 'wp-parser-function', 'wp-parser-method', 'wp-parser-hook' ),
+			'post_type'           => array( 'wp-parser-function', 'wp-parser-method' ),
 			'connected_type'      => $connection_types,
-			'connected_direction' => array( 'from', 'from', 'from' ),
+			'connected_direction' => array( 'from', 'from' ),
+			'connected_items'     => $post_id,
+			'nopaging'            => true,
+		) );
+
+		return $connected;
+	}
+
+	/**
+	 * Retrieves a WP_Query object for the hook posts that the current post is linked to.
+	 *
+	 * @param int|WP_Post|null $post Optional. Post ID or post object. Default is global $post.
+	 * @return WP_Query|null   The WP_Query if the post's post type supports 'uses', null otherwise.
+	 */
+	function get_hooks( $post = null ) {
+		$post_id   = get_post_field( 'ID', $post );
+		$post_type = get_post_type( $post );
+
+		if ( 'wp-parser-function' === $post_type ) {
+			$connection_types = array( 'functions_to_hooks' );
+		} else {
+			$connection_types = array( 'methods_to_hooks' );
+		}
+
+		$connected = new \WP_Query( array(
+			'post_type'           => 'wp-parser-hook',
+			'connected_type'      => $connection_types,
+			'connected_direction' => array( 'from' ),
 			'connected_items'     => $post_id,
 			'nopaging'            => true,
 		) );
@@ -1859,6 +1900,7 @@ namespace DevHub {
 			'return',
 			'explanation',
 			'source',
+			'hooks',
 			'related',
 			'methods',
 			'changelog',

--- a/source/wp-content/themes/wporg-developer/reference/template-hooks.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-hooks.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Reference Template: Hooks Functionality
+ *
+ * @package wporg-developer
+ * @subpackage Reference
+ */
+
+namespace DevHub;
+
+if ( show_usage_info() ) :
+
+	$has_hooks   = ( post_type_has_hooks_info() && ( $hooks   = get_hooks()   ) && $hooks->have_posts()   );
+
+	if ( $has_hooks ) :
+	?>
+	<hr />
+	<section class="hooks">
+		<h2><?php _e( 'Hooks', 'wporg' ); ?></h2>
+		<article class="hooks">
+
+			<?php while ( $hooks->have_posts() ) : $hooks->the_post(); ?>
+			<dl>
+				<dt class="signature-highlight">
+					<a href="<?php the_permalink(); ?>" style="text-decoration: none">
+						<?php echo get_signature(); ?>
+					</a>
+				</dt>
+				<dd class="hook-desc">
+					<p>
+						<?php echo get_summary(); ?>
+					</p>
+				</dd>
+			</dl>
+			<?php endwhile; wp_reset_postdata(); ?>
+		</article>
+	</section>
+	<?php endif; ?>
+<?php endif; ?>

--- a/source/wp-content/themes/wporg-developer/reference/template-related.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-related.php
@@ -36,9 +36,9 @@ if ( show_usage_info() ) :
 					<tbody>
 						<?php while ( $uses->have_posts() ) : $uses->the_post(); ?>
 						<tr>
-							<td>
-								<span><?php echo esc_attr( get_source_file() ); ?>:</span>
+							<td class="related-title">
 								<a href="<?php the_permalink(); ?>"><?php the_title(); ?><?php if ( ! in_array( get_post_type(), array( 'wp-parser-class', 'wp-parser-hook' ), true ) ) : ?>()<?php endif; ?></a>
+								<span><?php echo esc_attr( get_source_file() ); ?></span>
 							</td>
 							<td class="related-desc">
 								<?php echo get_summary(); ?>
@@ -76,9 +76,9 @@ if ( show_usage_info() ) :
 					<tbody>
 						<?php while ( $used_by->have_posts() ) : $used_by->the_post(); ?>
 						<tr>
-							<td>
-								<span><?php echo esc_attr( get_source_file() ); ?>:</span>
+							<td class="related-title">
 								<a href="<?php the_permalink(); ?>"><?php the_title(); ?><?php if ( ! in_array( get_post_type(), array( 'wp-parser-class', 'wp-parser-hook' ), true ) ) : ?>()<?php endif; ?></a>
+									<span><?php echo esc_attr( get_source_file() ); ?></span>
 							</td>
 							<td class="related-desc">
 								<?php echo get_summary(); ?>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1038,15 +1038,26 @@
 			margin: 24px 0;
 			padding-left: 100px;
 			text-indent: -100px;
+			font-size: 20px;
+		}
+
+		h2 {
+			font-family: $serif-font;
+			margin-bottom: .5em;
+		}
+
+		h1, .signature-highlight {
 			color: #24831d;
 			font-family: $code-font;
-			font-size: 20px;
+			font-weight: normal;
+
 			.hook-func {
 				color: #888888;
 			}
 			.arg-type {
 				color: #cd2f23;
 				font-style: italic;
+				font-size: 0.9em;
 			}
 			.arg-name {
 				color: #0f55c8;
@@ -1054,17 +1065,16 @@
 			.arg-default {
 				color: #000000;
 			}
+
 			a:hover {
 				border-bottom: 1px dotted #21759b;
 			}
 		}
-		h2 {
-			font-family: $serif-font;
-			margin-bottom: .5em;
-		}
+
 		.return-type {
 			font-style: italic;
 		}
+
 		.parameters {
 			p {
 				margin-bottom: 0;

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1198,6 +1198,13 @@
 			width: 50%;
 		}
 
+		.used-by, .uses {
+			td.related-title span {
+				display: block;
+				color: #666;
+			}
+		}
+
 		@media (max-width: 43em) {
 			.related-desc, span {
 				display: none;

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1429,35 +1429,40 @@ input {
   margin: 24px 0;
   padding-left: 100px;
   text-indent: -100px;
-  color: #24831d;
-  font-family: monospace;
   font-size: 20px;
-}
-
-.devhub-wrap .wp-parser-class h1 .hook-func, .devhub-wrap .wp-parser-function h1 .hook-func, .devhub-wrap .wp-parser-hook h1 .hook-func, .devhub-wrap .wp-parser-method h1 .hook-func {
-  color: #888888;
-}
-
-.devhub-wrap .wp-parser-class h1 .arg-type, .devhub-wrap .wp-parser-function h1 .arg-type, .devhub-wrap .wp-parser-hook h1 .arg-type, .devhub-wrap .wp-parser-method h1 .arg-type {
-  color: #cd2f23;
-  font-style: italic;
-}
-
-.devhub-wrap .wp-parser-class h1 .arg-name, .devhub-wrap .wp-parser-function h1 .arg-name, .devhub-wrap .wp-parser-hook h1 .arg-name, .devhub-wrap .wp-parser-method h1 .arg-name {
-  color: #0f55c8;
-}
-
-.devhub-wrap .wp-parser-class h1 .arg-default, .devhub-wrap .wp-parser-function h1 .arg-default, .devhub-wrap .wp-parser-hook h1 .arg-default, .devhub-wrap .wp-parser-method h1 .arg-default {
-  color: #000000;
-}
-
-.devhub-wrap .wp-parser-class h1 a:hover, .devhub-wrap .wp-parser-function h1 a:hover, .devhub-wrap .wp-parser-hook h1 a:hover, .devhub-wrap .wp-parser-method h1 a:hover {
-  border-bottom: 1px dotted #21759b;
 }
 
 .devhub-wrap .wp-parser-class h2, .devhub-wrap .wp-parser-function h2, .devhub-wrap .wp-parser-hook h2, .devhub-wrap .wp-parser-method h2 {
   font-family: Georgia, Times, serif;
   margin-bottom: .5em;
+}
+
+.devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-class .signature-highlight, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-function .signature-highlight, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-hook .signature-highlight, .devhub-wrap .wp-parser-method h1, .devhub-wrap .wp-parser-method .signature-highlight {
+  color: #24831d;
+  font-family: monospace;
+  font-weight: normal;
+}
+
+.devhub-wrap .wp-parser-class h1 .hook-func, .devhub-wrap .wp-parser-class .signature-highlight .hook-func, .devhub-wrap .wp-parser-function h1 .hook-func, .devhub-wrap .wp-parser-function .signature-highlight .hook-func, .devhub-wrap .wp-parser-hook h1 .hook-func, .devhub-wrap .wp-parser-hook .signature-highlight .hook-func, .devhub-wrap .wp-parser-method h1 .hook-func, .devhub-wrap .wp-parser-method .signature-highlight .hook-func {
+  color: #888888;
+}
+
+.devhub-wrap .wp-parser-class h1 .arg-type, .devhub-wrap .wp-parser-class .signature-highlight .arg-type, .devhub-wrap .wp-parser-function h1 .arg-type, .devhub-wrap .wp-parser-function .signature-highlight .arg-type, .devhub-wrap .wp-parser-hook h1 .arg-type, .devhub-wrap .wp-parser-hook .signature-highlight .arg-type, .devhub-wrap .wp-parser-method h1 .arg-type, .devhub-wrap .wp-parser-method .signature-highlight .arg-type {
+  color: #cd2f23;
+  font-style: italic;
+  font-size: 0.9em;
+}
+
+.devhub-wrap .wp-parser-class h1 .arg-name, .devhub-wrap .wp-parser-class .signature-highlight .arg-name, .devhub-wrap .wp-parser-function h1 .arg-name, .devhub-wrap .wp-parser-function .signature-highlight .arg-name, .devhub-wrap .wp-parser-hook h1 .arg-name, .devhub-wrap .wp-parser-hook .signature-highlight .arg-name, .devhub-wrap .wp-parser-method h1 .arg-name, .devhub-wrap .wp-parser-method .signature-highlight .arg-name {
+  color: #0f55c8;
+}
+
+.devhub-wrap .wp-parser-class h1 .arg-default, .devhub-wrap .wp-parser-class .signature-highlight .arg-default, .devhub-wrap .wp-parser-function h1 .arg-default, .devhub-wrap .wp-parser-function .signature-highlight .arg-default, .devhub-wrap .wp-parser-hook h1 .arg-default, .devhub-wrap .wp-parser-hook .signature-highlight .arg-default, .devhub-wrap .wp-parser-method h1 .arg-default, .devhub-wrap .wp-parser-method .signature-highlight .arg-default {
+  color: #000000;
+}
+
+.devhub-wrap .wp-parser-class h1 a:hover, .devhub-wrap .wp-parser-class .signature-highlight a:hover, .devhub-wrap .wp-parser-function h1 a:hover, .devhub-wrap .wp-parser-function .signature-highlight a:hover, .devhub-wrap .wp-parser-hook h1 a:hover, .devhub-wrap .wp-parser-hook .signature-highlight a:hover, .devhub-wrap .wp-parser-method h1 a:hover, .devhub-wrap .wp-parser-method .signature-highlight a:hover {
+  border-bottom: 1px dotted #21759b;
 }
 
 .devhub-wrap .wp-parser-class .return-type, .devhub-wrap .wp-parser-function .return-type, .devhub-wrap .wp-parser-hook .return-type, .devhub-wrap .wp-parser-method .return-type {
@@ -1592,6 +1597,11 @@ input {
 
 .devhub-wrap .related th, .devhub-wrap .related td {
   width: 50%;
+}
+
+.devhub-wrap .related .used-by td.related-title span, .devhub-wrap .related .uses td.related-title span {
+  display: block;
+  color: #666;
 }
 
 @media (max-width: 43em) {


### PR DESCRIPTION
See #21 

Changes:
 - Dedicated hook section w/ hook syntax/params
 - File name is moved to newline and grey'd for Related functions.


| Before (Note red box indicates hooks) | After |
| --- | --- |
| <img width="787" alt="Screen Shot 2022-05-30 at 6 23 17 pm" src="https://user-images.githubusercontent.com/767313/170950500-3f28261d-8c0d-4918-a78b-69f18ef5716a.png">  | <img width="805" alt="Screen Shot 2022-05-30 at 6 23 38 pm" src="https://user-images.githubusercontent.com/767313/170950524-bd44f3a5-fdbe-4b15-8b40-1002399bd5dd.png">  | 
