### PR TITLE
Enhance search bar UX

### DIFF
--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -798,6 +798,10 @@
 		height: auto;
 		position: relative;
 
+		.search-bar {
+			display: flex;
+		}
+
 		input[type="text"] {
 			border-radius: 0;
 			margin: 0 auto;
@@ -806,18 +810,27 @@
 		}
 
 		.button-search {
-			background: transparent;
-			border: none;
+			background: #fff;
 			border-radius: 0;
 			box-shadow: none;
 			color: #32373c;
 			display: block;
-			height: 40px;
 			padding: 0.5rem 1rem;
-			position: absolute;
-			right: 0;
-			top: 0;
 			text-shadow: none;
+			border: 1px solid #ccc;
+			border-left: unset;
+			margin: 0;
+
+			&:focus {
+				outline-style: auto;
+				outline-color: get-color(blue-50);
+				z-index: 1;
+			}
+
+			&:active {
+				background: get-color(gray-5);
+				transform: translateY(0);
+			}
 		}
 
 		label {

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -198,6 +198,7 @@
 		}
 
 		.dashicons {
+			transform: scale(-1, 1);
 			vertical-align: text-bottom;
 		}
 	}
@@ -767,6 +768,7 @@
 				.dashicons-search {
 					height: auto;
 					width: auto;
+					transform: scale(-1, 1);
 
 					&::before {
 						font-size: 36px;

--- a/source/wp-content/themes/wporg-developer/searchform.php
+++ b/source/wp-content/themes/wporg-developer/searchform.php
@@ -19,9 +19,11 @@
 	?>
 
 	<form role="search" method="get" class="searchform<?php echo esc_attr( $form_class ); ?>" action="<?php echo esc_url( $search_url ); ?>">
-		<label for="search-field" class="screen-reader-text"><?php _ex( 'Search for:', 'label', 'wporg' ); ?></label>
-		<input type="text" id="search-field" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'wporg' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" name="s">
-		<button class="button button-primary button-search"><i class="dashicons dashicons-search"></i><span class="screen-reader-text"><?php _e( 'Search plugins', 'wporg' ); ?></span></button>
+		<div class="search-bar">
+			<label for="search-field" class="screen-reader-text"><?php _ex( 'Search for:', 'label', 'wporg' ); ?></label>
+			<input type="text" id="search-field" class="search-field" placeholder="<?php echo esc_attr_x( 'Search in Code Reference &hellip;', 'placeholder', 'wporg' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" name="s">
+			<button class="button button-primary button-search"><i class="dashicons dashicons-search"></i><span class="screen-reader-text"><?php _e( 'Search plugins', 'wporg' ); ?></span></button>
+		</div>
 	<?php if ( $filters ) : ?>
 
 		<div class="search-post-type">

--- a/source/wp-content/themes/wporg-developer/stylesheets/autocomplete.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/autocomplete.css
@@ -32,6 +32,10 @@ div.awesomplete li:hover mark, div.awesomplete li[aria-selected="true"] mark {
 	width: 100%;
 }
 
+.devhub-wrap div.awesomplete > input {
+	border-right: unset;
+}
+
 .devhub-wrap .searchform div.search-post-type {
 	clear: both;
 }

--- a/source/wp-content/themes/wporg-developer/stylesheets/autocomplete.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/autocomplete.css
@@ -3,8 +3,10 @@
  *
  * Mainly overrides for awesomplete.css
  */
+
 div.awesomplete > ul > li:hover {
 	background: hsl(200, 40%, 90%);
+	color: #000;
 }
 
 div.awesomplete > ul > li[aria-selected="true"] {
@@ -16,7 +18,8 @@ div.awesomplete mark {
 	color: #404040;
 }
 
-div.awesomplete li:hover mark, div.awesomplete li[aria-selected="true"] mark {
+div.awesomplete li:hover mark,
+div.awesomplete li[aria-selected="true"] mark {
 	background: hsl(65, 100%, 49%);
 }
 
@@ -24,11 +27,11 @@ div.awesomplete li:hover mark, div.awesomplete li[aria-selected="true"] mark {
 	max-height: 13.5em;
 	color: #404040;
 	overflow: auto;
-	background: linear-gradient(to bottom right, white, hsla(0,0%,100%,.9));
+	background: linear-gradient(to bottom right, #fff, hsla(0, 0%, 100%, 0.9));
 }
 
 .devhub-wrap .searchform label div.awesomplete > input,
-.devhub-wrap div.awesomplete {	
+.devhub-wrap div.awesomplete {
 	width: 100%;
 }
 
@@ -43,14 +46,11 @@ div.awesomplete li:hover mark, div.awesomplete li[aria-selected="true"] mark {
 .devhub-wrap .searchform,
 .devhub-wrap .searchform div:first-child,
 .devhub-wrap div.awesomplete {
+
 	/* Needs to be visible for the awesomplete popup */
 	overflow: visible;
 }
 
-div.awesomplete > ul > li:hover {
-	color: black;
-}
-
-div.awesomplete > ul:before {
+div.awesomplete > ul::before {
 	content: none;
 }

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1105,6 +1105,10 @@ img {
   position: relative;
 }
 
+.devhub-wrap .searchform .search-bar {
+  display: flex;
+}
+
 .devhub-wrap .searchform input[type="text"] {
   border-radius: 0;
   margin: 0 auto;
@@ -1113,18 +1117,27 @@ img {
 }
 
 .devhub-wrap .searchform .button-search {
-  background: transparent;
-  border: none;
+  background: #fff;
   border-radius: 0;
   box-shadow: none;
   color: #32373c;
   display: block;
-  height: 40px;
   padding: 0.5rem 1rem;
-  position: absolute;
-  right: 0;
-  top: 0;
   text-shadow: none;
+  border: 1px solid #ccc;
+  border-left: unset;
+  margin: 0;
+}
+
+.devhub-wrap .searchform .button-search:focus {
+  outline-style: auto;
+  outline-color: #2271b1;
+  z-index: 1;
+}
+
+.devhub-wrap .searchform .button-search:active {
+  background: #dcdcde;
+  transform: translateY(0);
 }
 
 .devhub-wrap .searchform label {

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -530,6 +530,7 @@ img {
 .devhub-wrap input[type="button"] .dashicons,
 .devhub-wrap input[type="reset"] .dashicons,
 .devhub-wrap input[type="submit"] .dashicons {
+  transform: scale(-1, 1);
   vertical-align: text-bottom;
 }
 
@@ -1076,6 +1077,7 @@ img {
 .devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon .dashicons-search {
   height: auto;
   width: auto;
+  transform: scale(-1, 1);
 }
 
 .devhub-wrap div#inner-search div#inner-search-icon-container div#inner-search-icon .dashicons-search::before {


### PR DESCRIPTION
This PR makes three simple changes to the search bar UX mentioned [here](https://github.com/WordPress/wporg-developer/issues/40#issuecomment-1144148805).
1. Make the Search Icon aligned with the global menu icon direction.
2. Make the focus state clear - the input ends before the icon.
3. Change the placeholder from `Search ...` to `Search in Code Reference ...`.

As to how to make the search button in the search bar more obvious, since we might be able to just use the search on top of the handbook sidebar ([comment](https://github.com/WordPress/wporg-developer/issues/40#issuecomment-1144451874)) or just move the search bar control into the site-title ([PR](https://github.com/WordPress/wporg-developer/pull/75)), I think it isn't worth spending time for the moment to figure out whether to implement any of the [proposals](https://github.com/WordPress/wporg-developer/issues/40#issuecomment-1144148805) or just remove the whole search bar.

## Screenshots
| Before | After |
| --- | --- |
| <img width="964" alt="image" src="https://user-images.githubusercontent.com/18050944/172102312-4698b08b-cadf-43ce-8f08-374a1d4093dd.png"> | <img width="983" alt="image" src="https://user-images.githubusercontent.com/18050944/172102454-075663d8-7603-4bd4-b7ad-b3cee0cd73a9.png"> |

## How to test
1. Go to any API detail page.
2. Click Search Icon
3. Check if the Search Icon Direction, Focus state, and Placeholder are correct.