### PR TITLE
Handbooks: Use code syntax block in handbook code examples

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -49,6 +49,7 @@ class DevHub_Formatting {
 		add_shortcode( 'php', array( __CLASS__, 'do_shortcode_php' ) );
 		add_shortcode( 'js', array( __CLASS__, 'do_shortcode_js' ) );
 		add_shortcode( 'css', array( __CLASS__, 'do_shortcode_css' ) );
+		add_shortcode( 'code', array( __CLASS__, 'do_shortcode_code' ) );
 
 		add_filter(
 			'no_texturize_shortcodes',
@@ -56,6 +57,7 @@ class DevHub_Formatting {
 				$shortcodes[] = 'php';
 				$shortcodes[] = 'js';
 				$shortcodes[] = 'css';
+				$shortcodes[] = 'code';
 				return $shortcodes;
 			}
 		);
@@ -685,7 +687,7 @@ class DevHub_Formatting {
 		return do_blocks(
 			sprintf(
 				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="php" class="language-php line-numbers">%s</code></pre><!-- /wp:code -->',
-				trim( $content )
+				self::_trim_code( $content )
 			)
 		);
 	}
@@ -704,7 +706,7 @@ class DevHub_Formatting {
 		return do_blocks(
 			sprintf(
 				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="javascript" class="language-javascript line-numbers">%s</code></pre><!-- /wp:code -->',
-				trim( $content )
+				self::_trim_code( $content )
 			)
 		);
 	}
@@ -723,11 +725,55 @@ class DevHub_Formatting {
 		return do_blocks(
 			sprintf(
 				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="css" class="language-css line-numbers">%s</code></pre><!-- /wp:code -->',
-				trim( $content )
+				self::_trim_code( $content )
 			)
 		);
 	}
 
+	/**
+	 * Render the code shortcode using the Code Syntax Block syntax.
+	 *
+	 * This is used in the handbooks content.
+	 *
+	 * @param array|string $attr    Shortcode attributes array or empty string.
+	 * @param string       $content Shortcode content.
+	 * @param string       $tag     Shortcode name.
+	 * @return string
+	 */
+	public static function do_shortcode_code( $attr, $content, $tag ) {
+		// Use an allowedlist of languages, falling back to PHP.
+		// This should account for all languages used in the handbooks.
+		$lang_list = [ 'js', 'json', 'sh', 'bash', 'html', 'css', 'scss', 'php', 'markdown', 'yaml' ];
+		$lang = in_array( $attr['lang'], $lang_list ) ? $attr['lang'] : 'php';
+
+		// Shell is flagged with `sh` or `bash` in the handbooks, but Prism uses `shell`.
+		if ( 'sh' === $lang || 'bash' === $lang ) {
+			$lang = 'shell';
+		}
+
+		return do_blocks(
+			sprintf(
+				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="%1$s" class="language-%1$s line-numbers">%2$s</code></pre><!-- /wp:code -->',
+				$lang,
+				self::_trim_code( $content )
+			)
+		);
+	}
+
+	/**
+	 * Trim off any extra space, including initial new lines.
+	 * Strip out <br /> and <p> added by WordPress.
+	 *
+	 * @param string $content Shortcode content.
+	 * @return string
+	 */
+	public static function _trim_code( $content ) {
+		$content = preg_replace( '/<br \/>/', '', $content );
+		$content = preg_replace( '/<\/p>\s*<p>/', "\n\n", $content );
+		// Trim everything except leading spaces.
+		$content = trim( $content, "\n\r\t\v\x00" );
+		return $content;
+	}
 } // DevHub_Formatting
 
 DevHub_Formatting::init();

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -57,9 +57,15 @@ jQuery( function ( $ ) {
 		$button.text( wporgFunctionReferenceI18n.copy );
 		$button.on( 'click', function () {
 			clearTimeout( timeoutId );
-			const code = $element.find( 'code' ).text();
+			const $code = $element.find( 'code' );
+			let code = $code.text();
 			if ( ! code ) {
 				return;
+			}
+
+			// For single-line shell scripts, trim off the initial `$ `, if exists.
+			if ( 'shell' === $code.attr( 'lang' ) && code.startsWith( '$ ' ) && ! code.includes( '\n' ) ) {
+				code = code.slice( 2 );
 			}
 
 			// This returns a promise which will resolve if the copy suceeded,


### PR DESCRIPTION
The handbooks use a `code` shortcode with a `lang` attribute to display the embedded code snippets. This PR updates that shortcode (which doesn't exist with SyntaxHighlighter Evolved disabled) to render the Code Syntax Block HTML instead. The new block also supports more languages when syntax highlighting (see the markdown example in the screenshot).

I also added a feature to the copy button that strips the leading `$` prompt from shell scripts, so they can be pasted directly into a terminal window.

Screenshots:

| Before | After |
|-------|------|
| ![before-php](https://user-images.githubusercontent.com/541093/172232130-f12d235d-2924-41ef-9fd2-9de7ca30873f.png) | ![after-php](https://user-images.githubusercontent.com/541093/172232125-48454dfa-2672-4c38-89ce-2778fb164349.png) |
| ![before-js](https://user-images.githubusercontent.com/541093/172232127-565b0f81-d346-413c-ba62-0c44905d2204.png) | ![after-js](https://user-images.githubusercontent.com/541093/172232120-095dac32-d55c-4d5a-9cc9-cb201773e523.png) |
| ![before-jsx](https://user-images.githubusercontent.com/541093/172232128-af8db292-2544-4259-8511-698bb75a7da7.png) | ![after-jsx](https://user-images.githubusercontent.com/541093/172232122-621e3b4a-7aec-4834-8466-9591ab7766ac.png) |
| ![before-markdown](https://user-images.githubusercontent.com/541093/172232129-24d0ffd7-2129-4dd5-abbb-58cfd79abe6b.png) | ![after-markdown](https://user-images.githubusercontent.com/541093/172232124-67e95e66-e55a-4b42-a19e-387ce94d9cbc.png) |

**To test**

- Manually run the cron tasks to import the handbook content, if you don't have it yet: `wp cron event run --all`
- View pages with code, the Block Editor handbook is good for this
- The code should be syntax-highlighted correctly, with line numbers and correct formatting
- The "copy" button should work
- Try looking at a block editor page with code tabs, ex: `/block-editor/how-to-guides/block-tutorial/block-controls-toolbar-and-sidebar/`
- The tabs should render correctly and work, and each code block should be copyable

View a page with shell commands, ex: http://localhost:8888/block-editor/reference-guides/packages/packages-env/

- Try copying a code snippet that's just one line
- It should strip the leading `$`
- Non-shell commands or multi-line text should not change