### PR TITLE
Fix the search display of functions/hooks

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/autocomplete.php
+++ b/source/wp-content/themes/wporg-developer/inc/autocomplete.php
@@ -114,7 +114,9 @@ class DevHub_Search_Form_Autocomplete {
 				if ( in_array( $post->post_type, $post_types_function_like ) ) {
 					$title .= '()';
 				}
-
+		if ( $post->post_type == 'wp-parser-class' ) {
+			$title =  'class ' . $title . ' {}';
+		}
 				$form_data['posts'][ $title ] = $permalink;
 			}
 		}

--- a/source/wp-content/themes/wporg-developer/inc/autocomplete.php
+++ b/source/wp-content/themes/wporg-developer/inc/autocomplete.php
@@ -104,11 +104,18 @@ class DevHub_Search_Form_Autocomplete {
 		$search = get_posts( $args );
 
 		if ( ! empty( $search ) ) {
-			$titles             = wp_list_pluck( $search, 'post_title', 'ID' );
-			$titles             = array_unique( $titles );
-			$titles             = array_flip( $titles );
-			$titles             = array_map( 'get_permalink', $titles );
-			$form_data['posts'] = $titles;
+			$post_types_function_like = array( 'wp-parser-function', 'wp-parser-method' );
+
+			foreach ( $search as $post ) {
+				$permalink = get_permalink( $post->ID );
+				$title     = $post->post_title;
+
+				if ( in_array( $post->post_type, $post_types_function_like ) ) {
+					$title .= '()';
+				}
+
+				$form_data['posts'][ $title ] = $permalink;
+			}
 		}
 
 		wp_send_json_success ( $form_data );

--- a/source/wp-content/themes/wporg-developer/inc/autocomplete.php
+++ b/source/wp-content/themes/wporg-developer/inc/autocomplete.php
@@ -99,6 +99,7 @@ class DevHub_Search_Form_Autocomplete {
 			'orderby'              => '',
 			'search_orderby_title' => 1,
 			'order'                => 'ASC',
+			'_autocomplete_search' => true,
 		);
 
 		$search = get_posts( $args );

--- a/source/wp-content/themes/wporg-developer/inc/search.php
+++ b/source/wp-content/themes/wporg-developer/inc/search.php
@@ -94,11 +94,11 @@ class DevHub_Search {
 		} else {
 			// If user has '()' at end of a search string, assume they want a specific function/method.
 			$s = htmlentities( $query->get( 's' ) );
-			if ( '()' === substr( $s, -2 ) ) {
+			if ( '()' === substr( $s, -2 ) || '(' == substr( $s, -1 ) ) {
 				// Enable exact search.
 				$query->set( 'exact',     true );
 				// Modify the search query to omit the parentheses.
-				$query->set( 's',         substr( $s, 0, -2 ) ); // remove '()'
+				$query->set( 's',         trim( $s, '()' ) );
 				// Restrict search to function-like content.
 				$query->set( 'post_type', array( 'wp-parser-function', 'wp-parser-method' ) );
 			}

--- a/source/wp-content/themes/wporg-developer/inc/search.php
+++ b/source/wp-content/themes/wporg-developer/inc/search.php
@@ -68,7 +68,16 @@ class DevHub_Search {
 	 */
 	public static function pre_get_posts( $query ) {
 		// Don't modify anything if not a non-admin main search query.
-		if ( ! ( ! is_admin() && $query->is_main_query() && $query->is_search() ) ) {
+		if (
+			(
+				// Not the admin
+				is_admin() ||
+				// Not non-main queries / non-searches
+				( ! $query->is_main_query() || ! $query->is_search() )
+			) &&
+			// but yes if it's the autocomplete search (which is admin, and not the main query).
+			! $query->get( '_autocomplete_search' )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #108 

 - Functions/Methods have () appended.
 - Hooks + Functions with the same base-name are both shown
 - Search tweaks are applied, so that () works in the search box

I'm not sure if there's a better way to specify the type of search it is, which is why I went with the `_autocomplete_search` extra param..

| Before | After |
| --- | --- |
| <img width="954" alt="Screen Shot 2022-06-09 at 4 07 34 pm" src="https://user-images.githubusercontent.com/7200686/172776766-e8939537-fe1f-4205-b596-04d4fca6172a.png"> |  <img width="961" alt="Screen Shot 2022-06-09 at 4 47 28 pm" src="https://user-images.githubusercontent.com/767313/172782590-2a8dae8d-1a33-42cb-88bb-257894a42d26.png"> |

 