### PR TITLE
Code Syntax Block: Iterate on expand/collapse button

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/user-content.php
+++ b/source/wp-content/themes/wporg-developer/inc/user-content.php
@@ -176,8 +176,8 @@ class DevHub_User_Submitted_Content {
 				array(
 					'copy'   => __( 'Copy', 'wporg' ),
 					'copied' => __( 'Code copied', 'wporg' ),
-					'expand'   => __( 'Expand full source code', 'wporg' ),
-					'collapse' => __( 'Collapse source code', 'wporg' ),
+					'expand'   => __( 'Expand code', 'wporg' ),
+					'collapse' => __( 'Collapse code', 'wporg' ),
 				)
 			);
 

--- a/source/wp-content/themes/wporg-developer/inc/user-content.php
+++ b/source/wp-content/themes/wporg-developer/inc/user-content.php
@@ -176,6 +176,8 @@ class DevHub_User_Submitted_Content {
 				array(
 					'copy'   => __( 'Copy', 'wporg' ),
 					'copied' => __( 'Code copied', 'wporg' ),
+					'expand'   => __( 'Expand full source code', 'wporg' ),
+					'collapse' => __( 'Collapse source code', 'wporg' ),
 				)
 			);
 

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -13,13 +13,13 @@ jQuery( function ( $ ) {
 
 	function collapseCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.expand );
-		$element.data( 'is-expanded', false );
+		$button.attr( 'aria-expanded', 'false' );
 		$element.css( { height: MIN_HEIGHT + 'px' } );
 	}
 
 	function expandCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.collapse );
-		$element.data( 'is-expanded', true );
+		$button.attr( 'aria-expanded', 'true' );
 		$element.css( { height: $element.data( 'height' ) + 'px' } );
 	}
 
