### PR TITLE
Try some parameter doc fixes

### DIFF
--- a/source/wp-content/plugins/phpdoc-parser/lib/runner.php
+++ b/source/wp-content/plugins/phpdoc-parser/lib/runner.php
@@ -161,6 +161,13 @@ function fix_newlines( $text ) {
 		$text
 	);
 
+	// Insert a newline when \n follows .
+	$text = preg_replace(
+		"/\.[\n\r]+(?!\s*[\n\r])/m",
+		'.<br>',
+		$text
+	);
+
 	// Merge consecutive non-blank lines together by replacing the newlines with a space.
 	$text = preg_replace(
 		"/[\n\r](?!\s*[\n\r])/m",
@@ -406,5 +413,8 @@ function format_description( $description ) {
 		$parsedown   = \Parsedown::instance();
 		$description = $parsedown->line( $description );
 	}
+
+	$description = fix_newlines( $description );
+
 	return $description;
 }

--- a/source/wp-content/plugins/phpdoc-parser/lib/runner.php
+++ b/source/wp-content/plugins/phpdoc-parser/lib/runner.php
@@ -161,10 +161,17 @@ function fix_newlines( $text ) {
 		$text
 	);
 
-	// Insert a newline when \n follows .
+	// Insert a newline when \n follows `.`.
 	$text = preg_replace(
 		"/\.[\n\r]+(?!\s*[\n\r])/m",
 		'.<br>',
+		$text
+	);
+
+	// Insert a new line when \n is followed by what appears to be a list.
+	$text = preg_replace(
+		"/[\n\r]+(\s+[*-] )(?!\s*[\n\r])/m",
+		'<br>$1',
 		$text
 	);
 

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -497,6 +497,11 @@ class DevHub_Formatting {
 	 * list processing during parsing.
 	 *
 	 * Recognizes lists where list items are denoted with an asterisk or dash.
+	 * Examples:
+	 * - https://developer.wordpress.org/reference/functions/add_menu_page/
+	 * - https://developer.wordpress.org/reference/classes/wp_term_query/__construct/
+	 * - https://developer.wordpress.org/reference/hooks/password_change_email/
+	 * - https://developer.wordpress.org/reference/classes/WP_Query/parse_query/
 	 *
 	 * Does not handle nesting of lists.
 	 *
@@ -504,53 +509,22 @@ class DevHub_Formatting {
 	 * @return string
 	 */
 	public static function convert_lists_to_markup( $text ) {
-		$inline_list = false;
-		$li = '<br /> * ';
+		// Expand new lines for ease of matching.
+		$text = preg_replace( '!<br>\s*!', "<br>\n", $text );
 
-		// Convert asterisks to a list.
-		// Example: https://developer.wordpress.org/reference/functions/add_menu_page/
-		if ( false !== strpos( $text, ' * ' ) )  {
-			// Display as simple plaintext list.
-			$text = str_replace( ' * ', "\n" . $li, $text );
-			$inline_list = true;
+		// Trim any trailing <br>s on strings.
+		$text = preg_replace( '/<br>\s*$/s', '', $text );
+
+		// Add line items
+		$text = preg_replace( '!^\s*[*-] (.+?)(<br>)*$!m', '<li>$1</li>', $text, -1, $replacements_made );
+
+		if ( ! $replacements_made ) {
+			return $text;
 		}
 
-		// Convert dashes to a list.
-		// Example: https://developer.wordpress.org/reference/classes/wp_term_query/__construct/
-		// Example: https://developer.wordpress.org/reference/hooks/password_change_email/
-		if ( false !== strpos( $text, ' - ' ) )  {
-			// Display as simple plaintext list.
-			$text = str_replace( ' - ', "\n" . $li, $text );
-			$inline_list = true;
-		}
-
-		// If list detected.
-		if ( $inline_list ) {
-			$text = str_replace( "<br>", "\n<br>", $text );
-
-			// Replace first item, ensuring the opening 'ul' tag is prepended.
-			$text = preg_replace( '~^' . preg_quote( $li ) . '(.+)$~mU', "<ul><li>\$1</li>\n", $text, 1 );
-			// Wrap subsequent list items in 'li' tags.
-			$text = preg_replace( '~^' . preg_quote( $li ) . '(.+)$~mU', "<li>\$1</li>\n", $text ); 
-			$text = trim( $text );
-
-			// Close the list if it hasn't been closed before start of next hash parameter.
-			//$text = preg_replace( '~(</li>)(\s+</li>)~smU', '$1</ul>$2', $text );
-			$text = preg_replace( '~(</li>)(\s*</li>)~smU', '$1</ul>$2', $text );
-
-			// Close the list after the last item if it hasn't been closed and it's the end of the description.
-			$closing_li = strrpos( $text, '</li>' );
-			$closing_ul = strrpos( $text, '</ul>' );
-			if ( ! $closing_ul || $closing_li > $closing_ul ) {
-				$text = substr( $text, 0, $closing_li ) . '</li></ul>' . trim( substr( $text, $closing_li + 5 ) );
-			}
-
-			// Remove new lines at the end of list items / lists.
-			$text = preg_replace( '!(</(ul|li)>)\s*?(<br/?>)+!i', '$1', $text );
-		}
-
-		// Trim off any newlines at the end of the section.
-		$text = preg_replace( '!(<br/?>)+$!i', '', $text );
+		// Wrap in a `ul`.
+		$text = substr_replace( $text, '<ul><li>', strpos( $text, '<li>' ), 4 ); // First instance
+		$text = substr_replace( $text, '</li></ul>', strrpos( $text, '</li>' ), 5 ); // Last instance.
 
 		return $text;
 	}

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -43,6 +43,7 @@ class DevHub_Formatting {
 
 		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'autolink_references' ) );
 		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'fix_param_description_parsedown_bug' ) );
