### PR TITLE
Search UX improvements

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/autocomplete.php
+++ b/source/wp-content/themes/wporg-developer/inc/autocomplete.php
@@ -42,7 +42,7 @@ class DevHub_Search_Form_Autocomplete {
 		wp_register_script( 'awesomplete', get_template_directory_uri() . '/js/awesomplete.min.js', array(), '20160322', true );
 		wp_enqueue_script( 'awesomplete' );
 
-		wp_register_script( 'autocomplete', get_template_directory_uri() . '/js/autocomplete.js', array( 'awesomplete' ), '20160524', true );
+		wp_register_script( 'autocomplete', get_stylesheet_directory_uri() . '/js/autocomplete.js', array( 'awesomplete' ), filemtime( dirname( __DIR__ ) . '/js/autocomplete.js' ), true );
 		wp_localize_script( 'autocomplete', 'autocomplete', array(
 				'ajaxurl' => admin_url( 'admin-ajax.php' ),
 				'nonce'   => wp_create_nonce( 'autocomplete_nonce' ),
@@ -103,9 +103,12 @@ class DevHub_Search_Form_Autocomplete {
 
 		$search = get_posts( $args );
 
-		if ( !empty( $search ) ) {
-			$titles = wp_list_pluck( $search, 'post_title' );
-			$form_data['posts'] = array_values( array_unique( $titles ) );
+		if ( ! empty( $search ) ) {
+			$titles             = wp_list_pluck( $search, 'post_title', 'ID' );
+			$titles             = array_unique( $titles );
+			$titles             = array_flip( $titles );
+			$titles             = array_map( 'get_permalink', $titles );
+			$form_data['posts'] = $titles;
 		}
 
 		wp_send_json_success ( $form_data );

--- a/source/wp-content/themes/wporg-developer/inc/loop-pagination.php
+++ b/source/wp-content/themes/wporg-developer/inc/loop-pagination.php
@@ -58,7 +58,7 @@ function loop_pagination( $args = array() ) {
 		//'next_text'  => __( 'Next &raquo;' ), // This is the WordPress default.
 		'show_all'     => false,
 		'end_size'     => 1,
-		'mid_size'     => 1,
+		'mid_size'     => 2,
 		'add_fragment' => '',
 		'type'         => 'plain',
 

--- a/source/wp-content/themes/wporg-developer/js/autocomplete.js
+++ b/source/wp-content/themes/wporg-developer/js/autocomplete.js
@@ -18,7 +18,8 @@
 
 	var	searchfield = $( '#search-field', form ),
 		processing = false,
-		search = '';
+		search = '',
+		autocompleteResults = {};
 
 	var awesome = new Awesomplete( searchfield.get( 0 ), {
 		maxItems: 9999,
@@ -62,6 +63,13 @@
 
 			return false;
 		},
+		replace: function( text ) {
+			searchfield.val( text );
+
+			if ( text in autocompleteResults ) {
+				window.location = autocompleteResults[ text ];
+			}
+		}
 	} );
 
 	// On input event for the search field.
@@ -101,9 +109,11 @@
 					return false;
 				}
 
-				if ( ( response.success === true ) && response.data.posts.length ) {
+				if ( response.success === true && Object.values( response.data.posts ).length ) {
+					autocompleteResults = response.data.posts;
+
 					// Update the autocomplete list
-					awesome.list = response.data.posts;
+					awesome.list = Object.keys( response.data.posts );
 				}
 			} )
 			.always( function() {

--- a/source/wp-content/themes/wporg-developer/searchform.php
+++ b/source/wp-content/themes/wporg-developer/searchform.php
@@ -7,32 +7,6 @@
 ?>
 <div class="search-section section clear <?php if ( ! ( is_page( 'reference' ) || is_search() || is_404() ) ) { echo 'hide-if-js'; } ?>">
 
-<?php if ( is_search() ) { ?>
-
-	<div class="search-results-summary"><?php
-	$count = (int) $GLOBALS['wp_query']->found_posts;
-
-	if ( $count ) {
-		if ( is_paged() ) {
-			$start = get_query_var( 'posts_per_page' ) * ( get_query_var( 'paged' ) - 1 );
-		} else {
-			$start = 0;
-		}
-		$end = min( $count, $start + get_query_var( 'posts_per_page' ) );
-		printf(
-			_n( '<strong>%d</strong> result found for "<strong>%s</strong>".', '<strong>%d</strong> results found for "<strong>%s</strong>". Showing results %d to %d.', $count, 'wporg' ),
-			$count,
-			esc_html( get_search_query() ),
-			$start + 1,
-			$end
-		);
-	} else {
-		printf( __( '<strong>%d</strong> results found for "<strong>%s</strong>".', 'wporg' ), $count, esc_html( get_search_query() ) );
-	}
-	?></div>
-
-<?php } ?>
-
 	<?php
 		$is_handbook = $GLOBALS['wp_query']->is_handbook;
 		$search_url  = get_query_var( 'current_handbook_home_url' );
@@ -81,3 +55,29 @@
 	</form>
 
 </div><!-- /search-guide -->
+
+<?php if ( is_search() ) { ?>
+
+<div class="search-results-summary"><?php
+$count = (int) $GLOBALS['wp_query']->found_posts;
+
+if ( $count ) {
+	if ( is_paged() ) {
+		$start = get_query_var( 'posts_per_page' ) * ( get_query_var( 'paged' ) - 1 );
+	} else {
+		$start = 0;
+	}
+	$end = min( $count, $start + get_query_var( 'posts_per_page' ) );
+	printf(
+		_n( '<strong>%d</strong> result found for "<strong>%s</strong>".', '<strong>%d</strong> results found for "<strong>%s</strong>". Showing results %d to %d.', $count, 'wporg' ),
+		$count,
+		esc_html( get_search_query() ),
+		$start + 1,
+		$end
+	);
+} else {
+	printf( __( '<strong>%d</strong> results found for "<strong>%s</strong>".', 'wporg' ), $count, esc_html( get_search_query() ) );
+}
+?></div>
+
+<?php } ?>


### PR DESCRIPTION
See #40 

 - Click/enter auto-complete item to go directly to it's page
 - Search/Enter on exact-match in text field still goes to search results
 - Archive and search count results in a more expected place (IMHO)

| Before | After |
| --- | --- |
| Instant load selected auto-complete item |
| <img src="https://user-images.githubusercontent.com/767313/171107964-c3a9b0f5-113c-4cf9-b33e-784df8f20e7d.gif"> | <img src="https://user-images.githubusercontent.com/767313/171120362-0cb8cc99-0d9b-47e3-bb9a-0f92d9da03f3.gif"> |
| Search result count between form |
| <img width="958" alt="Screen Shot 2022-05-31 at 5 48 02 pm" src="https://user-images.githubusercontent.com/767313/171120715-e3974f94-8108-47cf-814d-39ec6a21ed9b.png"> | <img width="961" alt="Screen Shot 2022-05-31 at 5 44 11 pm" src="https://user-images.githubusercontent.com/767313/171120752-714d20a1-8cda-43ad-aa6d-49fddfe6e5e8.png"> |
| Pagination links not hiding single-page |
| <img width="282" alt="Screen Shot 2022-05-31 at 5 50 07 pm" src="https://user-images.githubusercontent.com/767313/171121094-c6ba3f61-8d21-4075-8809-5b4dd22e56b7.png"> |  <img width="201" alt="Screen Shot 2022-05-31 at 5 51 06 pm" src="https://user-images.githubusercontent.com/767313/171121330-4fa2ac2b-3831-4282-9971-927c2d20fc5f.png"> |

