### PR TITLE
Extract Table of Contents from content to allow wider source view

### DIFF
--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -101,7 +101,7 @@ class WPorg_Handbook_TOC {
 	 * @access public
 	 *
 	 * @param string $content Content.
-	 * @return string Modified content.
+	 * @return array toc => Table of Contents, content => Modified Content.
 	 */
 	public function add_toc( $content ) {
 		if ( ! in_the_loop() ) {
@@ -164,7 +164,7 @@ class WPorg_Handbook_TOC {
 
 		$toc .= "</ul>\n</div>\n";
 
-		return $toc . $content;
+		return array('toc' => $toc, 'content' => $content);
 	}
 
 	/**

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -101,18 +101,31 @@ class WPorg_Handbook_TOC {
 	 * @access public
 	 *
 	 * @param string $content Content.
-	 * @return array toc => Table of Contents, content => Modified Content.
+	 * @return string toc => Modified Content.
 	 */
 	public function add_toc( $content ) {
+		$parts = $this->parse_content( $content );
+   		return $parts['toc'] . $parts['content'];
+	}
+
+	/**
+	 * Parses given content and returns modified content and the ToC.
+	 *
+	 * @access public
+	 *
+	 * @param string $content Content.
+	 * @return array toc => Table of Contents, content => Modified Content.
+	 */
+	public function parse_content( $content ) {
 		if ( ! in_the_loop() ) {
-			return $content;
+			return array('content' => $content, 'toc' => null);
 		}
 
 		$toc   = '';
 		$items = $this->get_tags( 'h(?P<level>[1-4])', $content );
 
 		if ( count( $items ) < 2 ) {
-			return $content;
+			return array('content' => $content, 'toc' => null);
 		}
 
 		// Remove any links we don't need.
@@ -138,7 +151,7 @@ class WPorg_Handbook_TOC {
 		$content = $this->add_ids_and_jumpto_links( $items, $content );
 
 		if ( ! apply_filters( 'handbook_display_toc', true ) ) {
-			return $content;
+			return array('content' => $content, 'toc' => null);
 		}
 
 		$contents_header = 'h' . reset( $items )['level']; // Duplicate the first <h#> tag in the document for the TOC header

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -154,9 +154,8 @@ class WPorg_Handbook_TOC {
 			return array('content' => $content, 'toc' => null);
 		}
 
-		$contents_header = 'h' . reset( $items )['level']; // Duplicate the first <h#> tag in the document for the TOC header
 		$toc            .= '<div class="table-of-contents">';
-		$toc            .= "<$contents_header>" . esc_html( $this->args->header_text ) . "</$contents_header><ul class=\"items\">";
+		$toc            .= '<p class="table-of-contents-title">' . esc_html( $this->args->header_text ) . '</p><ul class="items">';
 		$last_item       = false;
 
 		foreach ( $items as $item ) {

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -101,7 +101,7 @@ class WPorg_Handbook_TOC {
 	 * @access public
 	 *
 	 * @param string $content Content.
-	 * @return string toc => Modified Content.
+	 * @return string Modified content.
 	 */
 	public function add_toc( $content ) {
 		$parts = $this->parse_content( $content );

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -10,10 +10,10 @@
 			'header_text' => __( 'Contents', 'wporg' )
 		) );
 		
-		$TOC_parts = $TOC->add_toc( $content );
+		$parts = $TOC->parse_content( $content );
 
-		$content = $TOC_parts['content'];
-		$toc = $TOC_parts['toc'];
+		$content = $parts['content'];
+		$toc = $parts['toc'];
 	endif;
 
 endif; ?>

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -1,20 +1,7 @@
 <?php namespace DevHub; ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<?php if ( is_single() ) : 
 
-	<?php echo get_deprecated(); ?>
-
-	<?php echo get_private_access_message(); ?>
-
-	<h1><?php echo get_signature(); ?></h1>
-
-	<section class="summary">
-		<?php echo get_summary(); ?>
-	</section>
-
-<?php if ( is_single() ) : ?>
-
-	<?php
 	$content = get_reference_template_parts();
 
 	// If the Handbook TOC is available, use it.
@@ -22,14 +9,41 @@
 		$TOC = new \WPorg_Handbook_TOC( get_parsed_post_types(), array(
 			'header_text' => __( 'Contents', 'wporg' )
 		) );
+		
+		$TOC_parts = $TOC->add_toc( $content );
 
-		$content = '<div class="content-toc">' . $TOC->add_toc( $content ) . '</div>';
-
+		$content = $TOC_parts['content'];
+		$toc = $TOC_parts['toc'];
 	endif;
-	?>
 
-	<?php echo $content; ?>
+endif; ?>
 
-<?php endif; ?>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<?php echo get_deprecated(); ?>
+
+	<?php echo get_private_access_message(); ?>
+
+	<header class="post-header">
+		<div class="post-title">
+
+			<h1><?php echo get_signature(); ?></h1>
+			
+			<section class="summary">
+				<?php echo get_summary(); ?>
+			</section>
+		</div>
+		<?php if ( is_single() ) :
+
+			echo $toc;
+
+		endif; ?>
+	</header>
+
+<?php if ( is_single() ) :  
+
+	echo '<div class="content">' . $content . '</div>'; 
+
+endif; ?>
 
 </article>

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -25,6 +25,11 @@ endif; ?>
 	<?php echo get_private_access_message(); ?>
 
 	<header class="post-header">
+		<?php if ( is_single() ) :
+
+			echo $toc;
+
+		endif; ?>
 		<div class="post-title">
 
 			<h1><?php echo get_signature(); ?></h1>
@@ -33,11 +38,6 @@ endif; ?>
 				<?php echo get_summary(); ?>
 			</section>
 		</div>
-		<?php if ( is_single() ) :
-
-			echo $toc;
-
-		endif; ?>
 	</header>
 
 <?php if ( is_single() ) :  

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -2108,6 +2108,7 @@ aside[id^="nav_menu"] .widget-title {
 .site-main {
 	.post-header {
 		display: flex;
+		flex-direction: row-reverse;
 		
 		.post-title {
 			flex: 1;
@@ -2127,19 +2128,8 @@ aside[id^="nav_menu"] .widget-title {
 		background-color: #fff;
 		box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
 		border-radius: 3px;
-		
-		@media (max-width: 1475px) {
-			position: static;
-			top: initial;
-			right: initial;
-		}
 
-		@media (max-width: 970px) {
-			position: fixed;
-			visibility: hidden;
-		}
-
-		h2 {
+		&-title {
 			margin: 0;
 			padding: 0.7rem 1.2rem;
 			font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -2215,12 +2205,6 @@ h2.toc-heading + h3.toc-heading:target {
 
 .toc-jump a {
 	z-index: 1;
-}
-
-@media (max-width: 480px) {
-	.table-of-contents {
-		display: none;
-	}
 }
 
 /** Menu */
@@ -2565,6 +2549,16 @@ body.responsive-show {
 	}
 }
 
+@media ( max-width: 94em ) {
+	.devhub-wrap {
+		.table-of-contents {
+			position: static;
+			top: initial;
+			right: initial;
+		}
+	}
+}
+
 @media ( max-width: 59.999999em ) {
 	.devhub-wrap {
 		max-width: 100%;
@@ -2636,6 +2630,15 @@ body.responsive-show {
 	}
 
 	.devhub-wrap {
+		.post-header {
+			flex-direction: column;
+		}
+
+		.table-of-contents {
+			margin-left: 0;
+			width: 100%;
+		}
+
 		.three-columns .box,
 		.section .box,
 		.home-primary-content,
@@ -2702,12 +2705,6 @@ body.responsive-show {
 
 @media (max-width: 32em) {
 	.devhub-wrap {
-		.table-of-contents {
-			float: none;
-			margin-left: 0;
-			width: 100%;
-		}
-
 		section {
 			overflow: inherit;
 		}

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -2104,32 +2104,51 @@ aside[id^="nav_menu"] .widget-title {
 	background-color: #fff;
 }
 
-/** Table of Contents */
-.site-main .table-of-contents {
-	float: right;
-	width: 250px;
-	border: 1px solid #eee;
-	margin: 0 0 15px 15px;
-	z-index: 1;
-	position: relative;
-	color: #555d66;
-	background-color: #fff;
-	box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-	border-radius: 3px;
-
-	@media (min-width: 971px) {
-		margin: 0 -30px 15px 15px;
+/** Header layout: H1, Summary and Table of Contents **/
+.site-main {
+	.post-header {
+		display: flex;
+		
+		.post-title {
+			flex: 1;
+		}
 	}
+	
+	.table-of-contents {
+		position: fixed;
+		top: 210px;
+		right: 30px;
+		width: 250px;
+		border: 1px solid #eee;
+		// Top margin matches H1
+		margin: 24px 0 15px 15px;
+		z-index: 1;
+		color: #555d66;
+		background-color: #fff;
+		box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+		border-radius: 3px;
+		
+		@media (max-width: 1475px) {
+			position: static;
+			top: initial;
+			right: initial;
+		}
 
-	h2 {
-		margin: 0;
-		padding: 0.7rem 1.2rem;
-		font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
-		font-size: 1.3em;
-		color: #32373c;
-		text-transform: uppercase;
-		border-bottom: 1px solid #eee;
-		margin-bottom: 0;
+		@media (max-width: 970px) {
+			position: fixed;
+			visibility: hidden;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 0.7rem 1.2rem;
+			font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+			font-size: 1.3em;
+			color: #32373c;
+			text-transform: uppercase;
+			border-bottom: 1px solid #eee;
+			margin-bottom: 0;
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2776,6 +2776,7 @@ aside[id^="nav_menu"] .widget-title {
 /** Header layout: H1, Summary and Table of Contents **/
 .site-main .post-header {
   display: flex;
+  flex-direction: row-reverse;
 }
 
 .site-main .post-header .post-title {
@@ -2796,22 +2797,7 @@ aside[id^="nav_menu"] .widget-title {
   border-radius: 3px;
 }
 
-@media (max-width: 1475px) {
-  .site-main .table-of-contents {
-    position: static;
-    top: initial;
-    right: initial;
-  }
-}
-
-@media (max-width: 970px) {
-  .site-main .table-of-contents {
-    position: fixed;
-    visibility: hidden;
-  }
-}
-
-.site-main .table-of-contents h2 {
+.site-main .table-of-contents-title {
   margin: 0;
   padding: 0.7rem 1.2rem;
   font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -2895,12 +2881,6 @@ h2.toc-heading + h3.toc-heading:target {
 
 .toc-jump a {
   z-index: 1;
-}
-
-@media (max-width: 480px) {
-  .table-of-contents {
-    display: none;
-  }
 }
 
 /** Menu */
@@ -3218,6 +3198,14 @@ body.responsive-show #o2-expand-editor {
   }
 }
 
+@media (max-width: 94em) {
+  .devhub-wrap .table-of-contents {
+    position: static;
+    top: initial;
+    right: initial;
+  }
+}
+
 @media (max-width: 59.999999em) {
   .devhub-wrap {
     max-width: 100%;
@@ -3265,6 +3253,13 @@ body.responsive-show #o2-expand-editor {
     clear: both;
   }
   #content-area.has-sidebar .widget-area .widget {
+    width: 100%;
+  }
+  .devhub-wrap .post-header {
+    flex-direction: column;
+  }
+  .devhub-wrap .table-of-contents {
+    margin-left: 0;
     width: 100%;
   }
   .devhub-wrap .three-columns .box,
@@ -3320,11 +3315,6 @@ body.responsive-show #o2-expand-editor {
 }
 
 @media (max-width: 32em) {
-  .devhub-wrap .table-of-contents {
-    float: none;
-    margin-left: 0;
-    width: 100%;
-  }
   .devhub-wrap section {
     overflow: inherit;
   }

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2773,23 +2773,41 @@ aside[id^="nav_menu"] .widget-title {
   background-color: #fff;
 }
 
-/** Table of Contents */
+/** Header layout: H1, Summary and Table of Contents **/
+.site-main .post-header {
+  display: flex;
+}
+
+.site-main .post-header .post-title {
+  flex: 1;
+}
+
 .site-main .table-of-contents {
-  float: right;
+  position: fixed;
+  top: 210px;
+  right: 30px;
   width: 250px;
   border: 1px solid #eee;
-  margin: 0 0 15px 15px;
+  margin: 24px 0 15px 15px;
   z-index: 1;
-  position: relative;
   color: #555d66;
   background-color: #fff;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   border-radius: 3px;
 }
 
-@media (min-width: 971px) {
+@media (max-width: 1475px) {
   .site-main .table-of-contents {
-    margin: 0 -30px 15px 15px;
+    position: static;
+    top: initial;
+    right: initial;
+  }
+}
+
+@media (max-width: 970px) {
+  .site-main .table-of-contents {
+    position: fixed;
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
See #76 

This PR moves the Table of Contents from the content of the page and inserts it into the header.

- On wide screens it's fixed in the top right
- On medium screens it's within the header
- On small screens it's at the top of the page

A further improvement might be to add expand/collapse behaviour and collapse by default on small screens. Although that might mask the utility of it for jumping down a long page.

Wide
<img width="1700" alt="Screen Shot 2022-06-08 at 2 34 38 PM" src="https://user-images.githubusercontent.com/1017872/172519005-9e4ab36e-5ac1-429e-9e9a-fd63e018c5a4.png">

Medium
<img width="1025" alt="Screen Shot 2022-06-10 at 11 10 45 AM" src="https://user-images.githubusercontent.com/1017872/172959977-ffe5a6e9-568d-4bb5-8f36-f934290fac3a.png">

Small
<img width="480" alt="Screen Shot 2022-06-10 at 11 09 18 AM" src="https://user-images.githubusercontent.com/1017872/172959865-86819289-c7cf-410e-be82-d80b4a7985c4.png">