### PR TITLE
Code Syntax Block: Fix button style and adjust its behavior

### DIFF
--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -7,9 +7,9 @@
 
 // eslint-disable-next-line id-length -- $ OK.
 jQuery( function ( $ ) {
-	// 22.5px (line height) * 10 for 10 lines + 15px top padding + 10px extra.
+	// 22.5px (line height) * 10 for 10 lines + 15px top padding + 45px button height + 10px extra.
 	// The extra 10px added to partially show next line so it's clear there is more.
-	const MIN_HEIGHT = 22.5 * 10 + 15 + 10;
+	const MIN_HEIGHT = 22.5 * 10 + 15 + 45 + 10;
 
 	function collapseCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.expand );

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -7,9 +7,9 @@
 
 // eslint-disable-next-line id-length -- $ OK.
 jQuery( function ( $ ) {
-	// 22.5px (line height) * 10 for 10 lines + 15px top padding + 45px button height + 10px extra.
+	// 22.5px (line height) * 15 for 15 lines + 15px top padding + 45px button height + 10px extra.
 	// The extra 10px added to partially show next line so it's clear there is more.
-	const MIN_HEIGHT = 22.5 * 10 + 15 + 45 + 10;
+	const MIN_HEIGHT = 22.5 * 15 + 15 + 45 + 10;
 
 	function collapseCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.expand );

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -23,7 +23,9 @@ jQuery( function ( $ ) {
 	function expandCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.collapse );
 		$button.attr( 'aria-expanded', 'true' );
-		$element.height( $element.data( 'height' ) );
+		// 45px: button height.
+		// { height: auto; } can't be used here or the transition effect won't work.
+		$element.height( $element.data( 'height' ) + 45 );
 	}
 
 	// For each code block, add the copy button & expanding functionality.

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -7,9 +7,9 @@
 
 // eslint-disable-next-line id-length -- $ OK.
 jQuery( function ( $ ) {
-	// 22.5px (line height) * 15 for 15 lines + 15px top padding + 45px button height + 10px extra.
+	// 22.5px (line height) * 15 for 15 lines + 15px top padding + 10px extra.
 	// The extra 10px added to partially show next line so it's clear there is more.
-	const MIN_HEIGHT = 22.5 * 15 + 15 + 45 + 10;
+	const MIN_HEIGHT = 22.5 * 15 + 15 + 10;
 
 	function collapseCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.expand );
@@ -23,9 +23,8 @@ jQuery( function ( $ ) {
 	function expandCodeBlock( $element, $button ) {
 		$button.text( wporgFunctionReferenceI18n.collapse );
 		$button.attr( 'aria-expanded', 'true' );
-		// 45px: button height.
 		// { height: auto; } can't be used here or the transition effect won't work.
-		$element.height( $element.data( 'height' ) + 45 );
+		$element.height( $element.data( 'height' ) );
 	}
 
 	// For each code block, add the copy button & expanding functionality.
@@ -68,7 +67,6 @@ jQuery( function ( $ ) {
 			$element.data( 'height', originalHeight );
 
 			const $expandButton = $( document.createElement( 'button' ) );
-			$expandButton.addClass( 'button-link' );
 			$expandButton.on( 'click', function () {
 				if ( 'true' === $expandButton.attr( 'aria-expanded' ) ) {
 					collapseCodeBlock( $element, $expandButton );
@@ -81,7 +79,7 @@ jQuery( function ( $ ) {
 			$container.append( $expandButton );
 		}
 
-		$element.prepend( $container );
+		$element.before( $container );
 	} );
 
 	let $usesList, $usedByList, $showMoreUses, $hideMoreUses, $showMoreUsedBy, $hideMoreUsedBy;

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -212,10 +212,6 @@ pre.line-numbers > code {
 .wp-code-block-button-container {
 	display: flex;
 	justify-content: right;
-	z-index: 2;
-	position: sticky;
-	left: 0;
-	top: 0;
 	padding: 1rem;
 	background: $color-white;
 	border-width: 1px 1px 0;

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -213,11 +213,14 @@ pre.wp-block-code {
 	position: relative;
 
 	> .wp-code-block-button-container {
-		display: none;
-		position: absolute;
-		top: 1rem;
-		right: 1rem;
+		display: flex;
+		justify-content: right;
 		z-index: 2;
+		position: sticky;
+		left: 0;
+		top: 0;
+		visibility: hidden;
+		margin-bottom: 1rem;
 
 		button {
 			font-size: 1.4rem;
@@ -230,6 +233,6 @@ pre.wp-block-code {
 
 	&:hover > .wp-code-block-button-container,
 	&:focus-within > .wp-code-block-button-container {
-		display: revert;
+		visibility: visible;
 	}
 }

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -209,30 +209,35 @@ pre.line-numbers > code {
 }
 
 /* Copy button */
-pre.wp-block-code {
-	position: relative;
+.wp-code-block-button-container {
+	display: flex;
+	justify-content: right;
+	z-index: 2;
+	position: sticky;
+	left: 0;
+	top: 0;
+	padding: 1rem;
+	background: $color-white;
+	border-width: 1px 1px 0;
+	border-style: solid;
+	border-color: get-color(gray-5);
+	border-top-left-radius: 0.3em;
+	border-top-right-radius: 0.3em;
 
-	> .wp-code-block-button-container {
-		display: flex;
-		justify-content: right;
-		z-index: 2;
-		position: sticky;
-		left: 0;
-		top: 0;
-		visibility: hidden;
-		margin-bottom: 1rem;
-
-		button {
-			font-size: 1.4rem;
-		}
-
-		button + button {
-			margin-left: 0.5em;
-		}
+	button {
+		font-size: 1.2rem !important;
 	}
 
-	&:hover > .wp-code-block-button-container,
-	&:focus-within > .wp-code-block-button-container {
-		visibility: visible;
+	button + button {
+		margin-left: 0.5em;
+	}
+
+	+ pre {
+		margin-top: 0;
+		border-width: 0 1px 1px;
+		border-style: solid;
+		border-color: get-color(gray-5);
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
 	}
 }

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -202,11 +202,14 @@ pre.wp-block-code {
 }
 
 pre.wp-block-code > .wp-code-block-button-container {
-  display: none;
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
+  display: flex;
+  justify-content: right;
   z-index: 2;
+  position: sticky;
+  left: 0;
+  top: 0;
+  visibility: hidden;
+  margin-bottom: 1rem;
 }
 
 pre.wp-block-code > .wp-code-block-button-container button {
@@ -219,5 +222,5 @@ pre.wp-block-code > .wp-code-block-button-container button + button {
 
 pre.wp-block-code:hover > .wp-code-block-button-container,
 pre.wp-block-code:focus-within > .wp-code-block-button-container {
-  display: revert;
+  visibility: visible;
 }

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -197,30 +197,35 @@ pre.line-numbers > code {
 }
 
 /* Copy button */
-pre.wp-block-code {
-  position: relative;
-}
-
-pre.wp-block-code > .wp-code-block-button-container {
+.wp-code-block-button-container {
   display: flex;
   justify-content: right;
   z-index: 2;
   position: sticky;
   left: 0;
   top: 0;
-  visibility: hidden;
-  margin-bottom: 1rem;
+  padding: 1rem;
+  background: #fff;
+  border-width: 1px 1px 0;
+  border-style: solid;
+  border-color: #dcdcde;
+  border-top-left-radius: 0.3em;
+  border-top-right-radius: 0.3em;
 }
 
-pre.wp-block-code > .wp-code-block-button-container button {
-  font-size: 1.4rem;
+.wp-code-block-button-container button {
+  font-size: 1.2rem !important;
 }
 
-pre.wp-block-code > .wp-code-block-button-container button + button {
+.wp-code-block-button-container button + button {
   margin-left: 0.5em;
 }
 
-pre.wp-block-code:hover > .wp-code-block-button-container,
-pre.wp-block-code:focus-within > .wp-code-block-button-container {
-  visibility: visible;
+.wp-code-block-button-container + pre {
+  margin-top: 0;
+  border-width: 0 1px 1px;
+  border-style: solid;
+  border-color: #dcdcde;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -200,10 +200,6 @@ pre.line-numbers > code {
 .wp-code-block-button-container {
   display: flex;
   justify-content: right;
-  z-index: 2;
-  position: sticky;
-  left: 0;
-  top: 0;
   padding: 1rem;
   background: #fff;
   border-width: 1px 1px 0;


### PR DESCRIPTION
This PR fixes #99 and increases the number of lines shown based on discussion [here](https://github.com/WordPress/wporg-developer/issues/22#issuecomment-1140675129).

This is how it works currently:
`<= 15 lines, show all` 
`> 15 lines, show expand button`

Note: This PR is based on #100, should be merged after it.

>
> The Copy button is not sticky, but it's also too-sticky.
>
> Scrolling:
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/767313/172580958-77b99154-18b0-440e-9a23-0608e28a4941.gif)
>
> Scrolling and hiding:
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/767313/172580978-4d47f715-77c7-474e-af9e-3087fb7b91dc.gif)

Screenshots of Result:
| apply_filters | password_change_email |
| ------------ | ------------------------- | 
| ![Screen Capture on 2022-06-09 at 22-20-36](https://user-images.githubusercontent.com/18050944/172869890-29afd1ab-e7b8-4799-b2f9-41efd59fe6f2.gif) | ![Screen Capture on 2022-06-09 at 12-37-31](https://user-images.githubusercontent.com/18050944/172765249-cb74fe5a-265b-42ce-825d-b287e0b7d2ef.gif) |

I'm not sure if we still want to make the button show on hover as there's a big empty space when it's not hovered?
Personally I like it to always show in the case there, it'd have better UX and it's friendly for mobile device users.
