### PR TITLE
Add return syntax highlighting

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -782,6 +782,11 @@ namespace DevHub {
 		}
 		$signature .= ')';
 
+		$return = get_return( $post_id, false );
+		if ( $return ) {
+			$signature .= ': ' . $return;
+		}
+
 		return wp_kses_post( $signature );
 	}
 
@@ -915,7 +920,7 @@ namespace DevHub {
 	 *
 	 * @return string
 	 */
-	function get_return( $post_id = null ) {
+	function get_return( $post_id = null, $include_description = true ) {
 
 		if ( empty( $post_id ) ) {
 			$post_id = get_the_ID();
@@ -934,7 +939,11 @@ namespace DevHub {
 		$type        = empty( $return['types'] ) ? '' : esc_html( implode( '|', $return['types'] ) );
 		$type        = apply_filters( 'devhub-function-return-type', $type, $post_id );
 
-		return "<span class='return-type'>({$type})</span> $description";
+		if ( $include_description ) {
+			return "<span class='return-type'>{$type}</span> $description";
+		} else {
+			return "<span class='return-type'>{$type}</span>";
+		}
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1066,13 +1066,32 @@
 				color: #000000;
 			}
 
-			a:hover {
-				border-bottom: 1px dotted #21759b;
+			a {
+				text-decoration: none;
+
+				&:hover {
+					border-bottom: 1px dotted #21759b;
+				}
 			}
 		}
 
-		.return-type {
-			font-style: italic;
+		.return .return-type {
+			margin-right: 8px;
+			font-size: 14px;
+		}
+
+		.return-type,
+		.parameters .type {
+			color: #dc3232;
+
+			a {
+				color: inherit;
+				text-decoration: none;
+
+				&:hover {
+					border-bottom: 1px dotted #21759b;
+				}
+			}
 		}
 
 		.parameters {
@@ -1123,7 +1142,6 @@
 
 			.type {
 				margin-left: 8px;
-				color: #dc3232;
 				font-size: 14px;
 				font-style: normal;
 			}

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1461,12 +1461,42 @@ input {
   color: #000000;
 }
 
+.devhub-wrap .wp-parser-class h1 a, .devhub-wrap .wp-parser-class .signature-highlight a, .devhub-wrap .wp-parser-function h1 a, .devhub-wrap .wp-parser-function .signature-highlight a, .devhub-wrap .wp-parser-hook h1 a, .devhub-wrap .wp-parser-hook .signature-highlight a, .devhub-wrap .wp-parser-method h1 a, .devhub-wrap .wp-parser-method .signature-highlight a {
+  text-decoration: none;
+}
+
 .devhub-wrap .wp-parser-class h1 a:hover, .devhub-wrap .wp-parser-class .signature-highlight a:hover, .devhub-wrap .wp-parser-function h1 a:hover, .devhub-wrap .wp-parser-function .signature-highlight a:hover, .devhub-wrap .wp-parser-hook h1 a:hover, .devhub-wrap .wp-parser-hook .signature-highlight a:hover, .devhub-wrap .wp-parser-method h1 a:hover, .devhub-wrap .wp-parser-method .signature-highlight a:hover {
   border-bottom: 1px dotted #21759b;
 }
 
-.devhub-wrap .wp-parser-class .return-type, .devhub-wrap .wp-parser-function .return-type, .devhub-wrap .wp-parser-hook .return-type, .devhub-wrap .wp-parser-method .return-type {
-  font-style: italic;
+.devhub-wrap .wp-parser-class .return .return-type, .devhub-wrap .wp-parser-function .return .return-type, .devhub-wrap .wp-parser-hook .return .return-type, .devhub-wrap .wp-parser-method .return .return-type {
+  margin-right: 8px;
+  font-size: 14px;
+}
+
+.devhub-wrap .wp-parser-class .return-type,
+.devhub-wrap .wp-parser-class .parameters .type, .devhub-wrap .wp-parser-function .return-type,
+.devhub-wrap .wp-parser-function .parameters .type, .devhub-wrap .wp-parser-hook .return-type,
+.devhub-wrap .wp-parser-hook .parameters .type, .devhub-wrap .wp-parser-method .return-type,
+.devhub-wrap .wp-parser-method .parameters .type {
+  color: #dc3232;
+}
+
+.devhub-wrap .wp-parser-class .return-type a,
+.devhub-wrap .wp-parser-class .parameters .type a, .devhub-wrap .wp-parser-function .return-type a,
+.devhub-wrap .wp-parser-function .parameters .type a, .devhub-wrap .wp-parser-hook .return-type a,
+.devhub-wrap .wp-parser-hook .parameters .type a, .devhub-wrap .wp-parser-method .return-type a,
+.devhub-wrap .wp-parser-method .parameters .type a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.devhub-wrap .wp-parser-class .return-type a:hover,
+.devhub-wrap .wp-parser-class .parameters .type a:hover, .devhub-wrap .wp-parser-function .return-type a:hover,
+.devhub-wrap .wp-parser-function .parameters .type a:hover, .devhub-wrap .wp-parser-hook .return-type a:hover,
+.devhub-wrap .wp-parser-hook .parameters .type a:hover, .devhub-wrap .wp-parser-method .return-type a:hover,
+.devhub-wrap .wp-parser-method .parameters .type a:hover {
+  border-bottom: 1px dotted #21759b;
 }
 
 .devhub-wrap .wp-parser-class .parameters p, .devhub-wrap .wp-parser-function .parameters p, .devhub-wrap .wp-parser-hook .parameters p, .devhub-wrap .wp-parser-method .parameters p {
@@ -1519,7 +1549,6 @@ input {
 
 .devhub-wrap .wp-parser-class .parameters .type, .devhub-wrap .wp-parser-function .parameters .type, .devhub-wrap .wp-parser-hook .parameters .type, .devhub-wrap .wp-parser-method .parameters .type {
   margin-left: 8px;
-  color: #dc3232;
   font-size: 14px;
   font-style: normal;
 }
@@ -1657,15 +1686,15 @@ input {
   padding-right: 1em;
 }
 
+.devhub-wrap .source-code-links span:last-of-type {
+  border-right: none;
+}
+
 .devhub-wrap .source-code-links span:first-child {
   display: none;
   border-left: 0;
   margin-left: 1em;
   padding-left: 0;
-}
-
-.devhub-wrap .source-code-links span:last-of-type {
-  border-right: none;
 }
 
 .devhub-wrap .source-code-container {


### PR DESCRIPTION
See #20 

This:
 - adds highlighting of types to the return data
 - adds the return-type to the function declaration, mimicking the PHP docs.

| Before | After |
| --- | --- |
| <img width="987" alt="Screen Shot 2022-05-31 at 3 23 44 pm" src="https://user-images.githubusercontent.com/767313/171099065-5d3ddb29-11af-4375-b9a1-ed69497b044b.png">  | <img width="989" alt="Screen Shot 2022-05-31 at 3 23 37 pm" src="https://user-images.githubusercontent.com/767313/171099036-f2068bf9-8f83-4200-9627-984b432b685c.png">  | 




