### PR TITLE
Reference Page: Update style of parameters and signature

### DIFF
--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1108,6 +1108,7 @@
 		}
 
 		.return-type,
+		.return .type,
 		.parameters .type {
 			color: get-color(red-50);
 
@@ -1122,7 +1123,8 @@
 			}
 		}
 
-		.parameters {
+		.parameters,
+		.return {
 			p {
 				margin-bottom: 0;
 			}

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1130,7 +1130,6 @@
 			}
 
 			dt code {
-				color: get-color(blue-60);
 				font-weight: 400;
 			}
 
@@ -1167,7 +1166,6 @@
 					> code {
 						background: transparent;
 						padding: unset;
-						color: get-color(blue-60);
 					}
 				}
 

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1070,33 +1070,34 @@
 
 		h1,
 		.signature-highlight {
-			color: #24831d;
+			color: get-color(green-50);
 			font-family: $code-font;
 			font-weight: 400;
 
 			.hook-func {
-				color: #888;
+				color: get-color(gray-50);
 			}
 
 			.arg-type {
-				color: #cd2f23;
+				color: get-color(red-50);
 				font-style: italic;
 				font-size: 0.9em;
 			}
 
 			.arg-name {
-				color: #0f55c8;
+				color: get-color(blue-60);
 			}
 
 			.arg-default {
-				color: #000;
+				color: $color-black;
 			}
 
 			a {
 				text-decoration: none;
+				color: inherit;
 
 				&:hover {
-					border-bottom: 1px dotted #21759b;
+					border-bottom: 1px dotted get-color(blue-50);
 				}
 			}
 		}
@@ -1108,14 +1109,15 @@
 
 		.return-type,
 		.parameters .type {
-			color: #dc3232;
+			color: get-color(red-50);
 
 			a {
 				color: inherit;
 				text-decoration: none;
+				border-bottom: 1px dotted get-color(gray-70);
 
 				&:hover {
-					border-bottom: 1px dotted #21759b;
+					border-bottom-style: solid;
 				}
 			}
 		}
@@ -1125,11 +1127,22 @@
 				margin-bottom: 0;
 			}
 
+			dt code {
+				color: get-color(blue-60);
+				font-weight: 400;
+			}
+
 			dd {
 				margin-bottom: 2em;
 
 				ul {
 					margin-left: 2.5rem;
+				}
+
+				code {
+					background: #efefef;
+					border-radius: 4px;
+					padding: 2px 6px;
 				}
 			}
 