@@ -65,7 +65,7 @@ jQuery( function ( $ ) {
 			const $expandButton = $( document.createElement( 'button' ) );
 			$expandButton.addClass( 'button-link' );
 			$expandButton.on( 'click', function () {
-				if ( $element.data( 'is-expanded' ) ) {
+				if ( 'true' === $expandButton.attr( 'aria-expanded' ) ) {
 					collapseCodeBlock( $element, $expandButton );
 				} else {
 					expandCodeBlock( $element, $expandButton );

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -14,13 +14,16 @@ jQuery( function ( $ ) {
 	function collapseCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.expand );
 		$button.attr( 'aria-expanded', 'false' );
+		// This uses `css()` instead of `height()` to prevent jQuery from adding
+		// in the padding. We want to add in just the top padding, since the
+		// bottom is intentionally cut off.
 		$element.css( { height: MIN_HEIGHT + 'px' } );
 	}
 
 	function expandCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.collapse );
 		$button.attr( 'aria-expanded', 'true' );
-		$element.css( { height: $element.data( 'height' ) + 'px' } );
+		$element.height( $element.data( 'height' ) );
 	}
 
 	// For each code block, add the copy button & expanding functionality.

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -5,83 +5,81 @@
  * Handles all interactivity on the single function page
  */
 
+// eslint-disable-next-line id-length -- $ OK.
 jQuery( function ( $ ) {
-	let $usesList, $usedByList, $showMoreUses, $hideMoreUses, $showMoreUsedBy, $hideMoreUsedBy;
-	let $sourceCollapsedHeight;
+	// 22.5px (line height) * 10 for 10 lines + 15px top padding + 10px extra.
+	// The extra 10px added to partially show next line so it's clear there is more.
+	const MIN_HEIGHT = 22.5 * 10 + 15 + 10;
 
-	function onLoad() {
-		sourceCodeHighlightInit();
-
-		toggleUsageListInit();
+	function collapseCodeBlock( $element, $button ) {
+		$button.text( wporgFunctionReferenceI18n.expand );
+		$element.data( 'is-expanded', false );
+		$element.css( { height: MIN_HEIGHT + 'px' } );
 	}
 
-	function sourceCodeHighlightInit() {
-		// We require the Prism javascript library
-		if ( undefined === window.Prism ) {
-			return;
-		}
-
-		// 1em (margin) + 10 * 17px + 10. Lines are 1.1em which rounds to 17px: calc( 1em + 17px * 10 + 10 ).
-		// Extra 10px added to partially show next line so it's clear there is more.
-		$sourceCollapsedHeight = 196;
-		sourceCodeDisplay();
+	function expandCodeBlock( $element, $button ) {
+		$button.text( wporgFunctionReferenceI18n.collapse );
+		$element.data( 'is-expanded', true );
+		$element.css( { height: $element.data( 'height' ) + 'px' } );
 	}
 
-	function sourceCodeDisplay( element ) {
-		let sourceCode = [];
-		if ( element !== undefined ) {
-			// Find table inside a specific source code element if passed.
-			sourceCode = $( '.source-content', element ).find( 'pre' );
-		} else {
-			// Find table inside all source code elements.
-			sourceCode = $( '.source-content' ).find( 'pre' );
-		}
+	// For each code block, add the copy button & expanding functionality.
+	$( '.wp-block-code' ).each( function ( i, element ) {
+		const $element = $( element );
+		let timeoutId;
 
-		if ( ! sourceCode.length ) {
-			return;
-		}
-
-		sourceCode.each( function () {
-			if ( $sourceCollapsedHeight - 12 < $( this ).height() ) {
-				const sourceContent = $( this ); //.closest( '.wp-block-code' );
-
-				// Do this with javascript so javascript-less can enjoy the total sourcecode
-				sourceContent.css( {
-					height: $sourceCollapsedHeight + 'px',
-				} );
-
-				sourceContent.next( '.source-code-links' ).find( 'span:first' ).show();
-				sourceContent.parent().find( '.show-complete-source' ).show();
-				sourceContent
-					.parent()
-					.find( '.show-complete-source' )
-					.off( 'click.togglesource' )
-					.on( 'click.togglesource', toggleCompleteSource );
-				sourceContent
-					.parent()
-					.find( '.less-complete-source' )
-					.off( 'click.togglesource' )
-					.on( 'click.togglesource', toggleCompleteSource );
+		const $copyButton = $( document.createElement( 'button' ) );
+		$copyButton.text( wporgFunctionReferenceI18n.copy );
+		$copyButton.on( 'click', function () {
+			clearTimeout( timeoutId );
+			const code = $element.find( 'code' ).text();
+			if ( ! code ) {
+				return;
 			}
+
+			// This returns a promise which will resolve if the copy suceeded,
+			// and we can set the button text to tell the user it worked.
+			// We don't do anything if it fails.
+			window.navigator.clipboard.writeText( code ).then( function () {
+				$copyButton.text( wporgFunctionReferenceI18n.copied );
+				wp.a11y.speak( wporgFunctionReferenceI18n.copied );
+
+				// After 5 seconds, reset the button text.
+				timeoutId = setTimeout( function () {
+					$copyButton.text( wporgFunctionReferenceI18n.copy );
+				}, 5000 );
+			} );
 		} );
-	}
 
-	function toggleCompleteSource( event ) {
-		event.preventDefault();
+		const $container = $( document.createElement( 'div' ) );
+		$container.addClass( 'wp-code-block-button-container' );
 
-		const sourceContent = $( this ).closest( '.source-content' ).find( 'pre' );
-		let heightGoal = 0;
+		$container.append( $copyButton );
 
-		if ( $( this ).parent().find( '.show-complete-source' ).is( ':visible' ) ) {
-			heightGoal = sourceContent.find( 'code' ).height() + 45; // takes into consideration potential x-scrollbar
-		} else {
-			heightGoal = $sourceCollapsedHeight;
+		// Check code block height, and if it's larger, add in the collapse
+		// button, and set it to be collapsed differently.
+		const originalHeight = $element.height();
+		if ( originalHeight > MIN_HEIGHT ) {
+			$element.data( 'height', originalHeight );
+
+			const $expandButton = $( document.createElement( 'button' ) );
+			$expandButton.addClass( 'button-link' );
+			$expandButton.on( 'click', function () {
+				if ( $element.data( 'is-expanded' ) ) {
+					collapseCodeBlock( $element, $expandButton );
+				} else {
+					expandCodeBlock( $element, $expandButton );
+				}
+			} );
+
+			collapseCodeBlock( $element, $expandButton );
+			$container.append( $expandButton );
 		}
 
-		sourceContent.animate( { height: heightGoal + 'px' } );
+		$element.prepend( $container );
+	} );
 
-		$( this ).parent().find( 'a' ).toggle();
-	}
+	let $usesList, $usedByList, $showMoreUses, $hideMoreUses, $showMoreUsedBy, $hideMoreUsedBy;
 
 	function toggleUsageListInit() {
 		// We only expect one used_by and uses per document
@@ -122,43 +120,4 @@ jQuery( function ( $ ) {
 	}
 
 	toggleUsageListInit();
-
-	// Inject the "copy" button into every code block.
-	$( '.wp-block-code' ).each( function ( i, element ) {
-		const $element = $( element );
-		let timeoutId;
-
-		const $button = $( document.createElement( 'button' ) );
-		$button.text( wporgFunctionReferenceI18n.copy );
-		$button.on( 'click', function () {
-			clearTimeout( timeoutId );
-			const $code = $element.find( 'code' );
-			let code = $code.text();
-			if ( ! code ) {
-				return;
-			}
-
-			// For single-line shell scripts, trim off the initial `$ `, if exists.
-			if ( 'shell' === $code.attr( 'lang' ) && code.startsWith( '$ ' ) && ! code.includes( '\n' ) ) {
-				code = code.slice( 2 );
-			}
-
-			// This returns a promise which will resolve if the copy suceeded,
-			// and we can set the button text to tell the user it worked.
-			// We don't do anything if it fails.
-			window.navigator.clipboard.writeText( code ).then( function () {
-				$button.text( wporgFunctionReferenceI18n.copied );
-				wp.a11y.speak( wporgFunctionReferenceI18n.copied );
-
-				// After 5 seconds, reset the button text.
-				timeoutId = setTimeout( function () {
-					$button.text( wporgFunctionReferenceI18n.copy );
-				}, 5000 );
-			} );
-		} );
-
-		$element.prepend( $button );
-	} );
-
-	$( onLoad );
 } );

--- a/source/wp-content/themes/wporg-developer/reference/template-source.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-source.php
@@ -44,10 +44,6 @@ if ( ! empty( $source_file ) ) :
 			?>
 
 			<p class="source-code-links">
-				<span>
-					<a href="#" class="show-complete-source"><?php _e( 'Expand full source code', 'wporg' ); ?></a>
-					<a href="#" class="less-complete-source"><?php _e( 'Collapse full source code', 'wporg' ); ?></a>
-				</span>
 				<span><a href="<?php echo get_source_file_link(); ?>"><?php _e( 'View on Trac', 'wporg' ); ?></a></span>
 				<span><a href="<?php echo get_github_source_file_link(); ?>"><?php _e( 'View on GitHub', 'wporg' ); ?></a></span>
 			</p>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1343,13 +1343,6 @@
 			&:last-of-type {
 				border-right: none;
 			}
-
-			&:first-child {
-				display: none;
-				border-left: 0;
-				margin-left: 1em;
-				padding-left: 0;
-			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -28,6 +28,8 @@ pre[class*="language-"] {
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
+
+	transition: height 500ms;
 }
 
 /* Code blocks */
@@ -210,17 +212,24 @@ pre.line-numbers > code {
 pre.wp-block-code {
 	position: relative;
 
-	> button {
+	> .wp-code-block-button-container {
 		display: none;
 		position: absolute;
 		top: 1rem;
 		right: 1rem;
-		font-size: 1.4rem;
 		z-index: 2;
+
+		button {
+			font-size: 1.4rem;
+		}
+
+		button + button {
+			margin-left: 0.5em;
+		}
 	}
 
-	&:hover > button,
-	&:focus-within > button {
+	&:hover > .wp-code-block-button-container,
+	&:focus-within > .wp-code-block-button-container {
 		display: revert;
 	}
 }

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -1892,13 +1892,6 @@ img {
   border-right: none;
 }
 
-.devhub-wrap .source-code-links span:first-child {
-  display: none;
-  border-left: 0;
-  margin-left: 1em;
-  padding-left: 0;
-}
-
 .devhub-wrap .source-code-container {
   overflow-x: auto;
   overflow-y: hidden;

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -23,6 +23,7 @@ pre[class*="language-"] {
   -moz-hyphens: none;
   -ms-hyphens: none;
   hyphens: none;
+  transition: height 500ms;
 }
 
 /* Code blocks */
@@ -200,16 +201,23 @@ pre.wp-block-code {
   position: relative;
 }
 
-pre.wp-block-code > button {
+pre.wp-block-code > .wp-code-block-button-container {
   display: none;
   position: absolute;
   top: 1rem;
   right: 1rem;
-  font-size: 1.4rem;
   z-index: 2;
 }
 
-pre.wp-block-code:hover > button,
-pre.wp-block-code:focus-within > button {
+pre.wp-block-code > .wp-code-block-button-container button {
+  font-size: 1.4rem;
+}
+
+pre.wp-block-code > .wp-code-block-button-container button + button {
+  margin-left: 0.5em;
+}
+
+pre.wp-block-code:hover > .wp-code-block-button-container,
+pre.wp-block-code:focus-within > .wp-code-block-button-container {
   display: revert;
 }


### PR DESCRIPTION
This PR refactors the collapse/expand functionality. It moves the button up into a group with the "copy" button, so it appears before the code, and clicking it doesn't move your focus out off the bottom of the screen. This also switches the two links to a single real `button`, for better keyboard behavior.

This also fixes the uses/used by toggles (https://github.com/WordPress/wporg-developer/pull/37#issuecomment-1149576182), something in trunk broke the JS connection there.

| Production | Trunk | PR |
|------------|-------|----|
| ![production](https://user-images.githubusercontent.com/541093/172700420-ad828c4f-40a5-4dfa-a53c-d62f23b70515.png) | ![before](https://user-images.githubusercontent.com/541093/172700419-1a2af887-3fc9-483f-9d34-ef3a5c472f65.png) | ![after](https://user-images.githubusercontent.com/541093/172700416-7546f287-b7fe-490e-9f71-1759b3cb87d8.png)<br /><br />Hover<br /> ![after-hover](https://user-images.githubusercontent.com/541093/172701842-b24455d6-fdb5-406b-b42c-677120b668a0.png) |

Any code example more than 10 lines has the expand button now:

<img width="895" alt="Screen Shot 2022-06-08 at 3 36 49 PM" src="https://user-images.githubusercontent.com/541093/172702477-e4f687e8-a650-4d3d-8618-dd1b9c41950a.png">

Screencast of it in use:

https://user-images.githubusercontent.com/541093/172700358-f9421168-50de-48ca-ba19-82d4bf9b9464.mp4