+		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'convert_lists_to_markup' ) );
 
 		add_filter( 'devhub-function-return-type', array( __CLASS__, 'autolink_references' ) );
 

--- a/source/wp-content/themes/wporg-developer/reference/template-params.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-params.php
@@ -27,12 +27,11 @@ if ( $params = get_params() ) :
 					</dt>
 				<?php endif; ?>
 				<dd>
-					<p class="desc">
-
+					<div class="desc">
 						<?php if ( ! empty( $param['content'] ) ) : ?>
 							<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
 						<?php endif; ?>
-					</p>
+					</div>
 					<?php if ( ! empty( $param['default'] ) ) : ?>
 						<p class="default"><?php _e( 'Default:', 'wporg' );?> <code><?php echo htmlentities( $param['default'] ); ?></code></p>
 					<?php endif; ?>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1144,6 +1144,10 @@
 
 				ul {
 					margin-left: 2.5rem;
+
+					ul {
+						margin-bottom: 0.5em;
+					}
 				}
 
 				code {


### PR DESCRIPTION
See #45.

Notes:
 - This is not mergable as-is, and is mostly untested.
 - Commit [Process lists within parameter blocks when deliberate br's are reta…](https://github.com/WordPress/wporg-developer/commit/249038c2dc524d3130c1bd6963327009b0537f83) relies upon this upstream change: https://github.com/WordPress/phpdoc-parser/compare/master...try/dev-45-newlines-in-docs

| Before | After |
| --- | --- |
| With Commit 1: [Parse lists within hash parameters.](https://github.com/WordPress/wporg-developer/commit/b7b60c323ade89245ce767cb5bf322b59b712663) |
| <img width="832" alt="Screen Shot 2022-06-01 at 4 47 26 pm" src="https://user-images.githubusercontent.com/767313/171344307-059a35ab-0052-4f62-93c7-5a462f3220eb.png"> | <img width="899" alt="Screen Shot 2022-06-01 at 4 11 42 pm" src="https://user-images.githubusercontent.com/767313/171344373-4f908f5f-a9b3-4311-b69a-45cebfd791f8.png"> |
| With Commit 2: [Process lists within parameter blocks when deliberate br's are reta…](https://github.com/WordPress/wporg-developer/commit/249038c2dc524d3130c1bd6963327009b0537f83) |
| See above | <img width="598" alt="Screen Shot 2022-06-01 at 4 39 40 pm" src="https://user-images.githubusercontent.com/767313/171344642-4d17a5a4-f3cb-4a58-ad34-2c784304c010.png"> |
| Better example of newline retention |
| <img width="772" alt="Screen Shot 2022-06-01 at 4 50 13 pm" src="https://user-images.githubusercontent.com/767313/171344728-2999754a-31cb-410e-927a-e65e417512d8.png"> | <img width="613" alt="Screen Shot 2022-06-01 at 4 50 38 pm" src="https://user-images.githubusercontent.com/767313/171344796-e5356b49-e9fb-4adc-949f-071daad00100.png"> |

 