### PR TITLE
Tools: Ignore changes to built files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Hide changes in diffs for all minimized JS and lock files by default.
+# See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+*.min.js  linguist-generated
+*.lock    linguist-generated
+
+# Hide changes to built stylesheets
+source/wp-content/themes/wporg-developer/stylesheets/admin.css           linguist-generated
+source/wp-content/themes/wporg-developer/stylesheets/main.css            linguist-generated
+source/wp-content/themes/wporg-developer/stylesheets/page-dashicons.css  linguist-generated
+source/wp-content/themes/wporg-developer/stylesheets/prism.css           linguist-generated


### PR DESCRIPTION
[Github has a property, `linguist-generated`](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github), which hides changes to given files in diffs. It's useful when there are both source & built files in a repo, like we have with our Sass & CSS files, so the CSS changes can be hidden by default. 

I think it makes scanning a PR easier. Here's [an example from Twenty Twenty-One](https://github.com/WordPress/twentytwentyone/pull/909/files), the CSS changes are hidden, but can be expanded if you want to check for anything unexpected.

I've added the property to all `.lock` and `.min.js` files, and the 4 built CSS files.