### PR TITLE
Try adding `class %s {}` string to classes

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -707,8 +707,7 @@ namespace DevHub {
 		$types        = array();
 
 		if ( 'wp-parser-class' === get_post_type( $post_id ) ) {
-			/* translators: %s: The name of the class. */
-			return sprintf( __( 'class %s {}', 'wporg'), $signature );
+			return '<span class="keyword">class</span> ' . $signature . ' {}';
 		}
 
 		if ( $tags ) {

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -708,7 +708,7 @@ namespace DevHub {
 
 		if ( 'wp-parser-class' === get_post_type( $post_id ) ) {
 			/* translators: %s: The name of the class. */
-			return sprintf( __( 'Class %s {}', 'wporg'), $signature );
+			return sprintf( __( 'class %s {}', 'wporg'), $signature );
 		}
 
 		if ( $tags ) {

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -706,7 +706,6 @@ namespace DevHub {
 		$args_strings = array();
 		$types        = array();
 
-
 		if ( 'wp-parser-class' === get_post_type( $post_id ) ) {
 			/* translators: %s: The name of the class. */
 			return sprintf( __( 'Class %s {}', 'wporg'), $signature );

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -706,8 +706,10 @@ namespace DevHub {
 		$args_strings = array();
 		$types        = array();
 
+
 		if ( 'wp-parser-class' === get_post_type( $post_id ) ) {
-			return $signature;
+			/* translators: %s: The name of the class. */
+			return sprintf( __( 'Class %s {}', 'wporg'), $signature );
 		}
 
 		if ( $tags ) {

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1074,7 +1074,8 @@
 			font-family: $code-font;
 			font-weight: 400;
 
-			.hook-func {
+			.hook-func,
+			.keyword {
 				color: get-color(gray-50);
 			}
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1401,13 +1401,21 @@ input {
 }
 
 .devhub-wrap .wp-parser-class h1 .hook-func,
+.devhub-wrap .wp-parser-class h1 .keyword,
 .devhub-wrap .wp-parser-class .signature-highlight .hook-func,
+.devhub-wrap .wp-parser-class .signature-highlight .keyword,
 .devhub-wrap .wp-parser-function h1 .hook-func,
+.devhub-wrap .wp-parser-function h1 .keyword,
 .devhub-wrap .wp-parser-function .signature-highlight .hook-func,
+.devhub-wrap .wp-parser-function .signature-highlight .keyword,
 .devhub-wrap .wp-parser-hook h1 .hook-func,
+.devhub-wrap .wp-parser-hook h1 .keyword,
 .devhub-wrap .wp-parser-hook .signature-highlight .hook-func,
+.devhub-wrap .wp-parser-hook .signature-highlight .keyword,
 .devhub-wrap .wp-parser-method h1 .hook-func,
-.devhub-wrap .wp-parser-method .signature-highlight .hook-func {
+.devhub-wrap .wp-parser-method h1 .keyword,
+.devhub-wrap .wp-parser-method .signature-highlight .hook-func,
+.devhub-wrap .wp-parser-method .signature-highlight .keyword {
   color: #646970;
 }
 


### PR DESCRIPTION
When viewing a class, we only use the title in the `get_signature` which seems pretty lame.

**Update: I realized that C in class should be lower cased. I don't however want to redo the screenshots :)**

Related to: #72

| Before | After |
| --- | --- |
| ![](https://d.pr/i/sk6fe0.png)  | ![](https://d.pr/i/iIWEh1.png)  |
 | ![](https://d.pr/i/HktQkh.png)  | ![](https://d.pr/i/SpI3lt.png)

