### PR TITLE
WIP: Experiment: Advanced search qualifiers

### DIFF
--- a/source/wp-content/themes/wporg-developer/functions.php
+++ b/source/wp-content/themes/wporg-developer/functions.php
@@ -137,6 +137,11 @@ if ( is_admin() ) {
 }
 
 /**
+ * Custom class of modifying search queries.
+ */
+require __DIR__ . '/inc/advanced-search-filters.php';
+
+/**
  * Set the content width based on the theme's design and stylesheet.
  */
 if ( ! isset( $content_width ) ) {

--- a/source/wp-content/themes/wporg-developer/functions.php
+++ b/source/wp-content/themes/wporg-developer/functions.php
@@ -137,7 +137,7 @@ if ( is_admin() ) {
 }
 
 /**
- * Custom class of modifying search queries.
+ * Custom class for modifying search queries.
  */
 require __DIR__ . '/inc/advanced-search-filters.php';
 

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -1,0 +1,102 @@
+<?php
+
+class Advanced_Search_Filters {
+
+	public static function init() {
+		add_filter( 'the_posts', array( __CLASS__, 'modify_search' ), 10, 2 );
+	}
+
+	/**
+	 * Modifies the query if user has used advanced search filters
+	 *
+	 * @param \WP_Query $query
+	 * @return void
+	 */
+	public static function modify_query( $query ) {
+		$post_types = [];
+		$tax_queries = [];
+
+		// Clean up keyword
+		$keyword = trim( $query->get( 's' ) );
+
+		// Split on spaces
+		$groups = explode( " ", $keyword );
+
+		// Loop through groups
+		foreach( $groups as $group ){
+			// Check if {qualifier}:{keyword} is used;
+			$split = explode( ':', $group );
+
+			// We have mo qualifier
+			if( count( $split ) < 2 ) {
+				continue;
+			}
+	
+			$qualifier = strtolower( $split[ 0 ] );
+		
+			switch ( $qualifier ) {
+				case 'type':
+					// TO DO Validate the type
+					$post_types[] = 'wp-parser-'. strtolower($split[1]);
+
+					// Remove "type"	
+					$keyword = str_replace( $qualifier . ':' , '', $keyword );
+					break;
+				case 'file':
+					// Get the tax ids first
+					$tax_ids = get_terms( array(
+							'taxonomy' => 'wp-parser-source-file',
+							'name__like' => $split[1],
+							'fields' => 'ids'
+						) );
+
+					$tax_queries[] = array(
+							'taxonomy' => 'wp-parser-source-file',
+							'terms' => $tax_ids
+					);
+				
+					// Remove everything from the query
+					$keyword = str_replace( $group , '', $keyword );
+					break;
+				case 'version':
+					$tax_queries[] = array(
+							'taxonomy' => 'wp-parser-since',
+							'field'    => 'name',
+							'terms'    => $split[1],
+					);
+
+					// Remove everything from the query
+					$keyword = str_replace( $group , '', $keyword );
+					break;
+			}
+		}
+
+		if( count( $tax_queries ) > 0 ) {
+			$query->set( 'tax_query', $tax_queries );
+		}
+
+		// Add relevant post_types
+		$query->set( 'post_type', array_merge( $query->get( 'post_type' ) ?: [], $post_types ) );
+
+		// Reset the keyword
+		$query->set( 's', $keyword );
+
+		// If user has '()' at end of a search string, assume they want a specific function/method.
+		$s = htmlentities( $query->get( 's' ) );
+		if ( '()' === substr( $s, -2 ) ) {
+			// Enable exact search.
+			$query->set( 'exact',     true );
+			// Modify the search query to omit the parentheses.
+			$query->set( 's',         substr( $s, 0, -2 ) ); // remove '()'
+			// Restrict search to function-like content.
+			$query->set( 'post_type', array( 'wp-parser-function', 'wp-parser-method' ) );
+		}
+	}
+
+	public function modify_search( $posts, $query ) {
+		$query->set('s', $query->query["s"]);
+		return $posts;
+	}
+}
+
+Advanced_Search_Filters::init();

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -99,8 +99,8 @@ class Advanced_Search_Filters {
 
 					if ( in_array( $type, DevHub\get_parsed_post_types() ) ) {
 						$post_types[] = $type;
-
-						$keyword = str_replace( 'type:', '', $keyword );
+						// Remove everything from the query.
+						$keyword = str_replace( $group, '', $keyword );
 					}
 
 					break;
@@ -120,10 +120,10 @@ class Advanced_Search_Filters {
 		}
 
 		// Add relevant tax queries
-		$query->set( 'tax_query', array_merge( $query->get( 'tax_query' ) ?: array(), $tax_queries ) );
+		$query->set( 'tax_query', array_unique( array_merge( $query->get( 'tax_query' ) ?: array(), $tax_queries ), SORT_REGULAR ) );
 
 		// Add relevant post_types
-		$query->set( 'post_type', array_merge( $query->get( 'post_type' ) ?: array(), $post_types ) );
+		$query->set( 'post_type', array_unique( array_merge( $query->get( 'post_type' ) ?: array(), $post_types ), SORT_REGULAR ) );
 
 		// Reset the keyword
 		$query->set( 's', $keyword );
@@ -140,7 +140,7 @@ class Advanced_Search_Filters {
 	public static function modify_search( $posts, $query ) {
 		// Reset the keyword so we don't lose the qualifiers
 
-		if( isset( $query->query['s'] ) ) {
+		if ( isset( $query->query['s'] ) ) {
 			$query->set( 's', $query->query['s'] );
 		}
 

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -81,7 +81,7 @@ class Advanced_Search_Filters {
 
 				// If user has '()' at end of a search string, assume they want a specific function/method.
 				$s = htmlentities( $split[0] );
-				if ( str_contains( $s, '(' ) || '(' == substr( $s, -1 ) ) {
+				if ( str_contains( $s, '(' ) ) {
 					// Modify the search query to omit the parentheses.
 					$keyword = str_replace( array( '()', '(' ), '', $keyword );
 

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -130,6 +130,14 @@ class Advanced_Search_Filters {
 		$query->set( 's', $keyword );
 	}
 
+	/**
+	 * Reset the keyword back to the original keyword after we retrieve the posts.
+	 * We need to because we removed parts in modify_query().
+	 *
+	 * @param WP_Post[] $posts
+	 * @param WP_Query  $query
+	 * @return WP_Post[]
+	 */
 	public static function modify_search( $posts, $query ) {
 		// Reset the keyword so we don't lose the qualifiers
 		$query->set( 's', $query->query['s'] );

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -81,9 +81,9 @@ class Advanced_Search_Filters {
 
 				// If user has '()' at end of a search string, assume they want a specific function/method.
 				$s = htmlentities( $split[0] );
-				if ( str_contains( $s, '()' ) ) {
+				if ( str_contains( $s, '(' ) ) {
 					// Modify the search query to omit the parentheses.
-					$keyword = str_replace( '()', '', $keyword );
+					$keyword = rtrim( $keyword, '()' );
 
 					// Restrict search to function-like content.
 					$post_types[] = 'wp-parser-function';

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -139,7 +139,11 @@ class Advanced_Search_Filters {
 	 */
 	public static function modify_search( $posts, $query ) {
 		// Reset the keyword so we don't lose the qualifiers
-		$query->set( 's', $query->query['s'] );
+
+		if( isset( $query->query['s'] ) ) {
+			$query->set( 's', $query->query['s'] );
+		}
+
 		return $posts;
 	}
 }

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -100,8 +100,7 @@ class Advanced_Search_Filters {
 					if ( in_array( $type, DevHub\get_parsed_post_types() ) ) {
 						$post_types[] = $type;
 
-						// Remove "type"
-						$keyword = str_replace( $split[0] . ':', '', $keyword );
+						$keyword = str_replace( 'type:', '', $keyword );
 					}
 
 					break;

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -74,10 +74,13 @@ class Advanced_Search_Filters {
 			$split = explode( ':', $group );
 
 			// We have no qualifier.
-			if ( ! isset( $split[1] ) ) {
+			if ( ! isset( $split[1] ) ||
+				empty( $split[0] ) || // Missing a qualifier. Ie: :init
+				$split[1][0] == ':'  // Searching for a class method. Ie: {Class}::init()
+			) {
+
 				// If user has '()' at end of a search string, assume they want a specific function/method.
 				$s = htmlentities( $split[0] );
-
 				if ( str_contains( $s, '()' ) ) {
 					// Modify the search query to omit the parentheses.
 					$keyword = str_replace( '()', '', $keyword );
@@ -90,9 +93,7 @@ class Advanced_Search_Filters {
 				continue;
 			}
 
-			$qualifier = strtolower( $split[0] );
-
-			switch ( $qualifier ) {
+			switch ( strtolower( $split[0] ) ) {
 				case 'type':
 					$type = self::get_post_type_string( $split[1] );
 
@@ -100,7 +101,7 @@ class Advanced_Search_Filters {
 						$post_types[] = $type;
 
 						// Remove "type"
-						$keyword = str_replace( $qualifier . ':', '', $keyword );
+						$keyword = str_replace( $split[0] . ':', '', $keyword );
 					}
 
 					break;

--- a/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
+++ b/source/wp-content/themes/wporg-developer/inc/advanced-search-filters.php
@@ -81,9 +81,9 @@ class Advanced_Search_Filters {
 
 				// If user has '()' at end of a search string, assume they want a specific function/method.
 				$s = htmlentities( $split[0] );
-				if ( str_contains( $s, '(' ) ) {
+				if ( str_contains( $s, '(' ) || '(' == substr( $s, -1 ) ) {
 					// Modify the search query to omit the parentheses.
-					$keyword = rtrim( $keyword, '()' );
+					$keyword = str_replace( array( '()', '(' ), '', $keyword );
 
 					// Restrict search to function-like content.
 					$post_types[] = 'wp-parser-function';

--- a/source/wp-content/themes/wporg-developer/inc/search.php
+++ b/source/wp-content/themes/wporg-developer/inc/search.php
@@ -76,9 +76,7 @@ class DevHub_Search {
 			switch ( $qualifier ) {
 				case 'hook':
 				case 'function':
-				case 'functions':
 				case 'method':
-				case 'methods':
 				case 'class':
 					$query->set( 's',         substr( $query->get( 's' ) , strlen($qualifier) + 1  ) );
 					$query->set( 'post_type', array( 'wp-parser-'. $qualifier ) );

--- a/source/wp-content/themes/wporg-developer/inc/search.php
+++ b/source/wp-content/themes/wporg-developer/inc/search.php
@@ -62,42 +62,6 @@ class DevHub_Search {
 	}
 
 	/**
-	 * Modifies the query if user has used advanced search filters
-	 *
-	 * @param \WP_Query $query
-	 * @return void
-	 */
-	public static function process_qualifiers( $query ) {
-		// Check if {qualifier}:{keyword} is used;
-		$split = explode(':', $query->get( 's' ));
-
-		// TODO - We don't want to match on ::
-		if( count( $split ) > 1 ) {
-			$qualifier = strtolower( $split[0] );
-			
-			switch ( $qualifier ) {
-				case 'hook':
-				case 'function':
-				case 'method':
-				case 'class':
-					$query->set( 's', substr( $query->get( 's' ), strlen($qualifier) + 1 ) );
-					$query->set( 'post_type', array( 'wp-parser-'. $qualifier ) );
-			}
-		}
-
-		// If user has '()' at end of a search string, assume they want a specific function/method.
-		$s = htmlentities( $query->get( 's' ) );
-		if ( '()' === substr( $s, -2 ) || '(' == substr( $s, -1 ) ) {
-			// Enable exact search.
-			$query->set( 'exact',     true );
-			// Modify the search query to omit the parentheses.
-			$query->set( 's',         substr( $s, 0, -2 ) ); // remove '()'
-			// Restrict search to function-like content.
-			$query->set( 'post_type', array( 'wp-parser-function', 'wp-parser-method' ) );
-		}
-	}
-
-	/**
 	 * Query modifications.
 	 *
 	 * @param \WP_Query $query

--- a/source/wp-content/themes/wporg-developer/inc/search.php
+++ b/source/wp-content/themes/wporg-developer/inc/search.php
@@ -128,7 +128,7 @@ class DevHub_Search {
 			// Just to make sure. post type should already be set.
 			$query->set( 'post_type', wporg_get_current_handbook() );
 		} else {
-			self::process_qualifiers( $query );
+			Advanced_Search_Filters::modify_query( $query );
 		}
 
 		// Get post types (if used, or set above)

--- a/source/wp-content/themes/wporg-developer/inc/search.php
+++ b/source/wp-content/themes/wporg-developer/inc/search.php
@@ -70,6 +70,8 @@ class DevHub_Search {
 	public static function process_qualifiers( $query ) {
 		// Check if {qualifier}:{keyword} is used;
 		$split = explode(':', $query->get( 's' ));
+
+		// TODO - We don't want to match on ::
 		if( count( $split ) > 1 ) {
 			$qualifier = strtolower( $split[0] );
 			
@@ -78,9 +80,8 @@ class DevHub_Search {
 				case 'function':
 				case 'method':
 				case 'class':
-					$query->set( 's',         substr( $query->get( 's' ) , strlen($qualifier) + 1  ) );
+					$query->set( 's', substr( $query->get( 's' ), strlen($qualifier) + 1 ) );
 					$query->set( 'post_type', array( 'wp-parser-'. $qualifier ) );
-
 			}
 		}
 


### PR DESCRIPTION
Mentioned in: [meta:3158](https://meta.trac.wordpress.org/ticket/3158).

Allow some basic search qualifiers to make searching a little bit more powerful.

**Filter by type**:
You can combine multiple types to filter.

- `type:hook`
- `type:function`
- `type:method`
- `type:class`

**Filter by file**:
You can filter within 1 or more files. Will match partial paths. Uses `name__like`.

- `file:wp-settings.php`

**Filter by version**:
You can filter within 1 version. Must be a full version.

- `version:4.8.0`

<hr>

**Examples**:
Search: `version:4.8.0 file:class-wp-editor.php get`

See version `4.8.0`, file: `class-wp-editor.php`, looking for functions that have `get` in them.

**Returns:**
- [_WP_Editors::get_baseurl()](http://developer.wordpress.org/reference/classes/_wp_editors/get_baseurl/)
- [_WP_Editors::get_mce_locale()](http://developer.wordpress.org/reference/classes/_wp_editors/get_mce_locale/)
