### PR TITLE
Switch code highlighting to use Code Syntax Block

### DIFF
--- a/source/wp-content/themes/wporg-developer/functions.php
+++ b/source/wp-content/themes/wporg-developer/functions.php
@@ -170,7 +170,8 @@ function init() {
 	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_items_for_hooks', 10, 2 );
 	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_items_for_handbook_root', 10, 2 );
 
-	add_filter( 'syntaxhighlighter_htmlresult', __NAMESPACE__ . '\\syntaxhighlighter_htmlresult' );
+	add_filter( 'mkaz_code_syntax_force_loading', '__return_true' );
+	add_filter( 'mkaz_prism_css_path', __NAMESPACE__ . '\\update_prism_css_path' );
 }
 
 /**
@@ -392,42 +393,12 @@ function rename_comments_meta_box( $post_type, $post ) {
 }
 
 /**
- * If a syntax highlighted code block exceeds a given number of lines, wrap the
- * markup with other markup to trigger the code expansion/collapse JS handling
- * already implemented for the code reference.
+ * Customize the syntax highlighter style.
+ * See https://github.com/PrismJS/prism-themes.
  *
- * @param  string $text The pending result of the syntax highlighting.
+ * @param string $path Path to the file to override, relative to the theme.
  * @return string
  */
-function syntaxhighlighter_htmlresult( $text ) {
-
-	// is_admin() is true in front end AJAX requests.
-	if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
-		return $text;
-	}
-
-	$new_text      = '';
-	// Collapse is handled for >10 lines. But just go ahead and show the full
-	// code if that is just barely being exceeded (no one wants to expand to
-	// see one or two more lines).
-	$lines_to_show = 12;
-	$do_collapse   = ( substr_count( $text, "\n" ) - 1 ) > $lines_to_show;
-
-	if ( $do_collapse ) {
-		$new_text .= '<section class="source-content">';
-		$new_text .= '<div class="source-code-container">';
-	}
-
-	$new_text .= $text;
-
-	if ( $do_collapse ) {
-		$new_text .= '</div>';
-		$new_text .= '<p class="source-code-links"><span>';
-		$new_text .= '<a href="#" class="show-complete-source">' . __( 'Expand full source code', 'wporg' ) . '</a>';
-		$new_text .= '<a href="#" class="less-complete-source">' . __( 'Collapse full source code', 'wporg' ) . '</a>';
-		$new_text .= '</span></p>';
-		$new_text .= '</section>';
-	}
-
-	return $new_text;
+function update_prism_css_path( $path ) {
+	return '/stylesheets/prism.css';
 }

