### PR TITLE
Add copyable example code at the top of reference pages

### DIFF
--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -10,6 +10,7 @@
 
 	<section class="summary">
 		<?php echo get_summary(); ?>
+		<?php echo get_short_example(); ?>
 	</section>
 
 <?php if ( is_single() ) : ?>


### PR DESCRIPTION
Fixes #23.

This automatically adds some short example code that's easily copyable to the top of the page, right under the summary.

So far it only gives sample code for actions and filters. It probably needs a bit of styling and thought as to exactly where to put it.

Some examples:
<img width="940" alt="Screen Shot 2022-06-10 at 2 37 48 pm" src="https://user-images.githubusercontent.com/7200686/172991339-77c7a677-f257-4307-b088-5db0a472298e.png">
<img width="945" alt="Screen Shot 2022-06-10 at 2 37 41 pm" src="https://user-images.githubusercontent.com/7200686/172991361-a2bd99ba-c2a9-4c60-a299-8a0b8a9fbcf5.png">

Some that could use a bit of tweaking:
<img width="971" alt="Screen Shot 2022-06-10 at 2 37 25 pm" src="https://user-images.githubusercontent.com/7200686/172991429-fb57a6e2-c4dc-4590-b8d2-b86cae04829f.png">
<img width="966" alt="Screen Shot 2022-06-10 at 2 37 33 pm" src="https://user-images.githubusercontent.com/7200686/172991446-f9582901-69ef-4ed3-b370-f50b98af7412.png">

