### PR TITLE
Expand `$args` array parameters that are described in other functions

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -524,32 +524,9 @@ class DevHub_Formatting {
 			return $text;
 		}
 
-		// Convert dashes to a list.
-		// Example: https://developer.wordpress.org/reference/classes/wp_term_query/__construct/
-		// Example: https://developer.wordpress.org/reference/hooks/password_change_email/
-		if ( false !== strpos( $text, ' - ' ) )  {
-			// Display as simple plaintext list.
-			$text = str_replace( ' - ', "\n" . $li, $text );
-			$inline_list = true;
-		}
-
-		// If list detected.
-		if ( $inline_list ) {
-			// Replace first item, ensuring the opening 'ul' tag is prepended.
-			$text = preg_replace( '~^' . preg_quote( $li ) . '(.+)$~mU', "<ul><li>\$1</li>\n", $text, 1 );
-			// Wrap subsequent list items in 'li' tags.
-			$text = preg_replace( '~^' . preg_quote( $li ) . '(.+)$~mU', "<li>\$1</li>\n", $text );
-			$text = trim( $text );
-
-			// Close the list if it hasn't been closed before start of next hash parameter.
-			//$text = preg_replace( '~(</li>)(\s+</li>)~smU', '$1</ul>$2', $text );
-			$text = preg_replace( '~(</li>)(\s*</li>)~smU', '$1</ul>$2', $text );
-
-			// Closethe list if it hasn't been closed and it's the end of the description.
-			if ( '</li>' === substr( trim( $text ), -5 ) ) {
-				$text .= '</ul>';
-			}
-		}
+		// Wrap in a `ul`.
+		$text = substr_replace( $text, '<ul><li>', strpos( $text, '<li>' ), 4 ); // First instance
+		$text = substr_replace( $text, '</li></ul>', strrpos( $text, '</li>' ), 5 ); // Last instance.
 
 		return $text;
 	}

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -414,7 +414,7 @@ class DevHub_Formatting {
 								// Only link actually parsed methods.
 								if ( $post = get_page_by_title( $name, OBJECT, 'wp-parser-method' ) ) {
 									return sprintf(
-										'<a href="%s">%s</a>' . $after,
+										'<a href="%s" rel="method">%s</a>' . $after,
 										get_permalink( $post->ID ),
 										$name . '()'
 									);
@@ -425,7 +425,7 @@ class DevHub_Formatting {
 								// Only link actually parsed functions.
 								if ( $post = get_page_by_title( $name, OBJECT, 'wp-parser-function' ) ) {
 									return sprintf(
-										'<a href="%s">%s</a>' . $after,
+										'<a href="%s" rel="function">%s</a>' . $after,
 										get_permalink( $post->ID ),
 										$name . '()'
 									);
@@ -467,7 +467,7 @@ class DevHub_Formatting {
 						// Only link actually parsed classes.
 						if ( $post = get_page_by_title( $matches[0], OBJECT, 'wp-parser-class' ) ) {
 							return sprintf(
-								'<a href="%s">%s</a>',
+								'<a href="%s" rel="class">%s</a>',
 								get_permalink( $post->ID ),
 								$matches[0]
 							);
@@ -524,9 +524,32 @@ class DevHub_Formatting {
 			return $text;
 		}
 
-		// Wrap in a `ul`.
-		$text = substr_replace( $text, '<ul><li>', strpos( $text, '<li>' ), 4 ); // First instance
-		$text = substr_replace( $text, '</li></ul>', strrpos( $text, '</li>' ), 5 ); // Last instance.
+		// Convert dashes to a list.
+		// Example: https://developer.wordpress.org/reference/classes/wp_term_query/__construct/
+		// Example: https://developer.wordpress.org/reference/hooks/password_change_email/
+		if ( false !== strpos( $text, ' - ' ) )  {
+			// Display as simple plaintext list.
+			$text = str_replace( ' - ', "\n" . $li, $text );
+			$inline_list = true;
+		}
+
+		// If list detected.
+		if ( $inline_list ) {
+			// Replace first item, ensuring the opening 'ul' tag is prepended.
+			$text = preg_replace( '~^' . preg_quote( $li ) . '(.+)$~mU', "<ul><li>\$1</li>\n", $text, 1 );
+			// Wrap subsequent list items in 'li' tags.
+			$text = preg_replace( '~^' . preg_quote( $li ) . '(.+)$~mU', "<li>\$1</li>\n", $text );
+			$text = trim( $text );
+
+			// Close the list if it hasn't been closed before start of next hash parameter.
+			//$text = preg_replace( '~(</li>)(\s+</li>)~smU', '$1</ul>$2', $text );
+			$text = preg_replace( '~(</li>)(\s*</li>)~smU', '$1</ul>$2', $text );
+
+			// Closethe list if it hasn't been closed and it's the end of the description.
+			if ( '</li>' === substr( trim( $text ), -5 ) ) {
+				$text .= '</ul>';
+			}
+		}
 
 		return $text;
 	}

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -897,9 +897,14 @@ namespace DevHub {
 								// Sometimes the referenced doc page has another level of indirection!
 								$recurse = get_param_reference( $_params[ $variable_name ], $recursion_limit - 1 );
 								if ( $recurse ) {
+									$recurse[ 'parent' ] = $_post->post_title;
+									$recurse[ 'parent_var' ] = $variable_name;
 									return $recurse;
 								} else {
-									return $_params[ $variable_name ];
+									$result = $_params[ $variable_name ];
+									$result[ 'parent' ] = $_post->post_title;
+									$result[ 'parent_var' ] = $variable_name;
+									return $result;
 								}
 							}
 						}

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -888,6 +888,7 @@ namespace DevHub {
 
 						$arg_names_to_try = array_unique([
 							$param['variable'], // An exact match for the name eg $args
+							'$args',
 							'$query', // For example get_terms( $args ) -> WP_Term_Query::__construct( $query )
 						]);
 

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -883,12 +883,8 @@ namespace DevHub {
 	function get_param_reference( $param, $recursion_limit = 3 ) {
 		if ( $recursion_limit > 0 && preg_match_all( '#rel="(function|method)">([^<>()]+)[(][)]</a>#', $param[ 'content' ], $matches, PREG_SET_ORDER ) ) {
 			foreach ( $matches as $match ) {
-				#var_dump( "looking for post", $match[1], $match[2] );
-				#var_dump( "get_page_by_title( $match[2], OBJECT, 'wp-parser-' . $match[1] )" );
 				if ( $_post = get_page_by_title( $match[2], OBJECT, 'wp-parser-' . $match[1] ) ) {
-					#var_dump( 'got post', $_post->post_name, $_post->ID );
 					if ( $_params = get_params( $_post->ID ) ) {
-						#echo '<pre>'; var_dump( $param['variable'], 'inner params', $_params ); echo '</pre>';
 
 						$arg_names_to_try = array_unique([
 							$param['variable'], // An exact match for the name eg $args
@@ -900,10 +896,8 @@ namespace DevHub {
 								// Sometimes the referenced doc page has another level of indirection!
 								$recurse = get_param_reference( $_params[ $variable_name ], $recursion_limit - 1 );
 								if ( $recurse ) {
-									#var_dump( "Found recursive: ", $recurse );
 									return $recurse;
 								} else {
-									#var_dump( "Found here: ", $_params[ $variable_name ] );
 									return $_params[ $variable_name ];
 								}
 							}

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -863,12 +863,59 @@ namespace DevHub {
 						}
 					}
 				}
-
 			}
 		}
 
 		return $params;
 	}
+
+	/**
+	 * Recurse through parameters that referer to arguments in other functions or methods, and find the innermost parameter description.
+	 * For example the description for the wp_count_terms( $args ) parameter refers to get_terms( $args ) which in turn refers to WP_Term_Query::__construct( $query ).
+	 * Given the wp_count_terms( $args ) parameter, this will find and return the one for WP_Term_Query::__construct( $query ).
+	 *
+	 * @param array $param A single parameter array as found in `_wp-parser_args` postmeta.
+	 * @param int   $recursion_limit Maximum number of levels to recurse through.
+	 *
+	 * @return array|null
+	 */
+
+	function get_param_reference( $param, $recursion_limit = 3 ) {
+		if ( $recursion_limit > 0 && preg_match_all( '#rel="(function|method)">([^<>()]+)[(][)]</a>#', $param[ 'content' ], $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				#var_dump( "looking for post", $match[1], $match[2] );
+				#var_dump( "get_page_by_title( $match[2], OBJECT, 'wp-parser-' . $match[1] )" );
+				if ( $_post = get_page_by_title( $match[2], OBJECT, 'wp-parser-' . $match[1] ) ) {
+					#var_dump( 'got post', $_post->post_name, $_post->ID );
+					if ( $_params = get_params( $_post->ID ) ) {
+						#echo '<pre>'; var_dump( $param['variable'], 'inner params', $_params ); echo '</pre>';
+
+						$arg_names_to_try = array_unique([
+							$param['variable'], // An exact match for the name eg $args
+							'$query', // For example get_terms( $args ) -> WP_Term_Query::__construct( $query )
+						]);
+
+						foreach ( $arg_names_to_try as $variable_name ) {
+							if ( isset( $_params[ $variable_name ] ) ) {
+								// Sometimes the referenced doc page has another level of indirection!
+								$recurse = get_param_reference( $_params[ $variable_name ], $recursion_limit - 1 );
+								if ( $recurse ) {
+									#var_dump( "Found recursive: ", $recurse );
+									return $recurse;
+								} else {
+									#var_dump( "Found here: ", $_params[ $variable_name ] );
+									return $_params[ $variable_name ];
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
 
 	/**
 	 * Retrieve arguments as an array

--- a/source/wp-content/themes/wporg-developer/reference/template-params.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-params.php
@@ -29,7 +29,20 @@ if ( $params = get_params() ) :
 				<dd>
 					<div class="desc">
 						<?php if ( ! empty( $param['content'] ) ) : ?>
-							<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
+							<?php
+								if ( $extra = get_param_reference( $param ) ) {
+									?>
+									<details>
+										<summary>
+											<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
+										</summary>
+										<span class="description"><?php echo wp_kses_post( $extra['content'] ); ?></span>
+									</details>
+									<?php
+								} else {
+							?>
+								<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
+							<?php } ?>
 						<?php endif; ?>
 					</div>
 					<?php if ( ! empty( $param['default'] ) ) : ?>

--- a/source/wp-content/themes/wporg-developer/reference/template-params.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-params.php
@@ -33,7 +33,7 @@ if ( $params = get_params() ) :
 								<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
 								<details class="extended-description">
 									<summary>
-										<?php esc_html_e( 'More Arguments', 'wporg' ); ?>
+										<?php echo esc_html( sprintf( __( 'More Arguments from %s( ... %s )', 'wporg' ), $extra[ 'parent' ], $extra['parent_var'] ) ); ?>
 									</summary>
 									<span class="description"><?php echo wp_kses_post( $extra['content'] ); ?></span>
 								</details>

--- a/source/wp-content/themes/wporg-developer/reference/template-params.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-params.php
@@ -29,20 +29,17 @@ if ( $params = get_params() ) :
 				<dd>
 					<div class="desc">
 						<?php if ( ! empty( $param['content'] ) ) : ?>
-							<?php
-								if ( $extra = get_param_reference( $param ) ) {
-									?>
-									<details>
-										<summary>
-											<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
-										</summary>
-										<span class="description"><?php echo wp_kses_post( $extra['content'] ); ?></span>
-									</details>
-									<?php
-								} else {
-							?>
+							<?php if ( $extra = get_param_reference( $param ) ) : ?>
 								<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
-							<?php } ?>
+								<details class="extended-description">
+									<summary>
+										<?php esc_html_e( 'More Arguments', 'wporg' ); ?>
+									</summary>
+									<span class="description"><?php echo wp_kses_post( $extra['content'] ); ?></span>
+								</details>
+							<?php else : ?>
+								<span class="description"><?php echo wp_kses_post( $param['content'] ); ?></span>
+							<?php endif; ?>
 						<?php endif; ?>
 					</div>
 					<?php if ( ! empty( $param['default'] ) ) : ?>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1197,6 +1197,15 @@
 				margin: 1rem 0 0.5rem;
 			}
 
+			.extended-description {
+				margin: 1.5em 0 1.5em 1.2em;
+
+				summary + .description {
+					display: block;
+					margin-top: 1em;
+				}
+			}
+
 			.type,
 			.required {
 				margin: 0 4px;

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1204,6 +1204,11 @@
 					display: block;
 					margin-top: 1em;
 				}
+
+				summary {
+					color: #21759b;
+					text-decoration: underline;
+				}
 			}
 
 			.type,

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1691,6 +1691,29 @@ img {
   margin: 1rem 0 0.5rem;
 }
 
+.devhub-wrap .wp-parser-class .parameters .extended-description,
+.devhub-wrap .wp-parser-class .return .extended-description,
+.devhub-wrap .wp-parser-function .parameters .extended-description,
+.devhub-wrap .wp-parser-function .return .extended-description,
+.devhub-wrap .wp-parser-hook .parameters .extended-description,
+.devhub-wrap .wp-parser-hook .return .extended-description,
+.devhub-wrap .wp-parser-method .parameters .extended-description,
+.devhub-wrap .wp-parser-method .return .extended-description {
+  margin: 1.5em 0 1.5em 1.2em;
+}
+
+.devhub-wrap .wp-parser-class .parameters .extended-description summary + .description,
+.devhub-wrap .wp-parser-class .return .extended-description summary + .description,
+.devhub-wrap .wp-parser-function .parameters .extended-description summary + .description,
+.devhub-wrap .wp-parser-function .return .extended-description summary + .description,
+.devhub-wrap .wp-parser-hook .parameters .extended-description summary + .description,
+.devhub-wrap .wp-parser-hook .return .extended-description summary + .description,
+.devhub-wrap .wp-parser-method .parameters .extended-description summary + .description,
+.devhub-wrap .wp-parser-method .return .extended-description summary + .description {
+  display: block;
+  margin-top: 1em;
+}
+
 .devhub-wrap .wp-parser-class .parameters .type,
 .devhub-wrap .wp-parser-class .parameters .required,
 .devhub-wrap .wp-parser-class .return .type,

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1714,6 +1714,18 @@ img {
   margin-top: 1em;
 }
 
+.devhub-wrap .wp-parser-class .parameters .extended-description summary,
+.devhub-wrap .wp-parser-class .return .extended-description summary,
+.devhub-wrap .wp-parser-function .parameters .extended-description summary,
+.devhub-wrap .wp-parser-function .return .extended-description summary,
+.devhub-wrap .wp-parser-hook .parameters .extended-description summary,
+.devhub-wrap .wp-parser-hook .return .extended-description summary,
+.devhub-wrap .wp-parser-method .parameters .extended-description summary,
+.devhub-wrap .wp-parser-method .return .extended-description summary {
+  color: #21759b;
+  text-decoration: underline;
+}
+
 .devhub-wrap .wp-parser-class .parameters .type,
 .devhub-wrap .wp-parser-class .parameters .required,
 .devhub-wrap .wp-parser-class .return .type,


### PR DESCRIPTION
Quick WIP version. See #95.

Before, on the get_terms() function reference:
<img width="1092" alt="Screen Shot 2022-06-08 at 4 13 40 pm" src="https://user-images.githubusercontent.com/7200686/172544761-491de5bf-f0d3-44a6-b3db-40bb97caaf01.png">

After, collapsed (detail/summary tag - note the teeny tiny triangle):
<img width="1011" alt="Screen Shot 2022-06-08 at 4 15 11 pm" src="https://user-images.githubusercontent.com/7200686/172545485-4bbc0c96-36a5-41ab-b4c2-673a8bc7d759.png">

After, expanded:
<img width="1005" alt="Screen Shot 2022-06-08 at 4 15 25 pm" src="https://user-images.githubusercontent.com/7200686/172545535-ef2d99a6-03f9-4aa7-b4b2-506d0c3b8874.png">

Before, on get_posts(). Note that this one has a few arguments explicitly documented:
<img width="979" alt="Screen Shot 2022-06-08 at 4 21 35 pm" src="https://user-images.githubusercontent.com/7200686/172546064-a6b32bc1-8c5d-4998-8d88-c5f03f6e9e7c.png">

After, collapsed:
<img width="965" alt="Screen Shot 2022-06-08 at 4 21 51 pm" src="https://user-images.githubusercontent.com/7200686/172546227-e502eba8-427b-49ad-ad22-3e2ffcae0b4f.png">

After, expanded (note that it still has the explicit docs first, I haven't hidden that):
<img width="988" alt="Screen Shot 2022-06-08 at 4 22 28 pm" src="https://user-images.githubusercontent.com/7200686/172546334-1b02b7a3-4d27-4626-98ed-d7cbc1d3426a.png">

There are definitely some improvements needed especially on the front-end. But this seems to work pretty well at recursing through and finding the correct array. For example it works with multiple levels of indirection, like `wp_count_terms($args) -> get_terms($args) -> WP_Term_Query::__construct($query)`.