@@ -1148,6 +1161,12 @@
 
 				> li {
 					margin-top: 1.5em;
+
+					> code {
+						background: transparent;
+						padding: unset;
+						color: get-color(blue-60);
+					}
 				}
 
 				li li {
@@ -1177,13 +1196,6 @@
 
 			.required {
 				font-size: 12px;
-			}
-
-			code {
-				background: #efefef;
-				border-radius: 4px;
-				padding: 2px 6px;
-				font-weight: 400;
 			}
 		}
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1543,7 +1543,6 @@ input {
 .devhub-wrap .wp-parser-hook .return dt code,
 .devhub-wrap .wp-parser-method .parameters dt code,
 .devhub-wrap .wp-parser-method .return dt code {
-  color: #135e96;
   font-weight: 400;
 }
 
@@ -1638,7 +1637,6 @@ input {
 .devhub-wrap .wp-parser-method .return .param-hash > li > code {
   background: transparent;
   padding: unset;
-  color: #135e96;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash li li,

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1478,23 +1478,31 @@ input {
 }
 
 .devhub-wrap .wp-parser-class .return-type,
+.devhub-wrap .wp-parser-class .return .type,
 .devhub-wrap .wp-parser-class .parameters .type,
 .devhub-wrap .wp-parser-function .return-type,
+.devhub-wrap .wp-parser-function .return .type,
 .devhub-wrap .wp-parser-function .parameters .type,
 .devhub-wrap .wp-parser-hook .return-type,
+.devhub-wrap .wp-parser-hook .return .type,
 .devhub-wrap .wp-parser-hook .parameters .type,
 .devhub-wrap .wp-parser-method .return-type,
+.devhub-wrap .wp-parser-method .return .type,
 .devhub-wrap .wp-parser-method .parameters .type {
   color: #d63638;
 }
 
 .devhub-wrap .wp-parser-class .return-type a,
+.devhub-wrap .wp-parser-class .return .type a,
 .devhub-wrap .wp-parser-class .parameters .type a,
 .devhub-wrap .wp-parser-function .return-type a,
+.devhub-wrap .wp-parser-function .return .type a,
 .devhub-wrap .wp-parser-function .parameters .type a,
 .devhub-wrap .wp-parser-hook .return-type a,
+.devhub-wrap .wp-parser-hook .return .type a,
 .devhub-wrap .wp-parser-hook .parameters .type a,
 .devhub-wrap .wp-parser-method .return-type a,
+.devhub-wrap .wp-parser-method .return .type a,
 .devhub-wrap .wp-parser-method .parameters .type a {
   color: inherit;
   text-decoration: none;
@@ -1502,139 +1510,211 @@ input {
 }
 
 .devhub-wrap .wp-parser-class .return-type a:hover,
+.devhub-wrap .wp-parser-class .return .type a:hover,
 .devhub-wrap .wp-parser-class .parameters .type a:hover,
 .devhub-wrap .wp-parser-function .return-type a:hover,
+.devhub-wrap .wp-parser-function .return .type a:hover,
 .devhub-wrap .wp-parser-function .parameters .type a:hover,
 .devhub-wrap .wp-parser-hook .return-type a:hover,
+.devhub-wrap .wp-parser-hook .return .type a:hover,
 .devhub-wrap .wp-parser-hook .parameters .type a:hover,
 .devhub-wrap .wp-parser-method .return-type a:hover,
+.devhub-wrap .wp-parser-method .return .type a:hover,
 .devhub-wrap .wp-parser-method .parameters .type a:hover {
   border-bottom-style: solid;
 }
 
 .devhub-wrap .wp-parser-class .parameters p,
+.devhub-wrap .wp-parser-class .return p,
 .devhub-wrap .wp-parser-function .parameters p,
+.devhub-wrap .wp-parser-function .return p,
 .devhub-wrap .wp-parser-hook .parameters p,
-.devhub-wrap .wp-parser-method .parameters p {
+.devhub-wrap .wp-parser-hook .return p,
+.devhub-wrap .wp-parser-method .parameters p,
+.devhub-wrap .wp-parser-method .return p {
   margin-bottom: 0;
 }
 
 .devhub-wrap .wp-parser-class .parameters dt code,
+.devhub-wrap .wp-parser-class .return dt code,
 .devhub-wrap .wp-parser-function .parameters dt code,
+.devhub-wrap .wp-parser-function .return dt code,
 .devhub-wrap .wp-parser-hook .parameters dt code,
-.devhub-wrap .wp-parser-method .parameters dt code {
+.devhub-wrap .wp-parser-hook .return dt code,
+.devhub-wrap .wp-parser-method .parameters dt code,
+.devhub-wrap .wp-parser-method .return dt code {
   color: #135e96;
   font-weight: 400;
 }
 
 .devhub-wrap .wp-parser-class .parameters dd,
+.devhub-wrap .wp-parser-class .return dd,
 .devhub-wrap .wp-parser-function .parameters dd,
+.devhub-wrap .wp-parser-function .return dd,
 .devhub-wrap .wp-parser-hook .parameters dd,
-.devhub-wrap .wp-parser-method .parameters dd {
+.devhub-wrap .wp-parser-hook .return dd,
+.devhub-wrap .wp-parser-method .parameters dd,
+.devhub-wrap .wp-parser-method .return dd {
   margin-bottom: 2em;
 }
 
 .devhub-wrap .wp-parser-class .parameters dd ul,
+.devhub-wrap .wp-parser-class .return dd ul,
 .devhub-wrap .wp-parser-function .parameters dd ul,
+.devhub-wrap .wp-parser-function .return dd ul,
 .devhub-wrap .wp-parser-hook .parameters dd ul,
-.devhub-wrap .wp-parser-method .parameters dd ul {
+.devhub-wrap .wp-parser-hook .return dd ul,
+.devhub-wrap .wp-parser-method .parameters dd ul,
+.devhub-wrap .wp-parser-method .return dd ul {
   margin-left: 2.5rem;
 }
 
 .devhub-wrap .wp-parser-class .parameters dd code,
+.devhub-wrap .wp-parser-class .return dd code,
 .devhub-wrap .wp-parser-function .parameters dd code,
+.devhub-wrap .wp-parser-function .return dd code,
 .devhub-wrap .wp-parser-hook .parameters dd code,
-.devhub-wrap .wp-parser-method .parameters dd code {
+.devhub-wrap .wp-parser-hook .return dd code,
+.devhub-wrap .wp-parser-method .parameters dd code,
+.devhub-wrap .wp-parser-method .return dd code {
   background: #efefef;
   border-radius: 4px;
   padding: 2px 6px;
 }
 
 .devhub-wrap .wp-parser-class .parameters dd:last-child,
+.devhub-wrap .wp-parser-class .return dd:last-child,
 .devhub-wrap .wp-parser-function .parameters dd:last-child,
+.devhub-wrap .wp-parser-function .return dd:last-child,
 .devhub-wrap .wp-parser-hook .parameters dd:last-child,
-.devhub-wrap .wp-parser-method .parameters dd:last-child {
+.devhub-wrap .wp-parser-hook .return dd:last-child,
+.devhub-wrap .wp-parser-method .parameters dd:last-child,
+.devhub-wrap .wp-parser-method .return dd:last-child {
   margin-bottom: 0;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash,
+.devhub-wrap .wp-parser-class .return .param-hash,
 .devhub-wrap .wp-parser-function .parameters .param-hash,
+.devhub-wrap .wp-parser-function .return .param-hash,
 .devhub-wrap .wp-parser-hook .parameters .param-hash,
-.devhub-wrap .wp-parser-method .parameters .param-hash {
+.devhub-wrap .wp-parser-hook .return .param-hash,
+.devhub-wrap .wp-parser-method .parameters .param-hash,
+.devhub-wrap .wp-parser-method .return .param-hash {
   margin-left: 1.2em;
   margin-bottom: 0.5em;
   list-style: none;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash .desc,
+.devhub-wrap .wp-parser-class .return .param-hash .desc,
 .devhub-wrap .wp-parser-function .parameters .param-hash .desc,
+.devhub-wrap .wp-parser-function .return .param-hash .desc,
 .devhub-wrap .wp-parser-hook .parameters .param-hash .desc,
-.devhub-wrap .wp-parser-method .parameters .param-hash .desc {
+.devhub-wrap .wp-parser-hook .return .param-hash .desc,
+.devhub-wrap .wp-parser-method .parameters .param-hash .desc,
+.devhub-wrap .wp-parser-method .return .param-hash .desc {
   margin-left: 1.5em;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash > li,
+.devhub-wrap .wp-parser-class .return .param-hash > li,
 .devhub-wrap .wp-parser-function .parameters .param-hash > li,
+.devhub-wrap .wp-parser-function .return .param-hash > li,
 .devhub-wrap .wp-parser-hook .parameters .param-hash > li,
-.devhub-wrap .wp-parser-method .parameters .param-hash > li {
+.devhub-wrap .wp-parser-hook .return .param-hash > li,
+.devhub-wrap .wp-parser-method .parameters .param-hash > li,
+.devhub-wrap .wp-parser-method .return .param-hash > li {
   margin-top: 1.5em;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash > li > code,
+.devhub-wrap .wp-parser-class .return .param-hash > li > code,
 .devhub-wrap .wp-parser-function .parameters .param-hash > li > code,
+.devhub-wrap .wp-parser-function .return .param-hash > li > code,
 .devhub-wrap .wp-parser-hook .parameters .param-hash > li > code,
-.devhub-wrap .wp-parser-method .parameters .param-hash > li > code {
+.devhub-wrap .wp-parser-hook .return .param-hash > li > code,
+.devhub-wrap .wp-parser-method .parameters .param-hash > li > code,
+.devhub-wrap .wp-parser-method .return .param-hash > li > code {
   background: transparent;
   padding: unset;
   color: #135e96;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash li li,
+.devhub-wrap .wp-parser-class .return .param-hash li li,
 .devhub-wrap .wp-parser-function .parameters .param-hash li li,
+.devhub-wrap .wp-parser-function .return .param-hash li li,
 .devhub-wrap .wp-parser-hook .parameters .param-hash li li,
-.devhub-wrap .wp-parser-method .parameters .param-hash li li {
+.devhub-wrap .wp-parser-hook .return .param-hash li li,
+.devhub-wrap .wp-parser-method .parameters .param-hash li li,
+.devhub-wrap .wp-parser-method .return .param-hash li li {
   list-style-type: circle;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash .param-hash > li,
+.devhub-wrap .wp-parser-class .return .param-hash .param-hash > li,
 .devhub-wrap .wp-parser-function .parameters .param-hash .param-hash > li,
+.devhub-wrap .wp-parser-function .return .param-hash .param-hash > li,
 .devhub-wrap .wp-parser-hook .parameters .param-hash .param-hash > li,
-.devhub-wrap .wp-parser-method .parameters .param-hash .param-hash > li {
+.devhub-wrap .wp-parser-hook .return .param-hash .param-hash > li,
+.devhub-wrap .wp-parser-method .parameters .param-hash .param-hash > li,
+.devhub-wrap .wp-parser-method .return .param-hash .param-hash > li {
   list-style-type: disc;
 }
 
 .devhub-wrap .wp-parser-class .parameters .desc,
+.devhub-wrap .wp-parser-class .return .desc,
 .devhub-wrap .wp-parser-function .parameters .desc,
+.devhub-wrap .wp-parser-function .return .desc,
 .devhub-wrap .wp-parser-hook .parameters .desc,
-.devhub-wrap .wp-parser-method .parameters .desc {
+.devhub-wrap .wp-parser-hook .return .desc,
+.devhub-wrap .wp-parser-method .parameters .desc,
+.devhub-wrap .wp-parser-method .return .desc {
   margin: 1rem 0 0.5rem;
 }
 
 .devhub-wrap .wp-parser-class .parameters .type,
 .devhub-wrap .wp-parser-class .parameters .required,
+.devhub-wrap .wp-parser-class .return .type,
+.devhub-wrap .wp-parser-class .return .required,
 .devhub-wrap .wp-parser-function .parameters .type,
 .devhub-wrap .wp-parser-function .parameters .required,
+.devhub-wrap .wp-parser-function .return .type,
+.devhub-wrap .wp-parser-function .return .required,
 .devhub-wrap .wp-parser-hook .parameters .type,
 .devhub-wrap .wp-parser-hook .parameters .required,
+.devhub-wrap .wp-parser-hook .return .type,
+.devhub-wrap .wp-parser-hook .return .required,
 .devhub-wrap .wp-parser-method .parameters .type,
-.devhub-wrap .wp-parser-method .parameters .required {
+.devhub-wrap .wp-parser-method .parameters .required,
+.devhub-wrap .wp-parser-method .return .type,
+.devhub-wrap .wp-parser-method .return .required {
   margin: 0 4px;
   font-weight: 400;
 }
 
 .devhub-wrap .wp-parser-class .parameters .type,
+.devhub-wrap .wp-parser-class .return .type,
 .devhub-wrap .wp-parser-function .parameters .type,
+.devhub-wrap .wp-parser-function .return .type,
 .devhub-wrap .wp-parser-hook .parameters .type,
-.devhub-wrap .wp-parser-method .parameters .type {
+.devhub-wrap .wp-parser-hook .return .type,
+.devhub-wrap .wp-parser-method .parameters .type,
+.devhub-wrap .wp-parser-method .return .type {
   margin-left: 8px;
   font-size: 14px;
   font-style: 400;
 }
 
 .devhub-wrap .wp-parser-class .parameters .required,
+.devhub-wrap .wp-parser-class .return .required,
 .devhub-wrap .wp-parser-function .parameters .required,
+.devhub-wrap .wp-parser-function .return .required,
 .devhub-wrap .wp-parser-hook .parameters .required,
-.devhub-wrap .wp-parser-method .parameters .required {
+.devhub-wrap .wp-parser-hook .return .required,
+.devhub-wrap .wp-parser-method .parameters .required,
+.devhub-wrap .wp-parser-method .return .required {
   font-size: 12px;
 }
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1395,7 +1395,7 @@ input {
 .devhub-wrap .wp-parser-hook .signature-highlight,
 .devhub-wrap .wp-parser-method h1,
 .devhub-wrap .wp-parser-method .signature-highlight {
-  color: #24831d;
+  color: #008a20;
   font-family: Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
   font-weight: 400;
 }
@@ -1408,7 +1408,7 @@ input {
 .devhub-wrap .wp-parser-hook .signature-highlight .hook-func,
 .devhub-wrap .wp-parser-method h1 .hook-func,
 .devhub-wrap .wp-parser-method .signature-highlight .hook-func {
-  color: #888;
+  color: #646970;
 }
 
 .devhub-wrap .wp-parser-class h1 .arg-type,
@@ -1419,7 +1419,7 @@ input {
 .devhub-wrap .wp-parser-hook .signature-highlight .arg-type,
 .devhub-wrap .wp-parser-method h1 .arg-type,
 .devhub-wrap .wp-parser-method .signature-highlight .arg-type {
-  color: #cd2f23;
+  color: #d63638;
   font-style: italic;
   font-size: 0.9em;
 }
@@ -1432,7 +1432,7 @@ input {
 .devhub-wrap .wp-parser-hook .signature-highlight .arg-name,
 .devhub-wrap .wp-parser-method h1 .arg-name,
 .devhub-wrap .wp-parser-method .signature-highlight .arg-name {
-  color: #0f55c8;
+  color: #135e96;
 }
 
 .devhub-wrap .wp-parser-class h1 .arg-default,
@@ -1455,6 +1455,7 @@ input {
 .devhub-wrap .wp-parser-method h1 a,
 .devhub-wrap .wp-parser-method .signature-highlight a {
   text-decoration: none;
+  color: inherit;
 }
 
 .devhub-wrap .wp-parser-class h1 a:hover,
@@ -1465,7 +1466,7 @@ input {
 .devhub-wrap .wp-parser-hook .signature-highlight a:hover,
 .devhub-wrap .wp-parser-method h1 a:hover,
 .devhub-wrap .wp-parser-method .signature-highlight a:hover {
-  border-bottom: 1px dotted #21759b;
+  border-bottom: 1px dotted #2271b1;
 }
 
 .devhub-wrap .wp-parser-class .return .return-type,
@@ -1484,7 +1485,7 @@ input {
 .devhub-wrap .wp-parser-hook .parameters .type,
 .devhub-wrap .wp-parser-method .return-type,
 .devhub-wrap .wp-parser-method .parameters .type {
-  color: #dc3232;
+  color: #d63638;
 }
 
 .devhub-wrap .wp-parser-class .return-type a,
@@ -1497,6 +1498,7 @@ input {
 .devhub-wrap .wp-parser-method .parameters .type a {
   color: inherit;
   text-decoration: none;
+  border-bottom: 1px dotted #3c434a;
 }
 
 .devhub-wrap .wp-parser-class .return-type a:hover,
@@ -1507,7 +1509,7 @@ input {
 .devhub-wrap .wp-parser-hook .parameters .type a:hover,
 .devhub-wrap .wp-parser-method .return-type a:hover,
 .devhub-wrap .wp-parser-method .parameters .type a:hover {
-  border-bottom: 1px dotted #21759b;
+  border-bottom-style: solid;
 }
 
 .devhub-wrap .wp-parser-class .parameters p,
@@ -1515,6 +1517,14 @@ input {
 .devhub-wrap .wp-parser-hook .parameters p,
 .devhub-wrap .wp-parser-method .parameters p {
   margin-bottom: 0;
+}
+
+.devhub-wrap .wp-parser-class .parameters dt code,
+.devhub-wrap .wp-parser-function .parameters dt code,
+.devhub-wrap .wp-parser-hook .parameters dt code,
+.devhub-wrap .wp-parser-method .parameters dt code {
+  color: #135e96;
+  font-weight: 400;
 }
 
 .devhub-wrap .wp-parser-class .parameters dd,
@@ -1529,6 +1539,15 @@ input {
 .devhub-wrap .wp-parser-hook .parameters dd ul,
 .devhub-wrap .wp-parser-method .parameters dd ul {
   margin-left: 2.5rem;
+}
+
+.devhub-wrap .wp-parser-class .parameters dd code,
+.devhub-wrap .wp-parser-function .parameters dd code,
+.devhub-wrap .wp-parser-hook .parameters dd code,
+.devhub-wrap .wp-parser-method .parameters dd code {
+  background: #efefef;
+  border-radius: 4px;
+  padding: 2px 6px;
 }
 
 .devhub-wrap .wp-parser-class .parameters dd:last-child,
@@ -1559,6 +1578,15 @@ input {
 .devhub-wrap .wp-parser-hook .parameters .param-hash > li,
 .devhub-wrap .wp-parser-method .parameters .param-hash > li {
   margin-top: 1.5em;
+}
+
+.devhub-wrap .wp-parser-class .parameters .param-hash > li > code,
+.devhub-wrap .wp-parser-function .parameters .param-hash > li > code,
+.devhub-wrap .wp-parser-hook .parameters .param-hash > li > code,
+.devhub-wrap .wp-parser-method .parameters .param-hash > li > code {
+  background: transparent;
+  padding: unset;
+  color: #135e96;
 }
 
 .devhub-wrap .wp-parser-class .parameters .param-hash li li,
@@ -1608,16 +1636,6 @@ input {
 .devhub-wrap .wp-parser-hook .parameters .required,
 .devhub-wrap .wp-parser-method .parameters .required {
   font-size: 12px;
-}
-
-.devhub-wrap .wp-parser-class .parameters code,
-.devhub-wrap .wp-parser-function .parameters code,
-.devhub-wrap .wp-parser-hook .parameters code,
-.devhub-wrap .wp-parser-method .parameters code {
-  background: #efefef;
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-weight: 400;
 }
 
 .devhub-wrap .wp-parser-class .learn-more,


### PR DESCRIPTION
Iterate a little on the reference page styles.

- Switch colors to the [core color](https://codepen.io/ryelle/full/WNGVEjw) counterparts over 50 to ensure contrast against the white background
- Parameters are not using the grey background `code` style, but are now using the blue from the call signature
- Links in the call signature should inherit the colors (see the hooks section before & after)
- Links in the parameter types have dotted underlines by default, and solid underline on hover (so it's clear this is still a link)
- Style nested return types using the same styles as parameters (see [comment here](https://github.com/WordPress/wporg-developer/pull/49#issuecomment-1144229284))

See #20.

**Screenshots**

| Before | After |
|--------|-------|
| ![before-header](https://user-images.githubusercontent.com/541093/171737973-38555154-c0ba-4ba7-a318-8fa6d0461892.png) | ![after-header](https://user-images.githubusercontent.com/541093/171737970-bdf1f926-023c-4637-94da-9ec891d88720.png) |
| ![before-complex-params](https://user-images.githubusercontent.com/541093/171738269-9061ff73-2a04-43a7-b484-6895fdd4bd92.png) | ![after-complex-params](https://user-images.githubusercontent.com/541093/171737969-b42d1628-3cda-4515-909d-65a0674bef12.png) |

Hooks section with linked call signature

| Before | After |
|--------|-------|
| ![before-hooks](https://user-images.githubusercontent.com/541093/171737975-edc377c2-59b7-4dc1-b946-6211628400ea.png) | ![after-hooks](https://user-images.githubusercontent.com/541093/171737971-d075d2cb-d795-442b-af38-ffe1a5d7e28f.png) |

Nested return types highlighted correctly

| Before | After |
|--------|-------|
| ![Screen Shot 2022-06-02 at 17 17 15](https://user-images.githubusercontent.com/541093/171739963-1de52738-a2d1-43e6-8b84-2947a43418c9.png) | ![Screen Shot 2022-06-02 at 17 15 56](https://user-images.githubusercontent.com/541093/171739957-d276b437-dd98-4a50-84ba-873294565e6c.png) |

Note: this builds on the linter fixes in #64, but if we decide we don't want all that code turnover I can remake this on `trunk`.