### PR TITLE
Update pagination styles.

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/loop-pagination.php
+++ b/source/wp-content/themes/wporg-developer/inc/loop-pagination.php
@@ -54,8 +54,8 @@ function loop_pagination( $args = array() ) {
 		'total'        => $max_num_pages,
 		'current'      => $current,
 		'prev_next'    => true,
-		'prev_text'  => __( 'Previous' ),
-		'next_text'  => __( 'Next' ),
+		'prev_text'    => __( 'Previous', 'wporg' ),
+		'next_text'    => __( 'Next', 'wporg' ),
 		'show_all'     => false,
 		'end_size'     => 2,
 		'mid_size'     => 1,
@@ -110,4 +110,4 @@ function loop_pagination( $args = array() ) {
 		return $page_links;
 }
 
-?>
+

--- a/source/wp-content/themes/wporg-developer/inc/loop-pagination.php
+++ b/source/wp-content/themes/wporg-developer/inc/loop-pagination.php
@@ -54,11 +54,11 @@ function loop_pagination( $args = array() ) {
 		'total'        => $max_num_pages,
 		'current'      => $current,
 		'prev_next'    => true,
-		//'prev_text'  => __( '&laquo; Previous' ), // This is the WordPress default.
-		//'next_text'  => __( 'Next &raquo;' ), // This is the WordPress default.
+		'prev_text'  => __( 'Previous' ),
+		'next_text'  => __( 'Next' ),
 		'show_all'     => false,
-		'end_size'     => 1,
-		'mid_size'     => 2,
+		'end_size'     => 2,
+		'mid_size'     => 1,
 		'add_fragment' => '',
 		'type'         => 'plain',
 

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1374,10 +1374,39 @@
 		}
 	}
 
+
 	.loop-pagination {
-		text-align: center;
-		font-size: 18px;
-		margin-bottom: 20px;
+		display: flex;
+		margin: 3rem 0;
+		list-style: none;
+		justify-content: center;
+		align-items: center;
+		gap: 0.75rem;
+
+		.page-numbers {
+			display: inline-block;
+			padding: 1rem 1.25rem;
+			background: $color-white;
+			border: 1px solid get-color(gray-5);
+			border-radius: 2px;
+			line-height: 1;
+			text-decoration: none;
+
+			&:hover,
+			&:active {
+				color: #d54e21;
+			}
+
+			&.current {
+				border: 1px solid get-color(gray-90);
+				background: get-color(gray-90);
+				color: $color-white;
+			}
+
+			&.dots {
+				border: none;
+			}
+		}
 	}
 
 	/* Comments */

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1394,7 +1394,7 @@
 
 			&:hover,
 			&:active {
-				color: #d54e21;
+				color: get-color(wp4-link-hover);
 			}
 
 			&.current {

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1394,7 +1394,7 @@
 
 			&:hover,
 			&:active {
-				color: get-color(wp4-link-hover);
+				color: $wp4--link-color--hover;
 			}
 
 			&.current {

--- a/source/wp-content/themes/wporg-developer/scss/settings/_colors.scss
+++ b/source/wp-content/themes/wporg-developer/scss/settings/_colors.scss
@@ -8,6 +8,7 @@ $color-black: #000;
 $colors: (
 	white: #fff,
 	black: #000,
+	wp4-link-hover: #d54e21,
 	gray-0: #f6f7f7,
 	gray-2: #f0f0f1,
 	gray-5: #dcdcde,

--- a/source/wp-content/themes/wporg-developer/scss/settings/_colors.scss
+++ b/source/wp-content/themes/wporg-developer/scss/settings/_colors.scss
@@ -3,12 +3,13 @@
 $color-white: #fff;
 $color-black: #000;
 
-// Color map of all of the hex values.
-// Please keep this map in sync with the HTML
+// wp4.css Colors.
+$wp4--link-color: #21759b;
+$wp4--link-color--hover: #d54e21;
+
+// Color map of the WordPress core palette hex values.
+// Please keep this map in sync with the reference: https://codepen.io/ryelle/full/WNGVEjw.
 $colors: (
-	white: #fff,
-	black: #000,
-	wp4-link-hover: #d54e21,
 	gray-0: #f6f7f7,
 	gray-2: #f0f0f1,
 	gray-5: #dcdcde,

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1914,9 +1914,36 @@ input {
 }
 
 .devhub-wrap .loop-pagination {
-  text-align: center;
-  font-size: 18px;
-  margin-bottom: 20px;
+  display: flex;
+  margin: 3rem 0;
+  list-style: none;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.devhub-wrap .loop-pagination .page-numbers {
+  display: inline-block;
+  padding: 1rem 1.25rem;
+  background: #fff;
+  border: 1px solid #dcdcde;
+  border-radius: 2px;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.devhub-wrap .loop-pagination .page-numbers:hover, .devhub-wrap .loop-pagination .page-numbers:active {
+  color: #d54e21;
+}
+
+.devhub-wrap .loop-pagination .page-numbers.current {
+  border: 1px solid #1d2327;
+  background: #1d2327;
+  color: #fff;
+}
+
+.devhub-wrap .loop-pagination .page-numbers.dots {
+  border: none;
 }
 
 .devhub-wrap .comment-content a {


### PR DESCRIPTION
Closes: #63 

Take some of the applicable styles from the pattern directory pagination controls and move them to `main.scss`. This also adds the `wp4.css` link color to `_colors.scss` to keep it consistent. 

This theme overrides that color for links on hover but it's probably better to keep it around until we make the decision to remove it from everywhere.


### Changes
| Before | After |
| --- | --- |
| ![](https://d.pr/i/jsaVt7.png)  | ![](https://d.pr/i/ldjcyM.png) |


