### PR TITLE
Use code block for `get_signature`.

### DIFF
--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -6,7 +6,13 @@
 
 	<?php echo get_private_access_message(); ?>
 
-	<h1><?php echo get_signature(); ?></h1>
+	<h1><?php echo do_blocks(
+			sprintf(
+				'<!-- wp:code {"lineNumbers":false} --><div class="wp-block-code"><code lang="php" class="language-php">%s</code></div><!-- /wp:code -->',
+				get_signature()
+			)
+		);
+	?></h1>
 
 	<section class="summary">
 		<?php echo get_summary(); ?>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1028,8 +1028,6 @@
 
 		h1 {
 			margin: 24px 0;
-			padding-left: 100px;
-			text-indent: -100px;
 			font-size: 20px;
 		}
 

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -2522,13 +2522,6 @@ body.responsive-show {
 			clear: both;
 		}
 
-		.wp-parser-class, .wp-parser-function, .wp-parser-hook, .wp-parser-method {
-			h1 {
-				padding-left: 45px;
-				text-indent: -45px;
-			}
-		}
-
 		.two-columns .box {
 			width: 99%;
 		}

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -9,7 +9,8 @@
 @import "colors";
 
 code[class*="language-"],
-pre[class*="language-"] {
+pre[class*="language-"],
+.wp-block-code {
 	color: get-color(gray-100);
 	background: none;
 	font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
@@ -31,7 +32,8 @@ pre[class*="language-"] {
 }
 
 /* Code blocks */
-pre[class*="language-"] {
+pre[class*="language-"],
+.wp-block-code {
 	padding: 1em;
 	margin: 0.5em 0;
 	overflow: auto;
@@ -39,7 +41,8 @@ pre[class*="language-"] {
 }
 
 :not(pre) > code[class*="language-"],
-pre[class*="language-"] {
+pre[class*="language-"],
+.wp-block-code {
 	background: get-color(gray-0);
 }
 
@@ -122,13 +125,15 @@ pre[class*="language-"] {
 
 @media screen and (-ms-high-contrast: active) {
 	code[class*="language-"],
-	pre[class*="language-"] {
+	pre[class*="language-"],
+	.wp-block-code {
 		color: windowText;
 		background: window;
 	}
 
 	:not(pre) > code[class*="language-"],
-	pre[class*="language-"] {
+	pre[class*="language-"],
+	.wp-block-code {
 		background: window;
 	}
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2918,10 +2918,6 @@ body.responsive-show #o2-expand-editor {
     float: none;
     clear: both;
   }
-  .devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
-    padding-left: 45px;
-    text-indent: -45px;
-  }
   .devhub-wrap .two-columns .box {
     width: 99%;
   }

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1414,8 +1414,6 @@ input {
 
 .devhub-wrap .wp-parser-class h1, .devhub-wrap .wp-parser-function h1, .devhub-wrap .wp-parser-hook h1, .devhub-wrap .wp-parser-method h1 {
   margin: 24px 0;
-  padding-left: 100px;
-  text-indent: -100px;
   font-size: 20px;
 }
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -6,7 +6,8 @@
  * https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css
  */
 code[class*="language-"],
-pre[class*="language-"] {
+pre[class*="language-"],
+.wp-block-code {
   color: #101517;
   background: none;
   font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
@@ -26,7 +27,8 @@ pre[class*="language-"] {
 }
 
 /* Code blocks */
-pre[class*="language-"] {
+pre[class*="language-"],
+.wp-block-code {
   padding: 1em;
   margin: 0.5em 0;
   overflow: auto;
@@ -34,7 +36,8 @@ pre[class*="language-"] {
 }
 
 :not(pre) > code[class*="language-"],
-pre[class*="language-"] {
+pre[class*="language-"],
+.wp-block-code {
   background: #f6f7f7;
 }
 
@@ -117,12 +120,14 @@ pre[class*="language-"] {
 
 @media screen and (-ms-high-contrast: active) {
   code[class*="language-"],
-  pre[class*="language-"] {
+  pre[class*="language-"],
+  .wp-block-code {
     color: windowText;
     background: window;
   }
   :not(pre) > code[class*="language-"],
-  pre[class*="language-"] {
+  pre[class*="language-"],
+  .wp-block-code {
     background: window;
   }
   .token.important {


### PR DESCRIPTION
Closes: #23.
Related to: #65.

This PR uses `do_blocks` and `get_signature` to display the first code block on the page. We didn't agree on this approach, so we can have a discussion as to whether this approach makes sense.

**Changes**
- `do_blocks`
- Adds CSS to `prism.scss` for consistency since `<pre>` is not a valid child of `<h1>` and there doesn't appear to be a worthy `<h1>` other than the signature.

**Notes**
- If we were to go with this approach, we would probably want to change the data type colors in the parameters sections to match the code block.
- Also, if we wanted to go this route, we should probably update all the uses of `get_signature` (hook section..)
- The `wp` class below looks pretty sad, but it already does. I think maybe we should add `class` to it. I'll open another ticket.

## Screenshots
| Before | After |
| --- | --- |
| ![](https://d.pr/i/l0tSH6.png) | ![](https://d.pr/i/jwkegs.png) |
| ![](https://d.pr/i/M8P0QY.png) | ![](https://d.pr/i/YtRqRq.png) |
|  ![](https://d.pr/i/D8FFvA.png)| ![](https://d.pr/i/f464Yo.png)   |