### PR TITLE
Check if source is empty before printing block.

### DIFF
--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -10,7 +10,7 @@ namespace DevHub;
 
 $source_file = get_source_file();
 if ( ! empty( $source_file ) ) :
-	$source_code = get_source_code();
+	$source_code = post_type_has_source_code() ? get_source_code() : '';
 	?>
 	<hr />
 	<section class="source-content">
@@ -32,7 +32,7 @@ if ( ! empty( $source_file ) ) :
 			?>
 		</p>
 
-		<?php if ( post_type_has_source_code() && ! empty( $source_code ) ) : ?>
+		<?php if ( ! empty( $source_code ) ) : ?>
 			<?php
 				echo do_blocks(
 					sprintf(

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -9,7 +9,6 @@
 namespace DevHub;
 
 $source_file = get_source_file();
-
 if ( ! empty( $source_file ) ) :
 	$source_code = get_source_code();
 	?>

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -9,7 +9,10 @@
 namespace DevHub;
 
 $source_file = get_source_file();
+
 if ( ! empty( $source_file ) ) :
+	$source_code = get_source_code();
+
 	?>
 	<hr />
 	<section class="source-content">
@@ -31,14 +34,14 @@ if ( ! empty( $source_file ) ) :
 			?>
 		</p>
 
-		<?php if ( post_type_has_source_code() ) : ?>
+		<?php if ( post_type_has_source_code() && ! empty( $source_code ) ) : ?>
 			<?php
 				echo do_blocks(
 					sprintf(
 						'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code" data-start="%1$s" aria-label="%2$s"><code lang="php" class="language-php line-numbers">%3$s</code></pre><!-- /wp:code -->',
 						esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ),
 						__( 'Function source code', 'wporg' ),
-						htmlentities( get_source_code() )
+						htmlentities( $source_code )
 					)
 				);
 			?>

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -12,7 +12,6 @@ $source_file = get_source_file();
 
 if ( ! empty( $source_file ) ) :
 	$source_code = get_source_code();
-
 	?>
 	<hr />
 	<section class="source-content">


### PR DESCRIPTION
Fixes: #58.

Check to make sure the source code is not empty.

### Considerations
I considered updating `post_type_has_source_code` since it kind of implies that there is source code, but instead it checks if it _should_ have source code based on its type.

We could add the `get_source_code()` check inside of `post_type_has_source_code` as well, but it does database calls so it more performant to leave it out.
