### PR TITLE
Update the embed format.

### DIFF
--- a/source/wp-content/themes/wporg-developer/embed.php
+++ b/source/wp-content/themes/wporg-developer/embed.php
@@ -7,6 +7,8 @@
 
 use DevHub;
 
+remove_action( 'embed_content_meta', 'print_embed_comments_button' );
+
 if ( ! headers_sent() ) {
 	header( 'X-WP-embed: true' );
 }
@@ -64,7 +66,7 @@ $embed_post_id         = get_the_ID();
 $params                = get_params( $embed_post_id );
 $embed_title           = get_signature( $embed_post_id, count( $params ) > 0 );
 $param_count           = count( $params );
-$parameter_display_max = 3; // We truncate the display of params
+$parameter_display_max = 4; // We truncate the display of params
 
 ?>
 <!DOCTYPE html>
@@ -133,7 +135,7 @@ $parameter_display_max = 3; // We truncate the display of params
 
 			<?php if ( $params ) : ?>
 				<div class="wp-embed-parameters">
-					<h6 class="wp-embed-parameters-title"><?php echo __( 'Parameters', 'wporg' ); ?></h6>
+					<h6 class="wp-embed-parameters-title"><?php echo esc_html__( 'Parameters:', 'wporg' ); ?></h6>
 					<ul>
 						<?php
 						for ( $i = 0; $i < min( $param_count, $parameter_display_max ); $i++ ) {
@@ -179,6 +181,15 @@ $parameter_display_max = 3; // We truncate the display of params
 				do_action( 'embed_content_meta' );
 				?>
 			</div>
+
+			<?php
+				/**
+				 * Print scripts or data before the closing body tag in the embed template.
+				 *
+				 * @since 4.4.0
+				 */
+				do_action( 'embed_footer' );
+			?>
 		</div>
 	</div>
 </body>

--- a/source/wp-content/themes/wporg-developer/embed.php
+++ b/source/wp-content/themes/wporg-developer/embed.php
@@ -95,6 +95,7 @@ $parameter_display_max = 4; // We truncate the display of params
 
 		p.wp-embed-heading {
 			font-weight: normal;
+			font-size: 1.25rem;
 			font-family:
 				Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono",
 				"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono",

--- a/source/wp-content/themes/wporg-developer/embed.php
+++ b/source/wp-content/themes/wporg-developer/embed.php
@@ -46,11 +46,12 @@ function get_signature( $post_id ) {
 
 	if ( 'wp-parser-hook' === get_post_type( $post_id ) ) {
 		$hook_type = DevHub\get_hook_type_name( $post_id );
+		$delimiter = false !== strpos( $title, '$' ) ? '"' : "'";
 
 		if ( $has_args ) {
-			return "{$hook_type}( <span class=\"wp-embed-hook\">'{$title}',</span> ... )";
+			return "{$hook_type}( <span class=\"wp-embed-hook\">{$delimiter}{$title}{$delimiter},</span> ... )";
 		}
-		return "{$hook_type}( <span class=\"wp-embed-hook\">'{$title}'</span> )";
+		return "{$hook_type}( <span class=\"wp-embed-hook\">{$delimiter}{$title}{$delimiter}</span> )";
 	}
 
 	if ( $has_args ) {

--- a/source/wp-content/themes/wporg-developer/embed.php
+++ b/source/wp-content/themes/wporg-developer/embed.php
@@ -156,8 +156,7 @@ $parameter_display_max = 3; // We truncate the display of params
 			<?php endif; ?>
 
 		</div>
-
-
+		
 		<?php
 		/**
 		 * Print additional content after the embed excerpt.

--- a/source/wp-content/themes/wporg-developer/embed.php
+++ b/source/wp-content/themes/wporg-developer/embed.php
@@ -48,9 +48,9 @@ function get_signature( $post_id ) {
 		$hook_type = DevHub\get_hook_type_name( $post_id );
 
 		if ( $has_args ) {
-			return $hook_type . '( "<span class="wp-embed-hook">' . $title . '</span>", ... )';
+			return "{$hook_type}( <span class=\"wp-embed-hook\">'{$title}',</span> ... )";
 		}
-		return $hook_type . '( "<span class="wp-embed-hook">' . $title . '</span>" )';
+		return "{$hook_type}( <span class=\"wp-embed-hook\">'{$title}'</span> )";
 	}
 
 	if ( $has_args ) {
@@ -81,6 +81,10 @@ $parameter_display_max = 4; // We truncate the display of params
 	do_action( 'embed_head' );
 	?>
 	<style>
+		.wp-embed {
+			color: #50575e;
+		}
+
 		code {
 			background: #efefef;
 			border-radius: 4px;
@@ -88,8 +92,13 @@ $parameter_display_max = 4; // We truncate the display of params
 			font-weight: 400;
 		}
 
-		.wp-embed-heading {
+		p.wp-embed-heading {
 			font-weight: normal;
+			font-family:
+				Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono",
+				"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono",
+				"Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L",
+				"Courier New", Courier, monospace;
 		}
 
 		.wp-embed-parameters-title {
@@ -116,8 +125,11 @@ $parameter_display_max = 4; // We truncate the display of params
 			color: #24831d;
 		}
 
+		.wp-embed-footer a {
+			color: #135e96;
+		}
 	</style>
-	
+
 </head>
 <body <?php body_class(); ?>>
 	<div <?php post_class( 'wp-embed' ); ?>>

--- a/source/wp-content/themes/wporg-developer/embed.php
+++ b/source/wp-content/themes/wporg-developer/embed.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Modified version of the embed template from wp-includes/embed-template.php
+ *
+ * @package wporg-developer
+ */
+
+use DevHub;
+
+if ( ! headers_sent() ) {
+	header( 'X-WP-embed: true' );
+}
+
+$post_id = get_the_ID();
+
+$args                  = get_post_meta( $post_id, '_wp-parser_args', true );
+$tags                  = get_post_meta( $post_id, '_wp-parser_tags', true );
+$types                 = array();
+$formatted_args        = array();
+$PARAMETER_DISPLAY_MAX = 3;
+
+
+if ( $tags ) {
+	foreach ( $tags as $tag ) {
+		if ( is_array( $tag ) && 'param' == $tag['name'] ) {
+			$types[ $tag['variable'] ] = implode( ' | ', $tag['types'] );
+		}
+	}
+}
+
+// If it's a hook, the object is shaped differently
+if ( 'wp-parser-hook' === get_post_type( $post_id ) ) {
+	foreach ( $types as $arg => $type ) {
+		$formatted_args[] = array( $arg, $type );
+	}
+} else {
+	foreach ( $args as $arg ) {
+		$name = '';
+
+		if ( ! empty( $arg['name'] ) && ! empty( $types[ $arg['name'] ] ) ) {
+			$name = $types[ $arg['name'] ];
+		}
+
+		if ( ! empty( $arg['name'] ) ) {
+			$name = $arg['name'];
+		}
+
+		$formatted_args[] = array( $name, $types[ $arg['name'] ] );
+	}
+}
+
+
+function get_signature( $post_id, $args ) {
+	$title = get_the_title();
+
+	if ( 'wp-parser-hook' === get_post_type( $post_id ) ) {
+		$hook_type = DevHub\get_hook_type_name( $post_id );
+
+		if ( $args ) {
+			return $hook_type . '( "<span class="wp-embed-hook">' . $title . '</span>", ... )';
+		}
+		return $hook_type . '( "<span class="wp-embed-hook">' . $title . '</span>" )';
+	}
+
+	if ( $args ) {
+		return $title . '( ... )';
+	}
+
+	return $title . '()';
+}
+
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?> class="no-js">
+<head>
+	<title><?php echo esc_html( wp_get_document_title() ); ?></title>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<?php
+	/**
+	 * Print scripts or data in the embed template <head> tag.
+	 *
+	 * @since 4.4.0
+	 */
+	do_action( 'embed_head' );
+	?>
+	<style>
+		code {
+			background: #efefef;
+			border-radius: 4px;
+			padding: 2px 6px;
+			font-weight: 400;
+		}
+
+		.wp-embed-heading {
+			font-weight: normal;
+		}
+
+		.wp-embed-parameters-title {
+			margin: 16px 0 8px;
+			font-size: 14px;
+			font-weight: normal;
+		}
+
+		.wp-embed-parameters ul {
+			margin: 0 0 0 8px;
+			padding: 0;
+			list-style: none;
+		}
+
+		.wp-embed-parameters ul li {
+			padding: 4px;
+		}
+
+		.wp-embed-parameters code {
+			margin-right: 8px;
+		}
+
+		.wp-embed-hook {
+			color: #24831d;
+		}
+
+	</style>
+	
+</head>
+<body <?php body_class(); ?>>
+	<div <?php post_class( 'wp-embed' ); ?>>
+
+		<p class="wp-embed-heading">
+			<a href="<?php the_permalink(); ?>" target="_top">
+				<?php echo wp_kses_post( get_signature( $post_id, $formatted_args ) ); ?>
+			</a>
+		</p>
+
+		<div class="wp-embed-excerpt">
+			<?php the_excerpt(); ?>
+
+			<?php if ( $formatted_args ) : ?>
+				<div class="wp-embed-parameters">
+					<h6 class="wp-embed-parameters-title">Parameters</h6>
+					<ul>
+						<?php for ( $i = 0; $i < min( count( $formatted_args ), $PARAMETER_DISPLAY_MAX ); $i++ ) : ?>
+							<li>
+								<code><?php echo esc_html( $formatted_args[ $i ][0] ); ?></code>
+								<span class="wp-embed-parameters-type"><?php echo esc_html( $formatted_args[ $i ][1] ); ?></span>
+							</li>
+						<?php endfor; ?>
+
+						<?php if ( count( $formatted_args ) > $PARAMETER_DISPLAY_MAX ) : ?>
+							<li>... <?php echo count( $formatted_args ) - $PARAMETER_DISPLAY_MAX; ?> more </li>
+						<?php endif; ?>
+					</ul>
+				</div>
+			<?php endif; ?>
+
+		</div>
+
+
+		<?php
+		/**
+		 * Print additional content after the embed excerpt.
+		 *
+		 * @since 4.4.0
+		 */
+		do_action( 'embed_content' );
+		?>
+
+		<div class="wp-embed-footer">
+			<?php the_embed_site_title(); ?>
+
+			<div class="wp-embed-meta">
+				<?php
+				/**
+				 * Prints additional meta content in the embed template.
+				 *
+				 * @since 4.4.0
+				 */
+				do_action( 'embed_content_meta' );
+				?>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/source/wp-content/themes/wporg-developer/embed.php
+++ b/source/wp-content/themes/wporg-developer/embed.php
@@ -5,8 +5,6 @@
  * @package wporg-developer
  */
 
-use DevHub;
-
 remove_action( 'embed_content_meta', 'print_embed_comments_button' );
 
 if ( ! headers_sent() ) {
@@ -38,13 +36,13 @@ function get_params( $post_id ) {
 /**
  * Returns a function string to display.
  *
- * @param int     $post_id
- * @param boolean $has_args
+ * @param int $post_id
  *
  * @return string
  */
-function get_signature( $post_id, $has_args ) {
+function get_signature( $post_id ) {
 	$title = get_the_title();
+	$has_args = count( get_params( $post_id ) ) > 0;
 
 	if ( 'wp-parser-hook' === get_post_type( $post_id ) ) {
 		$hook_type = DevHub\get_hook_type_name( $post_id );
@@ -64,7 +62,7 @@ function get_signature( $post_id, $has_args ) {
 
 $embed_post_id         = get_the_ID();
 $params                = get_params( $embed_post_id );
-$embed_title           = get_signature( $embed_post_id, count( $params ) > 0 );
+$embed_title           = get_signature( $embed_post_id );
 $param_count           = count( $params );
 $parameter_display_max = 4; // We truncate the display of params
 

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -687,6 +687,36 @@ namespace DevHub {
 	}
 
 	/**
+	 * Returns the hook string.
+	 *
+	 * @param int $post_id
+	 *
+	 * @return string
+	 */
+	function get_hook_type_name( $post_id ) {
+		$hook_type = get_post_meta( $post_id, '_wp-parser_hook_type', true );
+		if ( false !== strpos( $hook_type, 'action' ) ) {
+			if ( 'action_reference' === $hook_type ) {
+				$hook_type = 'do_action_ref_array';
+			} elseif ( 'action_deprecated' === $hook_type ) {
+				$hook_type = 'do_action_deprecated';
+			} else {
+				$hook_type = 'do_action';
+			}
+		} else {
+			if ( 'filter_reference' === $hook_type ) {
+				$hook_type = 'apply_filters_ref_array';
+			} elseif ( 'filter_deprecated' === $hook_type ) {
+				$hook_type = 'apply_filters_deprecated';
+			} else {
+				$hook_type = 'apply_filters';
+			}
+		}
+
+		return $hook_type;
+	}
+
+	/**
 	 * Retrieve function name and arguments as signature string
 	 *
 	 * @param int $post_id
@@ -725,24 +755,7 @@ namespace DevHub {
 				$hook_args[] = ' <nobr><span class="arg-type">' . esc_html( $type ) . '</span> <span class="arg-name">' . esc_html( $arg ) . '</span></nobr>';
 			}
 
-			$hook_type = get_post_meta( $post_id, '_wp-parser_hook_type', true );
-			if ( false !== strpos( $hook_type, 'action' ) ) {
-				if ( 'action_reference' === $hook_type ) {
-					$hook_type = 'do_action_ref_array';
-				} elseif ( 'action_deprecated' === $hook_type ) {
-					$hook_type = 'do_action_deprecated';
-				} else {
-					$hook_type = 'do_action';
-				}
-			} else {
-				if ( 'filter_reference' === $hook_type ) {
-					$hook_type = 'apply_filters_ref_array';
-				} elseif ( 'filter_deprecated' === $hook_type ) {
-					$hook_type = 'apply_filters_deprecated';
-				} else {
-					$hook_type = 'apply_filters';
-				}
-			}
+			$hook_type = get_hook_type_name( $post_id );
 
 			$delimiter = false !== strpos( $signature, '$' ) ? '"' : "'";
 			$signature = $delimiter . $signature . $delimiter;


### PR DESCRIPTION
Closes: https://github.com/WordPress/wporg-developer/issues/34

This PR updates the embed layout by creating an `embed.php` file and serving a custom embed view. 

**Changes:**
- If `function` add `()`
- If `hook`, apply the correct `function` that wraps it. 
- If `hook` of `functions` has arguments, add `...` to denote parameters
  - I tried to show all the properties but it's overwhelming, at least how I had them styled.
- Show parameters in a list
- If parameters list is `> 4` truncate 

There are no examples of classes, and this wasn't tested on "classes" because of #35. This PR should probably wait for that bug fix.

If you think there is more pertinent information to add to the embed that is missing, please comment below!



### Screenshots
![](https://d.pr/i/xyEM2r.png) 
![](https://d.pr/i/6Tq49Q.png) 
![](https://d.pr/i/RNQClT.png) 
![](https://d.pr/i/2vWWkH.png) 
![](https://d.pr/i/2CWpYc.png) 