### PR TITLE
Fix/67 partial highlighting

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1451,7 +1451,7 @@ namespace DevHub {
 		// Get the source code stored in post meta.
 		$meta_key = '_wp-parser_source_code';
 		if ( ! $force_parse && $source_code = get_post_meta( $post_id, $meta_key, true ) ) {
-			return $source_code;
+			return '<?' . $source_code;
 		}
 
 		/* Source code hasn't been stored in post meta, so parse source file to get it. */
@@ -1494,7 +1494,7 @@ namespace DevHub {
 
 		update_post_meta( $post_id, $meta_key, addslashes( $source_code ) );
 
-		return $source_code;
+		return '<?' . $source_code;
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -143,6 +143,12 @@ jQuery( function ( $ ) {
 				code = code.slice( 2 );
 			}
 
+			// For PHP scripts, trim off the initial `<?`, if exists.
+			// See https://github.com/WordPress/wporg-developer/issues/67
+			if ( 'php' === $code.attr( 'lang' ) && code.startsWith( '<?' ) && ! code.startsWith( '<?php' ) ) {
+				code = code.slice( 2 );
+			}
+
 			// This returns a promise which will resolve if the copy suceeded,
 			// and we can set the button text to tell the user it worked.
 			// We don't do anything if it fails.

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -226,6 +226,6 @@ pre.wp-block-code {
 }
 
 /* Workaround for partial highlighting. See https://github.com/WordPress/wporg-developer/issues/67 */
-code.language-php > span.token.language-php:first-child > span.token.delimiter.important:first-child {
+section.source-content code > span.token.language-php:first-child > span.token.delimiter.important:first-child {
 	display: none;
 }

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -224,3 +224,8 @@ pre.wp-block-code {
 		display: revert;
 	}
 }
+
+/* Workaround for partial highlighting. See https://github.com/WordPress/wporg-developer/issues/67 */
+code.language-php > span.token.language-php:first-child > span.token.delimiter.important:first-child {
+	display: none;
+}

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -213,3 +213,8 @@ pre.wp-block-code:hover > button,
 pre.wp-block-code:focus-within > button {
   display: revert;
 }
+
+/* Workaround for partial highlights */
+code.language-php > span.token.language-php:first-child > span.token.delimiter.important:first-child {
+  display: none;
+}

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -214,7 +214,7 @@ pre.wp-block-code:focus-within > button {
   display: revert;
 }
 
-/* Workaround for partial highlights */
-code.language-php > span.token.language-php:first-child > span.token.delimiter.important:first-child {
+/* Workaround for partial highlighting. See https://github.com/WordPress/wporg-developer/issues/67 */
+section.source-content code > span.token.language-php:first-child > span.token.delimiter.important:first-child {
   display: none;
 }


### PR DESCRIPTION
See #67 

This takes a hackyish approach and prepends `<?` to all function/method/source previews, which forces it into PHP mode.

Unfortunately I don't see this as being a use-case that would be fixed upstream, as most uses would be highlighting `<?php` within a html highlighted block (which is what is happening here) rather than assuming there's a hidden `<?php` tag.

The major downside of this approach is that the `<?` is displayed prior to the syntax highlighting on load, causing the first line to jump slightly after a few milliseconds as the HTML elements are added and then it's hidden.

It might be possible to do this same thing, but dynamically prepend `<?` in JS when it's parsing.. 

| Before | After |
| --- | --- |
| <img width="673" alt="Screen Shot 2022-06-09 at 2 06 33 pm" src="https://user-images.githubusercontent.com/767313/172762027-5692844e-fdb1-4afb-90dd-aa6feab70138.png"> | <img width="673" alt="Screen Shot 2022-06-09 at 2 05 53 pm" src="https://user-images.githubusercontent.com/767313/172761963-70aa0aaa-69e6-4c24-bf3e-f0c5cf64900e.png"> |
| non-affected code blocks still work |
| <img width="911" alt="Screen Shot 2022-06-09 at 2 06 54 pm" src="https://user-images.githubusercontent.com/767313/172762065-5e7eadb2-7295-4718-85df-da9ce21de7f4.png"> | <img width="911" alt="Screen Shot 2022-06-09 at 2 06 54 pm" src="https://user-images.githubusercontent.com/767313/172762065-5e7eadb2-7295-4718-85df-da9ce21de7f4.png">  |