### PR TITLE
Experiment: Change site-title to  "Developer Resources".

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -629,7 +629,14 @@ namespace DevHub {
 	 * @return string
 	 */
 	function get_site_section_title() {
-		return __( 'Developer Resources', 'wporg' );
+		$parts = explode( '/', $GLOBALS['wp']->request );
+		switch ( $parts[0] ) {
+			case 'resources':
+			case 'resource':
+				return sprintf( __( 'Developer Resources: %s', 'wporg' ), get_the_title() );
+			default:
+				return __( 'Developer Resources', 'wporg' );
+		}
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -620,17 +620,7 @@ namespace DevHub {
 	 * @return string
 	 */
 	function get_site_section_url() {
-		$parts = explode( '/', $GLOBALS['wp']->request );
-		switch ( $parts[0] ) {
-			case 'reference':
-			case 'plugins':
-			case 'themes':
-				return home_url( '/' . $parts[0] . '/' );
-			case 'cli':
-				return home_url( '/cli/commands/' );
-			default:
-				return home_url( '/' );
-		}
+		return home_url( '/' );
 	}
 
 	/**
@@ -639,30 +629,7 @@ namespace DevHub {
 	 * @return string
 	 */
 	function get_site_section_title() {
-		$parts = explode( '/', $GLOBALS['wp']->request );
-		switch ( $parts[0] ) {
-			case 'resources':
-			case 'resource':
-				return sprintf( __( 'Developer Resources: %s', 'wporg' ), get_the_title() );
-			case 'reference':
-				return __( 'Code Reference', 'wporg' );
-			case 'plugins':
-				return __( 'Plugin Handbook', 'wporg' );
-			case 'themes':
-				return __( 'Theme Handbook', 'wporg' );
-			case 'apis':
-				return __( 'Common APIs Handbook', 'wporg' );
-			case 'block-editor':
-				return __( 'Block Editor Handbook', 'wporg' );
-			case 'cli':
-				return __( 'WP-CLI Commands', 'wporg' );
-			case 'coding-standards':
-				return __( 'Coding Standards Handbook', 'wporg' );
-			case 'rest-api':
-				return __( 'REST API Handbook', 'wporg' );
-			default:
-				return __( 'Developer Resources', 'wporg' );
-		}
+		return __( 'Developer Resources', 'wporg' );
 	}
 
 	/**


### PR DESCRIPTION
Source: https://meta.trac.wordpress.org/ticket/5585#comment:1

This PR makes the site title "Developers Resources" for all the subfolders except for `resources` and `resource` since they do not have breadcrumbs. 

