### PR TITLE
Iterate on anchor links on headings

### DIFF
--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -8,7 +8,7 @@ class WPorg_Handbook_TOC {
 	protected $post_types = array();
 
 	protected $styles = '<style>
-		.toc-header { display: flex; justify-content: space-between; }
+		.toc-header { display: flex; justify-content: space-between; margin-top: 48px !important; }
 		.toc-jump { text-align: right; font-size: 0.75em; order: 2; }
 		.toc-heading a { color: inherit; font-weight: inherit; margin-left: -32px; text-decoration: none !important; }
 		/* icon is 20px wide in a 32px space, so add a 12px margin. */

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -209,7 +209,7 @@ class WPorg_Handbook_TOC {
 				$extra_attrs,
 				$title
 			);
-			$replacements[] = $replacement;
+			$replacements[] = '<header class="toc-header">' . $replacement . '</header>';
 		}
 
 		if ( $replacements ) {

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -8,10 +8,16 @@ class WPorg_Handbook_TOC {
 	protected $post_types = array();
 
 	protected $styles = '<style>
-		.toc-jump { text-align: right; font-size: 12px; }
-		.toc-heading a { color: inherit; font-weight: inherit; margin-left: -25px; text-decoration: none !important; }
-		.toc-heading a:before { vertical-align: middle; margin-top: -5px; margin-right: 5px; }
-		.toc-heading:target a:before { margin-left: -8px; margin-right: 13px; }
+		.toc-header { display: flex; justify-content: space-between; }
+		.toc-jump { text-align: right; font-size: 0.75em; order: 2; }
+		.toc-heading a { color: inherit; font-weight: inherit; margin-left: -32px; text-decoration: none !important; }
+		/* icon is 20px wide in a 32px space, so add a 12px margin. */
+		.toc-heading a:before { vertical-align: middle; margin: -4px 8px 0 4px; }
+		@media (max-width: 876px) {
+			.toc-heading a { margin-left: -20px; }
+			/* icon is 16px wide in a 20px space, so add a 4px margin. */
+			.toc-heading a:before { margin: -2px 4px 0 2px; width: 14px; height: 14px; font-size: 14px; }
+		}
 	</style>';
 
 	/**

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -8,15 +8,38 @@ class WPorg_Handbook_TOC {
 	protected $post_types = array();
 
 	protected $styles = '<style>
-		.toc-header { display: flex; justify-content: space-between; margin-top: 48px !important; }
-		.toc-jump { text-align: right; font-size: 0.75em; order: 2; }
-		.toc-heading a { color: inherit; font-weight: inherit; margin-left: -32px; text-decoration: none !important; }
-		/* icon is 20px wide in a 32px space, so add a 12px margin. */
-		.toc-heading a:before { vertical-align: middle; margin: -4px 8px 0 4px; }
+		.toc-header {
+			display: flex;
+			justify-content: space-between;
+			margin-top: 48px !important;
+		}
+		.toc-jump {
+			text-align: right;
+			font-size: 0.75em;
+			order: 2;
+		}
+		.toc-heading a {
+			color: inherit;
+			font-weight: inherit;
+			margin-left: -32px;
+			text-decoration: none !important;
+		}
+		.toc-heading a:before {
+			vertical-align: middle;
+			/* icon is 20px wide in a 32px space, so add 12px horizontal margin. */
+			margin: -4px 8px 0 4px;
+		}
 		@media (max-width: 876px) {
-			.toc-heading a { margin-left: -20px; }
-			/* icon is 16px wide in a 20px space, so add a 4px margin. */
-			.toc-heading a:before { margin: -2px 4px 0 2px; width: 14px; height: 14px; font-size: 14px; }
+			.toc-heading a {
+				margin-left: -20px;
+			}
+			.toc-heading a:before {
+				/* icon is 14px wide in a 20px space, so add 6px horizontal margin. */
+				margin: -2px 4px 0 2px;
+				width: 14px;
+				height: 14px;
+				font-size: 14px;
+			}
 		}
 	</style>';
 

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -42,10 +42,6 @@
 	#content-area {
 		padding: 0 #{"max( 20px, 2% )"};
 
-		.toc-heading {
-			clear: left;
-		}
-
 		table {
 			border: 1px solid #f0f0f0;
 
@@ -1263,11 +1259,6 @@
 		.callout {
 			margin-top: 30px;
 		}
-
-		.toc-jump {
-			display: inline-block;
-			float: right;
-		}
 	}
 
 	.callout::before {
@@ -1354,10 +1345,6 @@
 				display: none;
 			}
 		}
-	}
-
-	.source-content {
-		overflow: auto;
 	}
 
 	.source-code-links {
@@ -2182,42 +2169,26 @@ aside[id^="nav_menu"] .widget-title {
 	}
 }
 
