### PR TITLE
Remove line numbers from short snippets

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -783,6 +783,7 @@ class DevHub_Formatting {
 		// This should account for all languages used in the handbooks.
 		$lang_list = [ 'js', 'json', 'sh', 'bash', 'html', 'css', 'scss', 'php', 'markdown', 'yaml' ];
 		$lang = in_array( $attr['lang'], $lang_list ) ? $attr['lang'] : 'php';
+		$show_line_numbers = substr_count( $content, '<br />' ) > 5; // The content usually has 1-2 extra breaks.
 
 		// Shell is flagged with `sh` or `bash` in the handbooks, but Prism uses `shell`.
 		if ( 'sh' === $lang || 'bash' === $lang ) {
@@ -791,9 +792,11 @@ class DevHub_Formatting {
 
 		return do_blocks(
 			sprintf(
-				'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code"><code lang="%1$s" class="language-%1$s line-numbers">%2$s</code></pre><!-- /wp:code -->',
+				'<!-- wp:code {"lineNumbers":$3$s} --><pre class="wp-block-code"><code lang="%1$s" class="language-%1$s %4$s">%2$s</code></pre><!-- /wp:code -->',
 				$lang,
-				self::_trim_code( $content )
+				self::_trim_code( $content ),
+				$show_line_numbers ? 'true' : 'false',
+				$show_line_numbers ? 'line-numbers' : ''
 			)
 		);
 	}

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -737,7 +737,7 @@ class DevHub_Formatting {
 	/**
 	 * Render the js shortcode using the Code Syntax Block syntax.
 	 *
-	 * This is a workaround for user-submitted code, which used the php shortcode from Syntax Highlighter Evolved.
+	 * This is a workaround for user-submitted code, which used the js shortcode from Syntax Highlighter Evolved.
 	 *
 	 * @param array|string $attr    Shortcode attributes array or empty string.
 	 * @param string       $content Shortcode content.

--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -783,7 +783,10 @@ class DevHub_Formatting {
 		// This should account for all languages used in the handbooks.
 		$lang_list = [ 'js', 'json', 'sh', 'bash', 'html', 'css', 'scss', 'php', 'markdown', 'yaml' ];
 		$lang = in_array( $attr['lang'], $lang_list ) ? $attr['lang'] : 'php';
-		$show_line_numbers = substr_count( $content, '<br />' ) > 5; // The content usually has 1-2 extra breaks.
+
+		$content = self::_trim_code( $content );
+		// Hides numbers if <= 4 lines of code (last line has no linebreak).
+		$show_line_numbers = substr_count( $content, "\n" ) > 3;
 
 		// Shell is flagged with `sh` or `bash` in the handbooks, but Prism uses `shell`.
 		if ( 'sh' === $lang || 'bash' === $lang ) {
@@ -794,7 +797,7 @@ class DevHub_Formatting {
 			sprintf(
 				'<!-- wp:code {"lineNumbers":$3$s} --><pre class="wp-block-code"><code lang="%1$s" class="language-%1$s %4$s">%2$s</code></pre><!-- /wp:code -->',
 				$lang,
-				self::_trim_code( $content ),
+				$content,
 				$show_line_numbers ? 'true' : 'false',
 				$show_line_numbers ? 'line-numbers' : ''
 			)


### PR DESCRIPTION
Fixes #101 

This isn't applied to `reference/template-source.php`, because the line number is important and absolute in that context.

Good pages to test:
* `/coding-standards/wordpress-coding-standards/html/#self-closing-elements`
* `/coding-standards/wordpress-coding-standards/css/#media-queries`
* `/coding-standards/inline-documentation-standards/php/#1-1-parameters-that-are-arrays`
*  `/coding-standards/inline-documentation-standards/javascript/`
* `/reference/hooks/oembed_providers/` (no change)
* `/reference/functions/_register_remote_theme_patterns/` (no change)