--- a/source/wp-content/themes/wporg-developer/functions.php
+++ b/source/wp-content/themes/wporg-developer/functions.php
@@ -147,6 +147,9 @@ if ( ! isset( $content_width ) ) {
 add_action( 'init', __NAMESPACE__ . '\\init' );
 add_action( 'widgets_init', __NAMESPACE__ . '\\widgets_init' );
 
+/**
+ * Set up the theme.
+ */
 function init() {
 
 	register_nav_menus();
@@ -164,8 +167,8 @@ function init() {
 	add_theme_support( 'title-tag' );
 
 	// Modify default breadcrumbs.
-	add_filter( 'breadcrumb_trail_items',  __NAMESPACE__ . '\\breadcrumb_trail_items_for_hooks', 10, 2 );
-	add_filter( 'breadcrumb_trail_items',  __NAMESPACE__ . '\\breadcrumb_trail_items_for_handbook_root', 10, 2 );
+	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_items_for_hooks', 10, 2 );
+	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_items_for_handbook_root', 10, 2 );
 
 	add_filter( 'syntaxhighlighter_htmlresult', __NAMESPACE__ . '\\syntaxhighlighter_htmlresult' );
 }
@@ -177,15 +180,15 @@ function init() {
  * Trail plugin to introduce trail items related to the parent that shouldn't
  * be shown.
  *
- * @param  array $items The breadcrumb trail items
- * @param  array $args  Original args
+ * @param  array $items The breadcrumb trail items.
+ * @param  array $args  Original args.
  * @return array
  */
 function breadcrumb_trail_items_for_hooks( $items, $args ) {
 	$post_type = 'wp-parser-hook';
 
 	// Bail early when not the single archive for hook
-	if ( ! is_singular() || $post_type !== get_post_type() || ! isset( $items[4] ) ) {
+	if ( ! is_singular() || get_post_type() !== $post_type || ! isset( $items[4] ) ) {
 		return $items;
 	}
 
@@ -208,8 +211,8 @@ function breadcrumb_trail_items_for_hooks( $items, $args ) {
  * item that simply links to the currently loaded page. The trailing breadcrumb
  * item is already the unlinked handbook name, which is sufficient.
  *
- * @param  array $items The breadcrumb trail items
- * @param  array $args  Original args
+ * @param  array $items The breadcrumb trail items.
+ * @param  array $args  Original args.
  * @return array
  */
 function breadcrumb_trail_items_for_handbook_root( $items, $args ) {
@@ -225,43 +228,51 @@ function breadcrumb_trail_items_for_handbook_root( $items, $args ) {
 }
 
 /**
- * widgets_init function.
+ * Register widget areas.
  *
  * @access public
  * @return void
  */
 function widgets_init() {
-	register_sidebar( array(
-		'name'          => __( 'Sidebar', 'wporg' ),
-		'id'            => 'sidebar-1',
-		'before_widget' => '<aside id="%1$s" class="box gray widget %2$s">',
-		'after_widget'  => '</div></aside>',
-		'before_title'  => '<h1 class="widget-title">',
-		'after_title'   => '</h1><div class="widget-content">',
-	) );
+	register_sidebar(
+		array(
+			'name'          => __( 'Sidebar', 'wporg' ),
+			'id'            => 'sidebar-1',
+			'before_widget' => '<aside id="%1$s" class="box gray widget %2$s">',
+			'after_widget'  => '</div></aside>',
+			'before_title'  => '<h1 class="widget-title">',
+			'after_title'   => '</h1><div class="widget-content">',
+		)
+	);
 
-	register_sidebar( array(
-		'name'          => __( 'Landing Page Footer - Left', 'wporg' ),
-		'id'            => 'landing-footer-1',
-		'description'   => __( 'Appears in footer of the primary landing page', 'wporg' ),
-		'before_widget' => '<div id="%1$s" class="widget box %2$s">',
-		'after_widget'  => '</div>',
-		'before_title'  => '<h4 class="widget-title">',
-		'after_title'   => '</h4>',
-	) );
+	register_sidebar(
+		array(
+			'name'          => __( 'Landing Page Footer - Left', 'wporg' ),
+			'id'            => 'landing-footer-1',
+			'description'   => __( 'Appears in footer of the primary landing page', 'wporg' ),
+			'before_widget' => '<div id="%1$s" class="widget box %2$s">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h4 class="widget-title">',
+			'after_title'   => '</h4>',
+		)
+	);
 
-	register_sidebar( array(
-		'name'          => __( 'Landing Page Footer - Center', 'wporg' ),
-		'id'            => 'landing-footer-2',
-		'description'   => __( 'Appears in footer of the primary landing page', 'wporg' ),
-		'before_widget' => '<div id="%1$s" class="widget box %2$s">',
-		'after_widget'  => '</div>',
-		'before_title'  => '<h4 class="widget-title">',
-		'after_title'   => '</h4>',
-	) );
+	register_sidebar(
+		array(
+			'name'          => __( 'Landing Page Footer - Center', 'wporg' ),
+			'id'            => 'landing-footer-2',
+			'description'   => __( 'Appears in footer of the primary landing page', 'wporg' ),
+			'before_widget' => '<div id="%1$s" class="widget box %2$s">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h4 class="widget-title">',
+			'after_title'   => '</h4>',
+		)
+	);
 }
 
 /**
+ * Modify the default query.
+ *
  * @param \WP_Query $query
  */
 function pre_get_posts( $query ) {
@@ -278,13 +289,17 @@ function pre_get_posts( $query ) {
 	// For search query modifications see DevHub_Search.
 }
 
+/**
+ * Regiser navigation menu area.
+ */
 function register_nav_menus() {
-
-	\register_nav_menus( array(
-		'devhub-menu' => __( 'Developer Resources Menu', 'wporg' ),
-		'devhub-cli-menu' => __( 'WP-CLI Commands Menu', 'wporg' ),
-		'reference-home-api' => __( 'Reference API Menu', 'wporg' ),
-	) );
+	\register_nav_menus(
+		array(
+			'devhub-menu' => __( 'Developer Resources Menu', 'wporg' ),
+			'devhub-cli-menu' => __( 'WP-CLI Commands Menu', 'wporg' ),
+			'reference-home-api' => __( 'Reference API Menu', 'wporg' ),
+		)
+	);
 }
 
 /**
@@ -308,6 +323,9 @@ function method_permalink( $link, $post ) {
 	return home_url( user_trailingslashit( "reference/classes/$class/$method" ) );
 }
 
+/**
+ * Filer the permalink for a taxonomy.
+ */
 function taxonomy_permalink( $link, $term, $taxonomy ) {
 	global $wp_rewrite;
 
@@ -315,16 +333,17 @@ function taxonomy_permalink( $link, $term, $taxonomy ) {
 		return $link;
 	}
 
-	if ( $taxonomy === 'wp-parser-source-file' ) {
+	if ( 'wp-parser-source-file' === $taxonomy ) {
 		$slug = $term->slug;
 		if ( substr( $slug, -4 ) === '-php' ) {
 			$slug = substr( $slug, 0, -4 ) . '.php';
 			$slug = str_replace( '_', '/', $slug );
 		}
 		$link = home_url( user_trailingslashit( "reference/files/$slug" ) );
-	} elseif ( $taxonomy === 'wp-parser-since' ) {
+	} elseif ( 'wp-parser-since' === $taxonomy ) {
 		$link = str_replace( $term->slug, str_replace( '-', '.', $term->slug ), $link );
 	}
+
 	return $link;
 }
 
@@ -343,8 +362,12 @@ function header_js() {
 	</script>\n";
 }
 
+/**
+ * Register and enqueue the theme assets.
+ */
 function theme_scripts_styles() {
 	wp_enqueue_style( 'dashicons' );
+	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_style( 'open-sans', '//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,400,300,600' );
 	wp_enqueue_style( 'wporg-developer-style', get_stylesheet_uri(), array(), filemtime( __DIR__ . '/style.css' ) );
 	wp_enqueue_style( 'wp-dev-sass-compiled', get_stylesheet_directory_uri() . '/stylesheets/main.css', array( 'wporg-developer-style' ), filemtime( __DIR__ . '/stylesheets/main.css' ) );
@@ -373,13 +396,13 @@ function rename_comments_meta_box( $post_type, $post ) {
  * markup with other markup to trigger the code expansion/collapse JS handling
  * already implemented for the code reference.
  *
- * @param string  $text The pending result of the syntax highlighting.
+ * @param  string $text The pending result of the syntax highlighting.
  * @return string
  */
 function syntaxhighlighter_htmlresult( $text ) {
 
 	// is_admin() is true in front end AJAX requests.
-	if ( is_admin() && !( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+	if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 		return $text;
 	}
 
@@ -390,7 +413,7 @@ function syntaxhighlighter_htmlresult( $text ) {
 	$lines_to_show = 12;
 	$do_collapse   = ( substr_count( $text, "\n" ) - 1 ) > $lines_to_show;
 
-	if ( $do_collapse )  {
+	if ( $do_collapse ) {
 		$new_text .= '<section class="source-content">';
 		$new_text .= '<div class="source-code-container">';
 	}
@@ -408,4 +431,3 @@ function syntaxhighlighter_htmlresult( $text ) {
 
 	return $new_text;
 }
-

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -45,6 +45,20 @@ class DevHub_Formatting {
 		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'fix_param_description_parsedown_bug' ) );
 
 		add_filter( 'devhub-function-return-type', array( __CLASS__, 'autolink_references' ) );
+
+		add_shortcode( 'php', array( __CLASS__, 'do_shortcode_php' ) );
+		add_shortcode( 'js', array( __CLASS__, 'do_shortcode_js' ) );
+		add_shortcode( 'css', array( __CLASS__, 'do_shortcode_css' ) );
+
+		add_filter(
+			'no_texturize_shortcodes',
+			function ( $shortcodes ) {
+				$shortcodes[] = 'php';
+				$shortcodes[] = 'js';
+				$shortcodes[] = 'css';
+				return $shortcodes;
+			}
+		);
 	}
 
 	/**
@@ -655,6 +669,63 @@ class DevHub_Formatting {
 		}
 
 		return $text;
+	}
+
+	/**
+	 * Render the php shortcode using the Code Syntax Block syntax.
+	 *
+	 * This is a workaround for user-submitted code, which used the php shortcode from Syntax Highlighter Evolved.
+	 *
+	 * @param array|string $attr    Shortcode attributes array or empty string.
+	 * @param string       $content Shortcode content.
+	 * @param string       $tag     Shortcode name.
+	 * @return string
+	 */
+	public static function do_shortcode_php( $attr, $content, $tag ) {
+		return do_blocks(
+			sprintf(
+				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="php" class="language-php line-numbers">%s</code></pre><!-- /wp:code -->',
+				trim( $content )
+			)
+		);
+	}
+
+	/**
+	 * Render the js shortcode using the Code Syntax Block syntax.
+	 *
+	 * This is a workaround for user-submitted code, which used the php shortcode from Syntax Highlighter Evolved.
+	 *
+	 * @param array|string $attr    Shortcode attributes array or empty string.
+	 * @param string       $content Shortcode content.
+	 * @param string       $tag     Shortcode name.
+	 * @return string
+	 */
+	public static function do_shortcode_js( $attr, $content, $tag ) {
+		return do_blocks(
+			sprintf(
+				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="javascript" class="language-javascript line-numbers">%s</code></pre><!-- /wp:code -->',
+				trim( $content )
+			)
+		);
+	}
+
+	/**
+	 * Render the css shortcode using the Code Syntax Block syntax.
+	 *
+	 * This is a new shortcode, but built to mirror the above two, `js` & `php`.
+	 *
+	 * @param array|string $attr    Shortcode attributes array or empty string.
+	 * @param string       $content Shortcode content.
+	 * @param string       $tag     Shortcode name.
+	 * @return string
+	 */
+	public static function do_shortcode_css( $attr, $content, $tag ) {
+		return do_blocks(
+			sprintf(
+				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="css" class="language-css line-numbers">%s</code></pre><!-- /wp:code -->',
+				trim( $content )
+			)
+		);
 	}
 
 } // DevHub_Formatting

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -45,19 +45,6 @@ class DevHub_Formatting {
 		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'fix_param_description_parsedown_bug' ) );
 
 		add_filter( 'devhub-function-return-type', array( __CLASS__, 'autolink_references' ) );
-
-		add_filter( 'syntaxhighlighter_htmlresult', array( __CLASS__, 'fix_code_entity_encoding' ), 20 );
-	}
-
-	/**
-	 * Fixes bug in (or at least in using) SyntaxHighlighter code shortcodes that
-	 * causes double-encoding of `>` character.
-	 *
-	 * @param string $content The text being handled as code.
-	 * @return string
-	 */
-	public static function fix_code_entity_encoding( $content ) {
-		return str_replace( '&amp;gt;', '&gt;', $content );
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/inc/import-block-editor.php
+++ b/source/wp-content/themes/wporg-developer/inc/import-block-editor.php
@@ -21,8 +21,6 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 		add_filter( 'wporg_markdown_after_transform',  array( $this, 'wporg_markdown_after_transform' ), 10, 2 );
 		add_filter( 'wporg_markdown_edit_link',        array( $this, 'wporg_markdown_edit_link' ), 10, 2 );
 
-		add_filter( 'syntaxhighlighter_htmlresult',    array( $this, 'fix_code_entity_encoding' ) );
-
 		add_action( 'pre_post_update', function( $post_id, $data ) {
 			if ( $this->get_post_type() === $data['post_type'] ) {
 				add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_extra_tags' ), 10, 1 );
@@ -140,30 +138,6 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 		}
 
 		return $display;
-	}
-
-	/**
-	 * Fixes unwarranted HTML entity encoding within code shortcodes.
-	 *
-	 * @param string $content Post content.
-	 * @return string
-	 */
-	public function fix_code_entity_encoding( $content ) {
-		if ( $this->get_post_type() !== get_post_type() ) {
-			return $content;
-		}
-
-		if ( false !== mb_strpos( $content, '&amp;' ) ) {
-			$content = preg_replace_callback(
-				'|(<pre class="brush[^>]+)(.+)(</pre)|Us',
-				function( $matches ) {
-					return $matches[1] . html_entity_decode( $matches[2], ENT_QUOTES | ENT_HTML401 ) . $matches[3];
-				},
-				$content
-			);
-		}
-
-		return $content;
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/inc/user-content.php
+++ b/source/wp-content/themes/wporg-developer/inc/user-content.php
@@ -55,12 +55,6 @@ class DevHub_User_Submitted_Content {
 		// Customize allowed tags
 		add_filter( 'wp_kses_allowed_html',            array( __CLASS__, 'wp_kses_allowed_html' ), 10, 2 );
 
-		// Make 'php' the default language
-		add_filter( 'syntaxhighlighter_shortcodeatts', array( __CLASS__, 'syntaxhighlighter_shortcodeatts' ) );
-
-		// Tweak code contained in shortcode
-		add_filter( 'syntaxhighlighter_precode',       array( __CLASS__, 'syntaxhighlighter_precode' ) );
-
 		// Allowed HTML for a new child comment
 		add_filter( 'preprocess_comment',              array( __CLASS__, 'comment_new_allowed_html' ) );
 
@@ -169,9 +163,7 @@ class DevHub_User_Submitted_Content {
 	 */
 	public static function scripts_and_styles() {
 		if ( is_singular() ) {
-			wp_enqueue_script( 'wporg-developer-function-reference', get_template_directory_uri() . '/js/function-reference.js', array( 'jquery', 'syntaxhighlighter-core', 'syntaxhighlighter-brush-php' ), '20180724', true );
-			wp_enqueue_style( 'syntaxhighlighter-core' );
-			wp_enqueue_style( 'syntaxhighlighter-theme-default' );
+			wp_enqueue_script( 'wporg-developer-function-reference', get_template_directory_uri() . '/js/function-reference.js', array( 'jquery' ), '20180724', true );
 
 			wp_enqueue_script( 'wporg-developer-user-notes', get_template_directory_uri() . '/js/user-notes.js', array( 'jquery', 'quicktags' ), '20200110', true );
 			wp_enqueue_script( 'wporg-developer-user-notes-feedback', get_template_directory_uri() . '/js/user-notes-feedback.js', array( 'jquery', 'quicktags' ), '20181023', true );
@@ -180,27 +172,6 @@ class DevHub_User_Submitted_Content {
 				'hide'             => __( 'Hide Feedback', 'wporg' ),
 			) );
 		}
-	}
-
-	/**
-	 * Sets the default language for SyntaxHighlighter shortcode.
-	 *
-	 * @param array $atts Shortcode attributes.
-	 * @return array
-	 */
-	public static function syntaxhighlighter_shortcodeatts( $atts ) {
-		$atts['language'] = 'php';
-		return $atts;
-	}
-
-	/**
-	 * Subverts capital_P_dangit for SyntaxHighlighter shortcode.
-	 *
-	 * @param string $code
-	 * @return string
-	 */
-	public static function syntaxhighlighter_precode( $code ) {
-		return str_replace( 'Wordpress', 'Word&#112;ress', $code );
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -1,89 +1,17 @@
+/* @global jQuery */
 /**
  * function-reference.js
  *
  * Handles all interactivity on the single function page
  */
-var wporg_developer = ( function( $ ) {
-	'use strict';
 
-	var $sourceCollapsedHeight;
-
-	var $usesList, $usedByList, $showMoreUses, $hideMoreUses, $showMoreUsedBy, $hideMoreUsedBy;
-
-	function onLoad() {
-		sourceCodeHighlightInit();
-
-		toggleUsageListInit();
-	}
-
-	function sourceCodeHighlightInit() {
-
-		// We require the SyntaxHighlighter javascript library
-		if ( undefined === window.SyntaxHighlighter ) {
-			return;
-		}
-
-		SyntaxHighlighter.highlight();
-
-		// 1em (margin) + 10 * 17px + 10. Lines are 1.1em which rounds to 17px: calc( 1em + 17px * 10 + 10 ).
-		// Extra 10px added to partially show next line so it's clear there is more.
-		$sourceCollapsedHeight = 196;
-		sourceCodeDisplay();
-	}
-
-	function sourceCodeDisplay( element ) {
-
-		if ( element !== undefined ) {
-			// Find table inside a specific source code element if passed.
-			var sourceCode = $( '.source-content', element ).find( 'table' );
-		} else {
-			// Find table inside all source code elements.
-			var sourceCode = $( '.source-content' ).find( 'table' );
-		}
-
-		if ( !sourceCode.length ) {
-			return;
-		}
-
-		sourceCode.each( function( t ) {
-			if ( ( $sourceCollapsedHeight - 12 ) < $( this ).height() ) {
-
-				var sourceContent = $( this ).closest( '.source-content' );
-
-				// Do this with javascript so javascript-less can enjoy the total sourcecode
-				sourceContent.find( '.source-code-container' ).css( {
-					height: $sourceCollapsedHeight + 'px'
-				} );
-
-				sourceContent.find( '.source-code-links' ).find( 'span:first' ).show();
-				sourceContent.find( '.show-complete-source' ).show();
-				sourceContent.find( '.show-complete-source' ).off( 'click.togglesource' ).on( 'click.togglesource', toggleCompleteSource );
-				sourceContent.find( '.less-complete-source' ).off( 'click.togglesource' ).on( 'click.togglesource', toggleCompleteSource );
-			}
-		} );
-	}
-
-	function toggleCompleteSource( e ) {
-		e.preventDefault();
-
-		var sourceContent = $( this ).closest( '.source-content' );
-
-		if ( $( this ).parent().find( '.show-complete-source' ).is( ':visible' ) ) {
-			var heightGoal = sourceContent.find( 'table' ).height() + 45; // takes into consideration potential x-scrollbar
-		} else {
-			var heightGoal = $sourceCollapsedHeight;
-		}
-
-		sourceContent.find( '.source-code-container:first' ).animate( { height: heightGoal + 'px' } );
-
-		$( this ).parent().find( 'a' ).toggle();
-	}
+jQuery( function( $ ) {
+	let $usesList, $usedByList, $showMoreUses, $hideMoreUses, $showMoreUsedBy, $hideMoreUsedBy;
 
 	function toggleUsageListInit() {
-
 		// We only expect one used_by and uses per document
 		$usedByList = $( 'tbody tr', '#used-by-table' );
-		$usesList   = $( 'tbody tr', '#uses-table' );
+		$usesList = $( 'tbody tr', '#uses-table' );
 
 		if ( $usedByList.length > 5 ) {
 			$usedByList = $usedByList.slice( 5 ).hide();
@@ -100,8 +28,8 @@ var wporg_developer = ( function( $ ) {
 		}
 	}
 
-	function toggleMoreUses( e ) {
-		e.preventDefault();
+	function toggleMoreUses( event ) {
+		event.preventDefault();
 
 		$usesList.toggle();
 
@@ -109,8 +37,8 @@ var wporg_developer = ( function( $ ) {
 		$hideMoreUses.toggle();
 	}
 
-	function toggleMoreUsedBy( e ) {
-		e.preventDefault();
+	function toggleMoreUsedBy( event ) {
+		event.preventDefault();
 
 		$usedByList.toggle();
 
@@ -118,11 +46,5 @@ var wporg_developer = ( function( $ ) {
 		$hideMoreUsedBy.toggle();
 	}
 
-	$( onLoad );
-
-	// Expose the sourceCodeDisplay() function for usage outside of this function.
-	return {
-		sourceCodeDisplay: sourceCodeDisplay
-	};
-
-} )( jQuery );
+	toggleUsageListInit();
+} );

--- a/source/wp-content/themes/wporg-developer/js/user-notes-preview.js
+++ b/source/wp-content/themes/wporg-developer/js/user-notes-preview.js
@@ -115,23 +115,10 @@
 		} );
 	}
 
-	// Add toggle links to source code in preview if needed.
-	function updateSourceCode() {
-		if ( undefined !== wporg_developer ) {
-			wporg_developer.sourceCodeDisplay( preview );
-		}
-	}
-
 	function updatePreview_HTML( content ) {
 		// Update preview content
 		previewContent.html( content );
 
-		if ( undefined !== window.SyntaxHighlighter ) {
-			SyntaxHighlighter.highlight();
-		}
-
-		// Add toggle link to source code in preview if needed.
-		updateSourceCode();
 		spinner.hide();
 	}
 

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -21,9 +21,15 @@ if ( ! empty( $source_file ) ) :
 		</p>
 
 		<?php if ( post_type_has_source_code() ) : ?>
-			<div class="source-code-container">
-				<pre class="brush: php; toolbar: false; first-line: <?php echo esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ); ?>"><?php echo htmlentities( get_source_code() ); ?></pre>
-			</div>
+			<?php
+				echo do_blocks(
+					sprintf(
+						'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="php" class="language-php line-numbers">%s</code></pre><!-- /wp:code -->',
+						htmlentities( get_source_code() )
+					)
+				);
+			?>
+
 			<p class="source-code-links">
 				<span>
 					<a href="#" class="show-complete-source"><?php _e( 'Expand full source code', 'wporg' ); ?></a>

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -24,7 +24,8 @@ if ( ! empty( $source_file ) ) :
 			<?php
 				echo do_blocks(
 					sprintf(
-						'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="php" class="language-php line-numbers">%s</code></pre><!-- /wp:code -->',
+						'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code" data-start="%s"><code lang="php" class="language-php line-numbers">%s</code></pre><!-- /wp:code -->',
+						esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ),
 						htmlentities( get_source_code() )
 					)
 				);

--- a/source/wp-content/themes/wporg-developer/scss/_colors.scss
+++ b/source/wp-content/themes/wporg-developer/scss/_colors.scss
@@ -1,0 +1,86 @@
+//Colors
+
+$color-white: #fff;
+$color-black: #000;
+
+// Color map of all of the hex values.
+// Please keep this map in sync with the HTML
+$colors: (
+	white: #fff,
+	black: #000,
+	gray-0: #f6f7f7,
+	gray-2: #f0f0f1,
+	gray-5: #dcdcde,
+	gray-10: #c3c4c7,
+	gray-20: #a7aaad,
+	gray-30: #8c8f94,
+	gray-40: #787c82,
+	gray-50: #646970,
+	gray-60: #50575e,
+	gray-70: #3c434a,
+	gray-80: #2c3338,
+	gray-90: #1d2327,
+	gray-100: #101517,
+	blue-0: #f0f6fc,
+	blue-5: #c5d9ed,
+	blue-10: #9ec2e6,
+	blue-20: #72aee6,
+	blue-30: #4f94d4,
+	blue-40: #3582c4,
+	blue-50: #2271b1,
+	blue-60: #135e96,
+	blue-70: #0a4b78,
+	blue-80: #043959,
+	blue-90: #01263a,
+	blue-100: #00131c,
+	red-0: #fcf0f1,
+	red-5: #facfd2,
+	red-10: #ffabaf,
+	red-20: #ff8085,
+	red-30: #f86368,
+	red-40: #e65054,
+	red-50: #d63638,
+	red-60: #b32d2e,
+	red-70: #8a2424,
+	red-80: #691c1c,
+	red-90: #451313,
+	red-100: #240a0a,
+	yellow-0: #fcf9e8,
+	yellow-5: #f5e6ab,
+	yellow-10: #f2d675,
+	yellow-20: #f0c33c,
+	yellow-30: #dba617,
+	yellow-40: #bd8600,
+	yellow-50: #996800,
+	yellow-60: #755100,
+	yellow-70: #614200,
+	yellow-80: #4a3200,
+	yellow-90: #362400,
+	yellow-100: #211600,
+	green-0: #edfaef,
+	green-5: #b8e6bf,
+	green-10: #68de7c,
+	green-20: #1ed14b,
+	green-30: #00ba37,
+	green-40: #00a32a,
+	green-50: #008a20,
+	green-60: #007017,
+	green-70: #005c12,
+	green-80: #00450c,
+	green-90: #003008,
+	green-100: #001c05
+);
+
+// Simple function to retreive colors in the $colors map.
+// e.g. `background-color: color(gray-50);`
+
+@function get-color($key) {
+
+	@if map-has-key($colors, $key) {
+
+		@return map-get($colors, $key);
+	}
+
+	@warn "Unknown `#{$key}` in $colors.";
+	@return null;
+}

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1670,13 +1670,6 @@
 		color: grey;
 	}
 
-	.syntaxhighlighter {
-		/* These are !important due to use of !important in SyntaxHighlighter Evolved plugin. */
-		max-width: 100% !important;
-		width: inherit !important;
-		padding-bottom: 0.5rem !important;
-	}
-
 	&.archive, &.blog {
 		.hentry {
 			padding: 0 0 1.5em 0;
@@ -2776,8 +2769,6 @@ body.responsive-show {
 		}
 	}
 }
-
-code[class*="language-"],pre[class*="language-"]{direction:ltr;text-align:left;white-space:pre;word-spacing:normal;word-break:normal;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;hyphens:none;background:#2b303b;color:#c0c5ce}pre[class*="language-"]::-moz-selection,pre[class*="language-"] ::-moz-selection,code[class*="language-"]::-moz-selection,code[class*="language-"] ::-moz-selection{text-shadow:none;background:#a7adba}pre[class*="language-"]::selection,pre[class*="language-"] ::selection,code[class*="language-"]::selection,code[class*="language-"] ::selection{text-shadow:none;background:#a7adba}pre[class*="language-"]{overflow:auto}:not(pre)>code[class*="language-"]{border-radius:.3em}.token.comment,.token.prolog,.token.doctype,.token.cdata{color:#65737e}.token.punctuation{color:#c0c5ce}.token.namespace{opacity:.7}.token.operator,.token.boolean,.token.number{color:#d08770}.token.property{color:#ebcb8b}.token.tag{color:#8fa1b3}.token.string{color:#96b5b4}.token.selector{color:#b48ead}.token.attr-name{color:#d08770}.token.entity,.token.url,.language-css .token.string,.style .token.string{color:#96b5b4}.token.attr-value,.token.keyword,.token.control,.token.directive,.token.unit{color:#a3be8c}.token.statement,.token.regex,.token.atrule{color:#96b5b4}.token.placeholder,.token.variable{color:#8fa1b3}.token.deleted{text-decoration:line-through}.token.inserted{border-bottom:1px dotted #eff1f5;text-decoration:none}.token.italic{font-style:italic}.token.important,.token.bold{font-weight:bold}.token.important{color:#bf616a}.token.entity{cursor:help}pre>code.highlight{outline:0.4em solid #bf616a;outline-offset:.4em}
 
 button.code-tab,
 button.code-tab:hover {

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -1,0 +1,207 @@
+/**
+ * Custom theme for developer.wordpress.org.
+ * Forked from a11y-dark theme by ericwbailey, which was based on the okaidia theme.
+ *
+ * https://github.com/PrismJS/prism-themes/blob/master/themes/prism-a11y-dark.css
+ * https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css
+ */
+
+@import "colors";
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: get-color(gray-100);
+	background: none;
+	font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: 0.5em 0;
+	overflow: auto;
+	border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: get-color(gray-0);
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: 0.1em;
+	border-radius: 0.3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: get-color(green-60);
+}
+
+.token.punctuation {
+	color: get-color(gray-60);
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: get-color(blue-80);
+}
+
+.token.boolean,
+.token.number {
+	color: get-color(gray-100);
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: get-color(blue-50);
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+	color: #a85f00;
+}
+
+.token.function {
+	color: #b8236d;
+}
+
+.token.keyword {
+	color: get-color(blue-60);
+	font-weight: 600;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function-definition {
+	color: get-color(gray-100);
+}
+
+.token.important,
+.token.bold {
+	font-weight: 700;
+}
+
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+
+@media screen and (-ms-high-contrast: active) {
+	code[class*="language-"],
+	pre[class*="language-"] {
+		color: windowText;
+		background: window;
+	}
+
+	:not(pre) > code[class*="language-"],
+	pre[class*="language-"] {
+		background: window;
+	}
+
+	.token.important {
+		background: highlight;
+		color: window;
+		font-weight: 700;
+	}
+
+	.token.atrule,
+	.token.attr-value,
+	.token.function,
+	.token.keyword,
+	.token.operator,
+	.token.selector {
+		font-weight: 700;
+	}
+
+	.token.attr-value,
+	.token.comment,
+	.token.doctype,
+	.token.function,
+	.token.keyword,
+	.token.operator,
+	.token.property,
+	.token.string {
+		color: highlight;
+	}
+
+	.token.attr-value,
+	.token.url {
+		font-weight: 700;
+	}
+}
+
+/* Line Numbers */
+pre.line-numbers {
+	position: relative;
+	padding-left: 3.8em;
+	counter-reset: linenumber;
+}
+
+pre.line-numbers > code {
+	position: relative;
+}
+
+.line-numbers .line-numbers-rows {
+	position: absolute;
+	pointer-events: none;
+	top: 0;
+	font-size: 100%;
+	left: -3.8em;
+	width: 3em; /* works for line-numbers below 1000 lines */
+	letter-spacing: -1px;
+	border-right: 0;
+
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+
+}
+
+.line-numbers-rows > span {
+	pointer-events: none;
+	display: block;
+	counter-increment: linenumber;
+}
+
+.line-numbers-rows > span::before {
+	content: counter(linenumber);
+	color: #5c6370;
+	display: block;
+	padding-right: 0.8em;
+	text-align: right;
+}

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -181,7 +181,7 @@ pre.line-numbers > code {
 	top: 0;
 	font-size: 100%;
 	left: -3.8em;
-	width: 3em; /* works for line-numbers below 1000 lines */
+	width: 4em; /* works for line-numbers below 10000 lines */
 	letter-spacing: -1px;
 	border-right: 0;
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2098,13 +2098,6 @@ input {
   color: grey;
 }
 
-.devhub-wrap .syntaxhighlighter {
-  /* These are !important due to use of !important in SyntaxHighlighter Evolved plugin. */
-  max-width: 100% !important;
-  width: inherit !important;
-  padding-bottom: 0.5rem !important;
-}
-
 .devhub-wrap.archive .hentry, .devhub-wrap.blog .hentry {
   padding: 0 0 1.5em 0;
   border-bottom: 1px solid #ddd;
@@ -3156,123 +3149,6 @@ body.responsive-show #o2-expand-editor {
   top: 6px;
   margin-right: 5px;
   cursor: pointer;
-}
-
-code[class*="language-"], pre[class*="language-"] {
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #2b303b;
-  color: #c0c5ce;
-}
-
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection, code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #a7adba;
-}
-
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection, code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #a7adba;
-}
-
-pre[class*="language-"] {
-  overflow: auto;
-}
-
-:not(pre) > code[class*="language-"] {
-  border-radius: .3em;
-}
-
-.token.comment, .token.prolog, .token.doctype, .token.cdata {
-  color: #65737e;
-}
-
-.token.punctuation {
-  color: #c0c5ce;
-}
-
-.token.namespace {
-  opacity: .7;
-}
-
-.token.operator, .token.boolean, .token.number {
-  color: #d08770;
-}
-
-.token.property {
-  color: #ebcb8b;
-}
-
-.token.tag {
-  color: #8fa1b3;
-}
-
-.token.string {
-  color: #96b5b4;
-}
-
-.token.selector {
-  color: #b48ead;
-}
-
-.token.attr-name {
-  color: #d08770;
-}
-
-.token.entity, .token.url, .language-css .token.string, .style .token.string {
-  color: #96b5b4;
-}
-
-.token.attr-value, .token.keyword, .token.control, .token.directive, .token.unit {
-  color: #a3be8c;
-}
-
-.token.statement, .token.regex, .token.atrule {
-  color: #96b5b4;
-}
-
-.token.placeholder, .token.variable {
-  color: #8fa1b3;
-}
-
-.token.deleted {
-  text-decoration: line-through;
-}
-
-.token.inserted {
-  border-bottom: 1px dotted #eff1f5;
-  text-decoration: none;
-}
-
-.token.italic {
-  font-style: italic;
-}
-
-.token.important, .token.bold {
-  font-weight: bold;
-}
-
-.token.important {
-  color: #bf616a;
-}
-
-.token.entity {
-  cursor: help;
-}
-
-pre > code.highlight {
-  outline: 0.4em solid #bf616a;
-  outline-offset: .4em;
 }
 
 button.code-tab,

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -1,0 +1,196 @@
+/**
+ * Custom theme for developer.wordpress.org.
+ * Forked from a11y-dark theme by ericwbailey, which was based on the okaidia theme.
+ *
+ * https://github.com/PrismJS/prism-themes/blob/master/themes/prism-a11y-dark.css
+ * https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css
+ */
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #101517;
+  background: none;
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background: #f6f7f7;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #007017;
+}
+
+.token.punctuation {
+  color: #50575e;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #043959;
+}
+
+.token.boolean,
+.token.number {
+  color: #101517;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #2271b1;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #a85f00;
+}
+
+.token.function {
+  color: #b8236d;
+}
+
+.token.keyword {
+  color: #135e96;
+  font-weight: 600;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function-definition {
+  color: #101517;
+}
+
+.token.important,
+.token.bold {
+  font-weight: 700;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  code[class*="language-"],
+  pre[class*="language-"] {
+    color: windowText;
+    background: window;
+  }
+  :not(pre) > code[class*="language-"],
+  pre[class*="language-"] {
+    background: window;
+  }
+  .token.important {
+    background: highlight;
+    color: window;
+    font-weight: 700;
+  }
+  .token.atrule,
+  .token.attr-value,
+  .token.function,
+  .token.keyword,
+  .token.operator,
+  .token.selector {
+    font-weight: 700;
+  }
+  .token.attr-value,
+  .token.comment,
+  .token.doctype,
+  .token.function,
+  .token.keyword,
+  .token.operator,
+  .token.property,
+  .token.string {
+    color: highlight;
+  }
+  .token.attr-value,
+  .token.url {
+    font-weight: 700;
+  }
+}
+
+/* Line Numbers */
+pre.line-numbers {
+  position: relative;
+  padding-left: 3.8em;
+  counter-reset: linenumber;
+}
+
+pre.line-numbers > code {
+  position: relative;
+}
+
+.line-numbers .line-numbers-rows {
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  font-size: 100%;
+  left: -3.8em;
+  width: 3em;
+  /* works for line-numbers below 1000 lines */
+  letter-spacing: -1px;
+  border-right: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.line-numbers-rows > span {
+  pointer-events: none;
+  display: block;
+  counter-increment: linenumber;
+}
+
+.line-numbers-rows > span::before {
+  content: counter(linenumber);
+  color: #5c6370;
+  display: block;
+  padding-right: 0.8em;
+  text-align: right;
+}

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -171,8 +171,8 @@ pre.line-numbers > code {
   top: 0;
   font-size: 100%;
   left: -3.8em;
-  width: 3em;
-  /* works for line-numbers below 1000 lines */
+  width: 4em;
+  /* works for line-numbers below 10000 lines */
   letter-spacing: -1px;
   border-right: 0;
   -webkit-user-select: none;


### PR DESCRIPTION
This removes the use of SyntaxHighlighter Evolved in favor of rendering using the core code block + enhancements from the Code Syntax Block (using prismjs to do syntax highlighting). I've made a semi-custom theme for the developer site, based on a combination of the existing theme, the a11y-dark CSS, and the core WordPress color system.

These are known issues and I think it would be best to turn these into separate issues once this PR is merged, rather than trying to do all of it in one:
 
- [ ] Turn on block editor for Explanations
- [ ] Convert shortcodes in Explanations to code blocks
- [ ] Add back in the collapsible toggle when code is longer than 12 lines
- [ ] PR upstream to Code Syntax Block to allow a custom line number start (added in code for the `source`, but not possible to add in the editor)
- [ ] Add `css` button to the user notes comment form, since that shortcode exists now

Fixes #25

## Screenshots

The function source:

| Before | After |
| --- | --- |
| ![source-before](https://user-images.githubusercontent.com/541093/171286182-b414517b-8a0b-47eb-8565-cf5d8311f7b5.png) | ![source-after](https://user-images.githubusercontent.com/541093/171290126-7c204713-1bfd-45fd-bcf6-acff2a66ffbe.png) |

Code in the "User Contributed Notes" section - note that I added a `css` shortcode to mirror the PHP & JS ones.

| Before | After |
| --- | --- |
| ![user-notes-before](https://user-images.githubusercontent.com/541093/171286186-7bc09785-4998-4666-9815-5e31247399ac.png) | ![user-notes-after](https://user-images.githubusercontent.com/541093/171286184-5c34f820-2bca-4639-add6-1be69360b40c.png) |

Code added in the Explanation section. Currently breaking due to `wpautop`, but if we convert this to the real block (instead of the shortcode workaround) it should fix that issue.

| Before | After |
| --- | --- |
| ![explanation-before](https://user-images.githubusercontent.com/541093/171286179-b5973a36-7f7b-4336-9a41-b1735a48e358.png) | ![explanation-after](https://user-images.githubusercontent.com/541093/171286172-0fa6bdde-7d5c-4f33-8e03-11b7cf133562.png) |