-/* Highlight current heading and adjust scroll position for fixed toolbar */
-.toc-heading:target {
-	position: initial;
-	padding-top: 50px;
-	margin-top: -50px;
+.toc-header {
+	margin-bottom: 1em;
 }
 
-/* Remove negative margin because there is no jump link before these headlines */
-.entry-content h2.toc-heading:first-of-type:target,
-.entry-content h3.toc-heading:first-of-type:target,
-h2.toc-heading + h3.toc-heading:target {
-	margin-top: 0;
-}
-
-.toc-heading:target::before {
-	content: "";
-	position: absolute;
-	left: -10px;
-	top: 50px;
-	border-left: 5px solid #0073aa;
-	height: calc(100% - 50px);
-}
-
-.toc-jump {
+.toc-heading {
 	position: relative;
-	height: 50px;
 }
 
-.toc-jump::after {
-	content: "";
-	display: table;
-	clear: both;
+.toc-heading a::before {
+	color: get-color(gray-30);
 }
 
-.toc-jump a {
-	z-index: 1;
+.toc-heading:target a::before {
+	color: inherit;
+}
+
+.toc-heading a:hover::before,
+.toc-heading a:active::before,
+.toc-heading a:focus::before {
+	color: get-color(blue-50);
 }
 
 @media (max-width: 480px) {
@@ -2810,12 +2781,6 @@ body.responsive-show {
 				color: #757575;
 			}
 		}
-	}
-
-	.toc-jump {
-		float: right;
-		font-size: 75%;
-		margin-top: 11px;
 	}
 
 	table {

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1074,6 +1074,10 @@
 			margin-bottom: 0.5em;
 		}
 
+		.toc-header {
+			margin-top: 0 !important;
+		}
+
 		h1,
 		.signature-highlight {
 			color: get-color(green-50);

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1382,6 +1382,13 @@ img {
   margin-bottom: 0.5em;
 }
 
+.devhub-wrap .wp-parser-class .toc-header,
+.devhub-wrap .wp-parser-function .toc-header,
+.devhub-wrap .wp-parser-hook .toc-header,
+.devhub-wrap .wp-parser-method .toc-header {
+  margin-top: 0 !important;
+}
+
 .devhub-wrap .wp-parser-class h1,
 .devhub-wrap .wp-parser-class .signature-highlight,
 .devhub-wrap .wp-parser-function h1,

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -332,11 +332,6 @@ img {
   padding: 0 max( 20px, 2% );
 }
 
-.devhub-wrap #content .toc-heading,
-.devhub-wrap #content-area .toc-heading {
-  clear: left;
-}
-
 .devhub-wrap #content table,
 .devhub-wrap #content-area table {
   border: 1px solid #f0f0f0;
@@ -1834,14 +1829,6 @@ img {
   margin-top: 30px;
 }
 
-.devhub-wrap .wp-parser-class .toc-jump,
-.devhub-wrap .wp-parser-function .toc-jump,
-.devhub-wrap .wp-parser-hook .toc-jump,
-.devhub-wrap .wp-parser-method .toc-jump {
-  display: inline-block;
-  float: right;
-}
-
 .devhub-wrap .callout::before {
   top: 0.4em;
 }
@@ -1921,10 +1908,6 @@ img {
   .devhub-wrap .related span {
     display: none;
   }
-}
-
-.devhub-wrap .source-content {
-  overflow: auto;
 }
 
 .devhub-wrap .source-code-links {
@@ -2884,42 +2867,26 @@ aside[id^="nav_menu"] .widget-title {
   padding-bottom: 0;
 }
 
-/* Highlight current heading and adjust scroll position for fixed toolbar */
-.toc-heading:target {
-  position: initial;
-  padding-top: 50px;
-  margin-top: -50px;
+.toc-header {
+  margin-bottom: 1em;
 }
 
-/* Remove negative margin because there is no jump link before these headlines */
-.entry-content h2.toc-heading:first-of-type:target,
-.entry-content h3.toc-heading:first-of-type:target,
-h2.toc-heading + h3.toc-heading:target {
-  margin-top: 0;
-}
-
-.toc-heading:target::before {
-  content: "";
-  position: absolute;
-  left: -10px;
-  top: 50px;
-  border-left: 5px solid #0073aa;
-  height: calc(100% - 50px);
-}
-
-.toc-jump {
+.toc-heading {
   position: relative;
-  height: 50px;
 }
 
-.toc-jump::after {
-  content: "";
-  display: table;
-  clear: both;
+.toc-heading a::before {
+  color: #8c8f94;
 }
 
-.toc-jump a {
-  z-index: 1;
+.toc-heading:target a::before {
+  color: inherit;
+}
+
+.toc-heading a:hover::before,
+.toc-heading a:active::before,
+.toc-heading a:focus::before {
+  color: #2271b1;
 }
 
 @media (max-width: 480px) {
@@ -3431,12 +3398,6 @@ body.responsive-show #o2-expand-editor {
 
 .single-command #content .quick-links a:hover {
   color: #757575;
-}
-
-.single-command #content .toc-jump {
-  float: right;
-  font-size: 75%;
-  margin-top: 11px;
 }
 
 .single-command #content table {


### PR DESCRIPTION
I noticed some issues with the heading positioning when the link was clicked, so I decided to try to fix it. While I was here, I made a few other tweaks too.

<details>
<summary>The initial bug:</summary>

https://user-images.githubusercontent.com/541093/172435040-0e2f0dfe-44b8-4b68-9383-298a207f138b.mp4

I didn't take an "after" screencast but the jumping is fixed :)
</details>


**Screenshots**

Visual changes:

- The top link & heading are wrapped in a `header` to put them on a single line. I see this is only the style on the code reference, so I can change this part back if it's not a desired change.
- Made the default link icon a lighter grey (icons can have a contrast of 3:1, this is the lightest grey we'd want to use here)
- When hovering/focusing, the link icon goes blue
- When a section is targeted (the URL has the `#create-a-block-tutorial`), the icon is black — I thought this would be a subtle way to draw attention, but we could go bigger here somehow. It looks like at some point this had a blue line like [the handbooks on p2](https://make.wordpress.org/meta/handbook/#documentation), but with the persistent link icon, this doesn't work.
- Remove the overflow from the source section, which was hiding the link icon. the `pre` adds its own overflow, so the one on the section was not needed.

| | Before | After |
|---|--------|-------|
| Default code reference | ![before-code-ref](https://user-images.githubusercontent.com/541093/172435820-85798146-56ab-4c5c-9d8a-31f4e7837785.png) | ![after-code-ref](https://user-images.githubusercontent.com/541093/172435806-e8555ed4-46ee-4a60-bca7-e2150d8e598f.png) |
| Heading targeted | ![before-code-ref-target](https://user-images.githubusercontent.com/541093/172435819-a5697d7c-b1ae-4e01-b0ef-fd5deac5a128.png) | ![after-code-ref-target](https://user-images.githubusercontent.com/541093/172435803-6d177536-d567-40e2-9d0a-780a64595976.png) |
| One heading targeted, one hovered | ![before-handbook](https://user-images.githubusercontent.com/541093/172435826-0038af2b-4654-40da-bb91-33b56ab0b854.png) | ![after-handbook](https://user-images.githubusercontent.com/541093/172440212-9c2684e0-58cd-4d8c-8e62-3d820b009cb8.png) |

And for smaller screens, I shrunk down the icon a little to fit.

| Before | After |
|--------|-------|
| ![before-code-ref-small](https://user-images.githubusercontent.com/541093/172435816-f6baacd4-8062-4f26-a5f2-90e02671362e.png) | ![after-code-ref-small](https://user-images.githubusercontent.com/541093/172435799-dae9d383-af75-4273-8451-b2398bda1de6.png) |
| ![before-handbook-small](https://user-images.githubusercontent.com/541093/172435822-83514c41-2809-41cd-96f2-0a80c1ecfb09.png) | ![after-handbook-small](https://user-images.githubusercontent.com/541093/172440206-5be24184-abd6-4222-8219-cfc6c150b6f7.png) |




