### PR TITLE
Display Class methods earlier in the page, between the Explanation and Source

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1921,10 +1921,10 @@ namespace DevHub {
 			'params',
 			'return',
 			'explanation',
+			'methods',
 			'source',
 			'hooks',
 			'related',
-			'methods',
 			'changelog',
 			'notes'
 		);


### PR DESCRIPTION
See #76

It seems to me that it's more likely a browser will want to look through the methods a class offers, rather than it's source code.

| Before | After |
| --- | --- |
| <img width="709" alt="Screen Shot 2022-06-06 at 3 01 48 pm" src="https://user-images.githubusercontent.com/767313/172097959-edb18811-2b3b-4b7f-81a2-c67d1d252c76.png"> | <img width="707" alt="Screen Shot 2022-06-06 at 3 01 29 pm" src="https://user-images.githubusercontent.com/767313/172097968-fb5dc754-c423-4787-8125-640ec3682b64.png"> |


