### PR TITLE
Trim the consistent leading whitespace tabs/spaces from source blocks.

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1492,6 +1492,14 @@ namespace DevHub {
 			fclose( $handle );
 		}
 
+		// Trim leading whitespace.
+		if ( preg_match_all( "!(?:^|\n)([\t ]*)!", $source_code, $m ) ) {
+			$strip_prefix = min( array_map( 'strlen', array_filter( $m[1] ) ) );
+			if ( $strip_prefix ) {
+				$source_code = preg_replace( "!(^|\n)[\t ]{" . $strip_prefix . "}!", '$1', $source_code );
+			}
+		}
+
 		update_post_meta( $post_id, $meta_key, addslashes( $source_code ) );
 
 		return $source_code;

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1493,19 +1493,10 @@ namespace DevHub {
 		}
 
 		// Trim leading whitespace.
-		if ( preg_match_all( "!^([\t ]*)(.*)$!m", $source_code, $m ) ) {
-			$non_empty_line_prefixes = array_filter(
-				$m[1],
-				function( $index ) use( $m ) {
-					return ! empty( $m[2][ $index ] );
-				},
-				ARRAY_FILTER_USE_KEY
-			);
-			if ( $non_empty_line_prefixes ) {
-				$strip_prefix = min( array_map( 'strlen', $non_empty_line_prefixes ) );
-				if ( $strip_prefix ) {
-					$source_code = preg_replace( "!^[\t ]{" . $strip_prefix . "}!m", '$1', $source_code );
-				}
+		if ( preg_match_all( "!^([\t ]*).+$!m", $source_code, $m ) ) {
+			$strip_prefix = min( array_map( 'strlen', $m[1]) );
+			if ( $strip_prefix ) {
+				$source_code = preg_replace( "!^[\t ]{" . $strip_prefix . "}!m", '$1', $source_code );
 			}
 		}
 

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1494,7 +1494,7 @@ namespace DevHub {
 
 		// Trim leading whitespace.
 		if ( preg_match_all( "!^([\t ]*).+$!m", $source_code, $m ) ) {
-			$strip_prefix = min( array_map( 'strlen', $m[1]) );
+			$strip_prefix = min( array_map( 'strlen', $m[1] ) );
 			if ( $strip_prefix ) {
 				$source_code = preg_replace( "!^[\t ]{" . $strip_prefix . "}!m", '$1', $source_code );
 			}

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1493,10 +1493,19 @@ namespace DevHub {
 		}
 
 		// Trim leading whitespace.
-		if ( preg_match_all( "!(?:^|\n)([\t ]*)!", $source_code, $m ) ) {
-			$strip_prefix = min( array_map( 'strlen', array_filter( $m[1] ) ) );
-			if ( $strip_prefix ) {
-				$source_code = preg_replace( "!(^|\n)[\t ]{" . $strip_prefix . "}!", '$1', $source_code );
+		if ( preg_match_all( "!^([\t ]*)(.*)$!m", $source_code, $m ) ) {
+			$non_empty_line_prefixes = array_filter(
+				$m[1],
+				function( $index ) use( $m ) {
+					return ! empty( $m[2][ $index ] );
+				},
+				ARRAY_FILTER_USE_KEY
+			);
+			if ( $non_empty_line_prefixes ) {
+				$strip_prefix = min( array_map( 'strlen', $non_empty_line_prefixes ) );
+				if ( $strip_prefix ) {
+					$source_code = preg_replace( "!^[\t ]{" . $strip_prefix . "}!m", '$1', $source_code );
+				}
 			}
 		}
 


### PR DESCRIPTION
Some code blocks are indented by a tab or two, and hook source often by a number of tabs.

This PR removes any consistent leading whitespace from hooks/methods/functions (although functions should not have any).

| Before | After |
| --- | --- |
| <img width="936" alt="Screen Shot 2022-06-09 at 3 15 50 pm" src="https://user-images.githubusercontent.com/767313/172771442-7cc53a52-9b47-4ddf-82f3-4cb43bb35e2c.png"> | <img width="915" alt="Screen Shot 2022-06-09 at 3 16 16 pm" src="https://user-images.githubusercontent.com/767313/172771471-31fabbb5-d253-4ff5-bb7e-54400dd8a354.png"> |
|  <img width="947" alt="Screen Shot 2022-06-09 at 3 32 27 pm" src="https://user-images.githubusercontent.com/767313/172771603-df1dd6ff-3e68-47cc-8647-5e0ede71526e.png"> | <img width="919" alt="Screen Shot 2022-06-09 at 3 16 29 pm" src="https://user-images.githubusercontent.com/767313/172771614-cae6435c-8ee6-4233-92f0-c5560fcd4b33.png"> |
| Functions are untouched after [667a4f5](https://github.com/WordPress/wporg-developer/pull/107/commits/667a4f5469667685a1781e44e97afe67d9600ebc) |
| <img width="937" alt="Screen Shot 2022-06-09 at 3 29 57 pm" src="https://user-images.githubusercontent.com/767313/172771651-1c093442-99e4-4f1e-8b65-564d3ae9ddea.png"> |

Testing:
 - Reparse after applying.


 