### PR TITLE
Code Blocks: Inject opening PHP tag via Prism hooks before parsing the syntax.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -208,15 +208,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "13.3.0",
+            "version": "13.4.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/13.3.0"
+                "reference": "tags/13.4.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.13.3.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.13.4.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -226,15 +226,15 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "11.0",
+            "version": "11.1-a.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/11.0"
+                "reference": "tags/11.1-a.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.11.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.11.1-a.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -2528,5 +2528,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -130,7 +130,9 @@ jQuery( function ( $ ) {
 	// Runs before the highlight parsing is run.
 	// `env` is defined here: https://github.com/PrismJS/prism/blob/2815f699970eb8387d741e3ac886845ce5439afb/prism.js#L583-L588
 	Prism.hooks.add( 'before-highlight', function ( env ) {
-		if ( 'php' === env.language && ! env.code.startsWith( '<?' ) ) {
+		// If the code starts with `<`, it's either already got an opening tag,
+		// or it starts with HTML. Either way, we don't want to inject here.
+		if ( 'php' === env.language && ! env.code.startsWith( '<' ) ) {
 			env.code = '<? ' + env.code;
 			env.hasAddedTag = true;
 		}

--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -1,4 +1,4 @@
-/* global jQuery, wporgFunctionReferenceI18n */
+/* global jQuery, Prism, wporgFunctionReferenceI18n */
 /**
  * function-reference.js
  *
@@ -85,7 +85,7 @@ jQuery( function ( $ ) {
 	let $usesList, $usedByList, $showMoreUses, $hideMoreUses, $showMoreUsedBy, $hideMoreUsedBy;
 
 	function toggleUsageListInit() {
-		var usesToShow   = $( '#uses-table' ).data( 'show' ),
+		var usesToShow = $( '#uses-table' ).data( 'show' ),
 			usedByToShow = $( '#used-by-table' ).data( 'show' );
 
 		// We only expect one used_by and uses per document
@@ -126,4 +126,23 @@ jQuery( function ( $ ) {
 	}
 
 	toggleUsageListInit();
+
+	// Runs before the highlight parsing is run.
+	// `env` is defined here: https://github.com/PrismJS/prism/blob/2815f699970eb8387d741e3ac886845ce5439afb/prism.js#L583-L588
+	Prism.hooks.add( 'before-highlight', function ( env ) {
+		if ( 'php' === env.language && ! env.code.startsWith( '<?' ) ) {
+			env.code = '<? ' + env.code;
+			env.hasAddedTag = true;
+		}
+	} );
+
+	// Runs before `highlightedCode` is set to the `innerHTML` of the container.
+	Prism.hooks.add( 'before-insert', function ( env ) {
+		if ( env.hasAddedTag ) {
+			env.highlightedCode = env.highlightedCode.replace(
+				'<span class="token delimiter important">&lt;?</span> ',
+				''
+			);
+		}
+	} );
 } );


### PR DESCRIPTION
Alternative to #105, this uses [Prism hooks](https://prismjs.com/extending.html#writing-plugins) to add and remove the initial `<? ` on PHP code (where one doesn't already exist). 

Uses `before-highlight` to inject a `<? ` before running the highlight function, and `before-insert` to remove it from the `highlightedCode` string before injecting it into the DOM.

Fixes #67 

<img width="700" alt="Screen Shot 2022-06-09 at 5 42 04 PM" src="https://user-images.githubusercontent.com/541093/172950174-56f8693f-24c0-499a-9170-42db83954b9a.png">
