### PR TITLE
Fix alignment of filter buttons

### DIFF
--- a/source/wp-content/themes/wporg-developer/scss/_global.scss
+++ b/source/wp-content/themes/wporg-developer/scss/_global.scss
@@ -159,23 +159,6 @@ img {
 	max-width: 100%; /* Adhere to container width. */
 }
 
-/* Form Elements */
-button,
-input,
-select,
-textarea {
-	font-size: 100%; /* Corrects font size not being inherited in all browsers */
-	margin: 0; /* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
-	vertical-align: baseline; /* Improves appearance and consistency in all browsers */
-	*vertical-align: middle; /* Improves appearance and consistency in all browsers */
-	font-weight: 300;
-}
-
-button,
-input {
-	line-height: normal; /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
-}
-
 /* Alignment */
 .alignleft {
 	display: inline;

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -178,25 +178,23 @@
 		}
 
 		&.shiny-blue {
-			background-color: #21759b;
-			background-image: linear-gradient(to bottom, #2a95c5, #21759b);
-			border-color: #21759b;
-			border-bottom-color: #1e6a8d;
-			-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
-			box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
+			background-color: get-color(blue-50);
+			border-color: get-color(blue-50);
+			border-bottom-color: get-color(blue-70);
 			color: #fff;
 			text-decoration: none;
-			text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
-			padding: 3px 8px;
 
-			&:hover {
-				background-color: #278ab7;
-				background-image: linear-gradient(to bottom, #2e9fd2, #21759b);
-				border-color: #1b607f;
-				-webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
-				box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
+			&:hover,
+			&:focus,
+			&:active {
+				background-color: get-color(blue-60);
+				border-color: get-color(blue-80);
 				color: #fff;
-				text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
+			}
+
+			&:focus,
+			&:active {
+				box-shadow: 0 0 3px 1px get-color(yellow-30);
 			}
 		}
 
@@ -777,12 +775,14 @@
 	.archive-filter-form {
 		margin: 5rem 0;
 		font-size: 1.5rem;
+		line-height: 1.5;
 
+		select,
 		input[type="submit"] {
 			margin-left: 0.5em;
-			padding: 0.2em 0.5em;
-			line-height: 1;
-			font-size: 1.5rem;
+			padding: 0.333em 1em;
+			font-size: inherit;
+			line-height: inherit;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -243,28 +243,6 @@ img {
   /* Adhere to container width. */
 }
 
-/* Form Elements */
-button,
-input,
-select,
-textarea {
-  font-size: 100%;
-  /* Corrects font size not being inherited in all browsers */
-  margin: 0;
-  /* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
-  vertical-align: baseline;
-  /* Improves appearance and consistency in all browsers */
-  *vertical-align: middle;
-  /* Improves appearance and consistency in all browsers */
-  font-weight: 300;
-}
-
-button,
-input {
-  line-height: normal;
-  /* Addresses FF3/4 setting line-height using !important in the UA stylesheet */
-}
-
 /* Alignment */
 .alignleft {
   display: inline;
@@ -511,30 +489,41 @@ input {
 .devhub-wrap input[type="button"].shiny-blue,
 .devhub-wrap input[type="reset"].shiny-blue,
 .devhub-wrap input[type="submit"].shiny-blue {
-  background-color: #21759b;
-  background-image: linear-gradient(to bottom, #2a95c5, #21759b);
-  border-color: #21759b;
-  border-bottom-color: #1e6a8d;
-  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
-  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.5);
+  background-color: #2271b1;
+  border-color: #2271b1;
+  border-bottom-color: #0a4b78;
   color: #fff;
   text-decoration: none;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
-  padding: 3px 8px;
 }
 
-.devhub-wrap a.button.shiny-blue:hover,
+.devhub-wrap a.button.shiny-blue:hover, .devhub-wrap a.button.shiny-blue:focus, .devhub-wrap a.button.shiny-blue:active,
 .devhub-wrap button.shiny-blue:hover,
+.devhub-wrap button.shiny-blue:focus,
+.devhub-wrap button.shiny-blue:active,
 .devhub-wrap input[type="button"].shiny-blue:hover,
+.devhub-wrap input[type="button"].shiny-blue:focus,
+.devhub-wrap input[type="button"].shiny-blue:active,
 .devhub-wrap input[type="reset"].shiny-blue:hover,
-.devhub-wrap input[type="submit"].shiny-blue:hover {
-  background-color: #278ab7;
-  background-image: linear-gradient(to bottom, #2e9fd2, #21759b);
-  border-color: #1b607f;
-  -webkit-box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
-  box-shadow: inset 0 1px 0 rgba(120, 200, 230, 0.6);
+.devhub-wrap input[type="reset"].shiny-blue:focus,
+.devhub-wrap input[type="reset"].shiny-blue:active,
+.devhub-wrap input[type="submit"].shiny-blue:hover,
+.devhub-wrap input[type="submit"].shiny-blue:focus,
+.devhub-wrap input[type="submit"].shiny-blue:active {
+  background-color: #135e96;
+  border-color: #043959;
   color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
+}
+
+.devhub-wrap a.button.shiny-blue:focus, .devhub-wrap a.button.shiny-blue:active,
+.devhub-wrap button.shiny-blue:focus,
+.devhub-wrap button.shiny-blue:active,
+.devhub-wrap input[type="button"].shiny-blue:focus,
+.devhub-wrap input[type="button"].shiny-blue:active,
+.devhub-wrap input[type="reset"].shiny-blue:focus,
+.devhub-wrap input[type="reset"].shiny-blue:active,
+.devhub-wrap input[type="submit"].shiny-blue:focus,
+.devhub-wrap input[type="submit"].shiny-blue:active {
+  box-shadow: 0 0 3px 1px #dba617;
 }
 
 .devhub-wrap a.button .dashicons,
@@ -1092,13 +1081,15 @@ input {
 .devhub-wrap .archive-filter-form {
   margin: 5rem 0;
   font-size: 1.5rem;
+  line-height: 1.5;
 }
 
+.devhub-wrap .archive-filter-form select,
 .devhub-wrap .archive-filter-form input[type="submit"] {
   margin-left: 0.5em;
-  padding: 0.2em 0.5em;
-  line-height: 1;
-  font-size: 1.5rem;
+  padding: 0.333em 1em;
+  font-size: inherit;
+  line-height: inherit;
 }
 
 .devhub-wrap .searchform {


### PR DESCRIPTION
This fixes the alignment and padding around the filter select & button on the by-file archive page.

| Before (production) | After |
|-------|-------|
| ![Screen Shot 2022-06-03 at 15 47 51](https://user-images.githubusercontent.com/541093/171939564-37f330d9-fa64-49a6-9dc0-8a1a6d56f419.png) | ![Screen Shot 2022-06-03 at 15 47 47](https://user-images.githubusercontent.com/541093/171939563-bd28f314-3d05-41d0-a92b-ea4630de3da9.png) |

**To test**

1. View any file archive page, ex: http://localhost:8888/reference/files/wp-includes/post-template.php/
2. The select & button should be lined up

Note: This is different on Safari, but I don't want to rewrite the whole select box styles, so I think this is fine.

<img width="331" alt="Screen Shot 2022-06-03 at 3 54 13 PM" src="https://user-images.githubusercontent.com/541093/171940917-3741d965-c172-414a-b3f9-8b12142ccd77.png">
 