### PR TITLE
Fix class/method embeds

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/registrations.php
+++ b/source/wp-content/themes/wporg-developer/inc/registrations.php
@@ -74,10 +74,11 @@ class DevHub_Registrations {
 			'show_in_rest' => true,
 		) );
 
-		// Methods
+		// Rewrite rules. The more specific rules like `/embed` must be first, to override the more generic rules.
 		add_rewrite_rule( 'reference/classes/page/([0-9]{1,})/?$', 'index.php?post_type=wp-parser-class&paged=$matches[1]', 'top' );
-		add_rewrite_rule( 'reference/classes/([^/]+)/(?!embed)([^/]+)/?$', 'index.php?post_type=wp-parser-method&name=$matches[1]-$matches[2]', 'top' );
-		add_rewrite_rule( 'reference/classes/([^/]+)/(?!embed)([^/]+)/embed/?$', 'index.php?post_type=wp-parser-method&name=$matches[1]-$matches[2]&embed=true', 'top' );
+		add_rewrite_rule( 'reference/classes/([^/]+)/embed/?$', 'index.php?post_type=wp-parser-class&name=$matches[1]&embed=true', 'top' );
+		add_rewrite_rule( 'reference/classes/([^/]+)/([^/]+)/embed/?$', 'index.php?post_type=wp-parser-method&name=$matches[1]-$matches[2]&embed=true', 'top' );
+		add_rewrite_rule( 'reference/classes/([^/]+)/([^/]+)/?$', 'index.php?post_type=wp-parser-method&name=$matches[1]-$matches[2]', 'top' );
 
 		// Classes
 		register_post_type( 'wp-parser-class', array(

--- a/source/wp-content/themes/wporg-developer/inc/registrations.php
+++ b/source/wp-content/themes/wporg-developer/inc/registrations.php
@@ -76,7 +76,8 @@ class DevHub_Registrations {
 
 		// Methods
 		add_rewrite_rule( 'reference/classes/page/([0-9]{1,})/?$', 'index.php?post_type=wp-parser-class&paged=$matches[1]', 'top' );
-		add_rewrite_rule( 'reference/classes/([^/]+)/([^/]+)/?$', 'index.php?post_type=wp-parser-method&name=$matches[1]-$matches[2]', 'top' );
+		add_rewrite_rule( 'reference/classes/([^/]+)/(?!embed)([^/]+)/?$', 'index.php?post_type=wp-parser-method&name=$matches[1]-$matches[2]', 'top' );
+		add_rewrite_rule( 'reference/classes/([^/]+)/(?!embed)([^/]+)/embed/?$', 'index.php?post_type=wp-parser-method&name=$matches[1]-$matches[2]&embed=true', 'top' );
 
 		// Classes
 		register_post_type( 'wp-parser-class', array(


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-developer/issues/35

1. checkout branch
2. visit `wp-admin/options-permalink.php` or `wp rewrite flush`
3. open `/reference/classes/wp_query/get/embed/`
3. open `/reference/classes/wp_query/embed/`
