### PR TITLE
UI: Style select dropdowns manually for more design control

### DIFF
--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -256,6 +256,19 @@
 		width: 98%;
 	}
 
+	select {
+		appearance: none;
+		background-color: $color-white;
+		background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' width='24' height='24' aria-hidden='true'%3E%3Cpath d='M17.5 11.6 12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z'/%3E%3C/svg%3E%0A");
+		background-position: right center;
+		background-repeat: no-repeat;
+		background-size: 1.5em 1.5em;
+		padding-right: 2em;
+		color: get-color(gray-70);
+		border: 1px solid get-color(gray-70);
+		border-radius: 3px;
+	}
+
 	/* Text meant only for screen readers */
 	.screen-reader-text {
 		clip: rect(1px, 1px, 1px, 1px);
@@ -784,10 +797,14 @@
 
 		select,
 		input[type="submit"] {
-			margin-left: 0.5em;
+			margin: 0 0 0 0.5em;
 			padding: 0.333em 1em;
 			font-size: inherit;
 			line-height: inherit;
+		}
+
+		select {
+			padding-right: 2em;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -597,6 +597,19 @@ img {
   width: 98%;
 }
 
+.devhub-wrap select {
+  appearance: none;
+  background-color: #fff;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' width='24' height='24' aria-hidden='true'%3E%3Cpath d='M17.5 11.6 12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z'/%3E%3C/svg%3E%0A");
+  background-position: right center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  padding-right: 2em;
+  color: #3c434a;
+  border: 1px solid #3c434a;
+  border-radius: 3px;
+}
+
 .devhub-wrap .screen-reader-text {
   clip: rect(1px, 1px, 1px, 1px);
   position: absolute !important;
@@ -1091,10 +1104,14 @@ img {
 
 .devhub-wrap .archive-filter-form select,
 .devhub-wrap .archive-filter-form input[type="submit"] {
-  margin-left: 0.5em;
+  margin: 0 0 0 0.5em;
   padding: 0.333em 1em;
   font-size: inherit;
   line-height: inherit;
+}
+
+.devhub-wrap .archive-filter-form select {
+  padding-right: 2em;
 }
 
 .devhub-wrap .searchform {


### PR DESCRIPTION
Fixes #89 — this customizes the select dropdown so that we can position the arrow. It also fixes the design disparity in Safari.

| Browser | Before | After | 
|----|-------|-----|
| Safari | <img width="315" alt="before-safari" src="https://user-images.githubusercontent.com/541093/172473454-e28db7e7-24a2-45b0-a28b-603b1feaab9f.png"> | <img width="339" alt="after-safari" src="https://user-images.githubusercontent.com/541093/172473459-bb9a1325-1352-4198-a8d0-cac138b3aa87.png"> |
| Firefox | <img width="354" alt="before-firefix" src="https://user-images.githubusercontent.com/541093/172473456-e8ebc198-9442-4331-90c4-135cb5179e2d.png"> | <img width="350" alt="after-firefox" src="https://user-images.githubusercontent.com/541093/172473465-11fff4f7-1adb-4d8d-9e86-2ce64fd02b48.png"> |
| Chrome | <img width="363" alt="before-chrome" src="https://user-images.githubusercontent.com/541093/172473457-564e5944-6dde-4107-9d3c-b0d93e113564.png"> | <img width="336" alt="after-chrome" src="https://user-images.githubusercontent.com/541093/172473466-a9d797a6-1648-4969-ab87-f967dd3931a1.png"> |