### PR TITLE
Mark some code-like items as code.

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -691,7 +691,7 @@ class DevHub_Formatting {
 			$piece = preg_replace( "/(([\w'\[\]]+\|)+[\w'\[\]]+)/", '<code>$1</code>', $piece, -1 );
 
 			// Quoted strings.
-			$piece = preg_replace( "/('[^']{0,20}')/", '<code>$1</code>', $piece, -1 );
+			$piece = preg_replace( "/('[^' ]*')/", '<code>$1</code>', $piece, -1 );
 
 			// Replace ###PARAM### too.
 			// Example: http://localhost:8888/reference/hooks/password_change_email/

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -684,12 +684,20 @@ class DevHub_Formatting {
 			return $text;
 		}
 
-		$textarr = preg_split( '/(<[^<>]+>)/', $text, -1, PREG_SPLIT_DELIM_CAPTURE ); // split out HTML tags
-		$text    = '';
+		$textarr     = preg_split( '/(<[^<>]+>)/', $text, -1, PREG_SPLIT_DELIM_CAPTURE ); // split out HTML tags
+		$text        = '';
+		$within_code = false;
 		foreach ( $textarr as $piece ) {
 			// HTML tags are untouched.
-			if ( str_starts_with( $piece, '<' ) ) {
+			if ( str_starts_with( $piece, '<' ) || $within_code ) {
 				$text .= $piece;
+
+				if ( str_starts_with( $piece, '</code' ) ) {
+					$within_code = false;
+				} elseif ( ! $within_code ) {
+					$within_code = str_starts_with( $piece, '<code' );
+				}
+
 				continue;
 			}
 

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -684,6 +684,7 @@ class DevHub_Formatting {
 			// HTML tags are untouched.
 			if ( str_starts_with( $piece, '<' ) ) {
 				$text .= $piece;
+				continue;
 			}
 
 			// Pipe delimited types inline.

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -39,11 +39,12 @@ class DevHub_Formatting {
 		add_filter( 'devhub-format-description', array( __CLASS__, 'autolink_references' ) );
 		add_filter( 'devhub-format-description', array( __CLASS__, 'fix_param_hash_formatting' ), 9 );
 		add_filter( 'devhub-format-description', array( __CLASS__, 'fix_param_description_html_as_code' ) );
+		add_filter( 'devhub-format-description', array( __CLASS__, 'fix_param_description_quotes_to_code' ) );
 		add_filter( 'devhub-format-description', array( __CLASS__, 'convert_lists_to_markup' ) );
-		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'fix_param_description_quotes_to_code' ) );
 
 		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'autolink_references' ) );
 		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'fix_param_description_parsedown_bug' ) );
+		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'fix_param_description_quotes_to_code' ) );
 		add_filter( 'devhub-format-hash-param-description', array( __CLASS__, 'convert_lists_to_markup' ) );
 
 		add_filter( 'devhub-function-return-type', array( __CLASS__, 'autolink_references' ) );
@@ -678,6 +679,11 @@ class DevHub_Formatting {
 	 * @return string
 	 */
 	public static function fix_param_description_quotes_to_code( $text ) {
+		// Don't do anything if this is a hash notation string.
+		if ( ! $text || str_starts_with( $text, '{' ) || str_contains( $text, '<ul class="param-hash">' ) ) {
+			return $text;
+		}
+
 		$textarr = preg_split( '/(<[^<>]+>)/', $text, -1, PREG_SPLIT_DELIM_CAPTURE ); // split out HTML tags
 		$text    = '';
 		foreach ( $textarr as $piece ) {


### PR DESCRIPTION
This PR marks up some code-like references as code.

| Before | After |
| --- | --- |
| Hash placeholders |
| <img width="647" alt="Screen Shot 2022-06-08 at 6 15 04 pm" src="https://user-images.githubusercontent.com/767313/172567228-3e7764c4-f12d-428e-ab29-ddbc1f7b5c1e.png"> | <img width="662" alt="Screen Shot 2022-06-08 at 6 15 25 pm" src="https://user-images.githubusercontent.com/767313/172567248-dcf6609a-c5f6-4836-941f-c0357f562290.png"> |
| Pipe delimited types |
|  <img width="748" alt="Screen Shot 2022-06-08 at 6 16 25 pm" src="https://user-images.githubusercontent.com/767313/172567429-92896b17-c3eb-4b27-b16f-203ea98c4b90.png"> | <img width="809" alt="Screen Shot 2022-06-08 at 6 16 31 pm" src="https://user-images.githubusercontent.com/767313/172567444-cdffeede-d6cb-44d0-ae25-22051f9aabfe.png"> |
| 'Quoted' strings. | I admit this one can look loud in some areas. |
| <img width="970" alt="Screen Shot 2022-06-08 at 6 17 17 pm" src="https://user-images.githubusercontent.com/767313/172567786-e23c1848-74a3-48d0-9309-f4fae96d0551.png"> | <img width="1016" alt="Screen Shot 2022-06-08 at 6 17 28 pm" src="https://user-images.githubusercontent.com/767313/172567718-ccf16643-613c-4d6d-a81e-6b871024f7a7.png"> |

 