### PR TITLE
Source: File link should have better language.

### DIFF
--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -15,9 +15,20 @@ if ( ! empty( $source_file ) ) :
 	<section class="source-content">
 		<h2><?php _e( 'Source', 'wporg' ); ?></h2>
 		<p>
-			<?php printf( __( 'File: %s', 'wporg' ),
-				'<a href="' . esc_url( get_source_file_archive_link( $source_file ) ) . '">' . esc_html( $source_file ) . '</a>'
-			); ?>
+			<?php
+			printf(
+				__( 'File: %s.', 'wporg' ),
+				esc_html( $source_file )
+			);
+			?>
+
+			<?php
+			printf(
+				'<a href="%s">%s</a>',
+				esc_url( get_source_file_archive_link( $source_file ) ),
+				__( 'View all references', 'wporg' )
+			);
+			?>
 		</p>
 
 		<?php if ( post_type_has_source_code() ) : ?>

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -18,7 +18,7 @@ if ( ! empty( $source_file ) ) :
 			<?php
 			printf(
 				__( 'File: %s.', 'wporg' ),
-				esc_html( $source_file )
+				'<code>' . esc_html( $source_file ) . '</code>'
 			);
 			?>
 


### PR DESCRIPTION
If you click on the file name in the Source section, it takes you to a page with other function/hooks related to that file. I found that useful but also surprising. I expected it to go to the source file.

| Before | After |
| --- | --- |
| ![](https://d.pr/i/3tCO9o.png) |  ![](https://d.pr/i/MrjVlU.png) |
