### PR TITLE
Code blocks: Add "Copy" button to copy code snippets

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/user-content.php
+++ b/source/wp-content/themes/wporg-developer/inc/user-content.php
@@ -163,14 +163,45 @@ class DevHub_User_Submitted_Content {
 	 */
 	public static function scripts_and_styles() {
 		if ( is_singular() ) {
-			wp_enqueue_script( 'wporg-developer-function-reference', get_template_directory_uri() . '/js/function-reference.js', array( 'jquery' ), '20180724', true );
+			wp_enqueue_script(
+				'wporg-developer-function-reference',
+				get_template_directory_uri() . '/js/function-reference.js',
+				array( 'jquery', 'wp-a11y' ),
+				filemtime( dirname( __DIR__ ) . '/js/function-reference.js' ),
+				true
+			);
+			wp_localize_script(
+				'wporg-developer-function-reference',
+				'wporgFunctionReferenceI18n',
+				array(
+					'copy'   => __( 'Copy', 'wporg' ),
+					'copied' => __( 'Code copied', 'wporg' ),
+				)
+			);
 
-			wp_enqueue_script( 'wporg-developer-user-notes', get_template_directory_uri() . '/js/user-notes.js', array( 'jquery', 'quicktags' ), '20200110', true );
-			wp_enqueue_script( 'wporg-developer-user-notes-feedback', get_template_directory_uri() . '/js/user-notes-feedback.js', array( 'jquery', 'quicktags' ), '20181023', true );
-			wp_localize_script( 'wporg-developer-user-notes-feedback', 'wporg_note_feedback', array(
-				'show'             => __( 'Show Feedback', 'wporg' ),
-				'hide'             => __( 'Hide Feedback', 'wporg' ),
-			) );
+			wp_enqueue_script(
+				'wporg-developer-user-notes',
+				get_template_directory_uri() . '/js/user-notes.js',
+				array( 'jquery', 'quicktags' ),
+				filemtime( dirname( __DIR__ ) . '/js/user-notes.js' ),
+				true
+			);
+
+			wp_enqueue_script(
+				'wporg-developer-user-notes-feedback',
+				get_template_directory_uri() . '/js/user-notes-feedback.js',
+				array( 'jquery', 'quicktags' ),
+				filemtime( dirname( __DIR__ ) . '/js/user-notes-feedback.js' ),
+				true
+			);
+			wp_localize_script(
+				'wporg-developer-user-notes-feedback',
+				'wporg_note_feedback',
+				array(
+					'show' => __( 'Show Feedback', 'wporg' ),
+					'hide' => __( 'Hide Feedback', 'wporg' ),
+				)
+			);
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -1,11 +1,11 @@
-/* @global jQuery */
+/* global jQuery, wporgFunctionReferenceI18n */
 /**
  * function-reference.js
  *
  * Handles all interactivity on the single function page
  */
 
-jQuery( function( $ ) {
+jQuery( function ( $ ) {
 	let $usesList, $usedByList, $showMoreUses, $hideMoreUses, $showMoreUsedBy, $hideMoreUsedBy;
 
 	function toggleUsageListInit() {
@@ -47,4 +47,35 @@ jQuery( function( $ ) {
 	}
 
 	toggleUsageListInit();
+
+	// Inject the "copy" button into every code block.
+	$( '.wp-block-code' ).each( function ( i, element ) {
+		const $element = $( element );
+		let timeoutId;
+
+		const $button = $( document.createElement( 'button' ) );
+		$button.text( wporgFunctionReferenceI18n.copy );
+		$button.on( 'click', function () {
+			clearTimeout( timeoutId );
+			const code = $element.find( 'code' ).text();
+			if ( ! code ) {
+				return;
+			}
+
+			// This returns a promise which will resolve if the copy suceeded,
+			// and we can set the button text to tell the user it worked.
+			// We don't do anything if it fails.
+			window.navigator.clipboard.writeText( code ).then( function () {
+				$button.text( wporgFunctionReferenceI18n.copied );
+				wp.a11y.speak( wporgFunctionReferenceI18n.copied );
+
+				// After 5 seconds, reset the button text.
+				timeoutId = setTimeout( function () {
+					$button.text( wporgFunctionReferenceI18n.copy );
+				}, 5000 );
+			} );
+		} );
+
+		$element.prepend( $button );
+	} );
 } );

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -35,8 +35,9 @@ if ( ! empty( $source_file ) ) :
 			<?php
 				echo do_blocks(
 					sprintf(
-						'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code" data-start="%s"><code lang="php" class="language-php line-numbers">%s</code></pre><!-- /wp:code -->',
+						'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code" data-start="%1$s" aria-label="%2$s"><code lang="php" class="language-php line-numbers">%3$s</code></pre><!-- /wp:code -->',
 						esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ),
+						__( 'Function source code', 'wporg' ),
 						htmlentities( get_source_code() )
 					)
 				);

--- a/source/wp-content/themes/wporg-developer/scss/_global.scss
+++ b/source/wp-content/themes/wporg-developer/scss/_global.scss
@@ -159,23 +159,6 @@ img {
 	max-width: 100%; /* Adhere to container width. */
 }
 
-/* Form Elements */
-button,
-input,
-select,
-textarea {
-	font-size: 100%; /* Corrects font size not being inherited in all browsers */
-	margin: 0; /* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
-	vertical-align: baseline; /* Improves appearance and consistency in all browsers */
-	*vertical-align: middle; /* Improves appearance and consistency in all browsers */
-	font-weight: 300;
-}
-
-button,
-input {
-	line-height: normal; /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
-}
-
 /* Alignment */
 .alignleft {
 	display: inline;

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -173,8 +173,7 @@
 		&:active {
 			border-color: #aaa #bbb #bbb #bbb;
 			background: #f0f0f0;
-			-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
-			box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
+			box-shadow: 0 0 3px get-color(blue-40);
 		}
 
 		&.shiny-blue {

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -205,3 +205,22 @@ pre.line-numbers > code {
 	padding-right: 0.8em;
 	text-align: right;
 }
+
+/* Copy button */
+pre.wp-block-code {
+	position: relative;
+
+	> button {
+		display: none;
+		position: absolute;
+		top: 1rem;
+		right: 1rem;
+		font-size: 1.4rem;
+		z-index: 2;
+	}
+
+	&:hover > button,
+	&:focus-within > button {
+		display: revert;
+	}
+}

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -243,28 +243,6 @@ img {
   /* Adhere to container width. */
 }
 
-/* Form Elements */
-button,
-input,
-select,
-textarea {
-  font-size: 100%;
-  /* Corrects font size not being inherited in all browsers */
-  margin: 0;
-  /* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
-  vertical-align: baseline;
-  /* Improves appearance and consistency in all browsers */
-  *vertical-align: middle;
-  /* Improves appearance and consistency in all browsers */
-  font-weight: 300;
-}
-
-button,
-input {
-  line-height: normal;
-  /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
-}
-
 /* Alignment */
 .alignleft {
   display: inline;
@@ -502,8 +480,7 @@ input {
 .devhub-wrap input[type="submit"]:active {
   border-color: #aaa #bbb #bbb #bbb;
   background: #f0f0f0;
-  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
-  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6), 1px 1px 2px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 3px #3582c4;
 }
 
 .devhub-wrap a.button.shiny-blue,

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -194,3 +194,22 @@ pre.line-numbers > code {
   padding-right: 0.8em;
   text-align: right;
 }
+
+/* Copy button */
+pre.wp-block-code {
+  position: relative;
+}
+
+pre.wp-block-code > button {
+  display: none;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 1.4rem;
+  z-index: 2;
+}
+
+pre.wp-block-code:hover > button,
+pre.wp-block-code:focus-within > button {
+  display: revert;
+}


### PR DESCRIPTION
This adds a "Copy" button to each code block on a page, which will copy the code in the block to the user's clipboard. The button is hidden until you hover over or tab to the code block, so that it doesn't overlap any code.

Fixes #24 

## Screenshots

I didn't take any "before" shots because they'd all be the same as this first one.

By default, no button:

![after-source](https://user-images.githubusercontent.com/541093/171937522-0cbf198f-5c92-4650-8f6f-350fdfb0e345.png)

When you hover over, it appears.

![after-source-hover](https://user-images.githubusercontent.com/541093/171937521-a22f2b46-99b2-46f4-8a9b-c52328a41ca4.png)

If you click copy, the button transforms to say "code copied", and if you're using a screen reader that's also announced.

![after-source-copied](https://user-images.githubusercontent.com/541093/171937519-48e70133-dadd-4e85-8a69-c08fc539ca79.png)

This also works when there are multiple code blocks on the page, each gets a copy button and they each copy only that block.

![after-user-content-hover](https://user-images.githubusercontent.com/541093/171937524-3a6d38fb-7533-4a83-aba3-04697f4675c5.png)
