### PR TITLE
Stop floating Table of Contents within content

### DIFF
--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -23,7 +23,7 @@
 			'header_text' => __( 'Contents', 'wporg' )
 		) );
 
-		$content = '<div class="content-toc">' . $TOC->add_toc( $content ) . '</div>';
+		$content = $TOC->add_toc( $content );
 
 	endif;
 	?>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -61,7 +61,7 @@
 	#content-area,
 	.inner-wrap {
 		margin: 2rem auto 0;
-		max-width: 60em;
+		max-width: $devhub-wrap-content-width;
 	}
 
 	.page-header {
@@ -1554,7 +1554,7 @@
 	#content-area.has-sidebar {
 		float: none;
 		margin: 0 auto;
-		width: 60em;
+		width: $devhub-wrap-content-width;
 	}
 
 	.has-sidebar {
@@ -1993,31 +1993,32 @@ aside[id^="nav_menu"] .widget-title {
 }
 
 /** Table of Contents */
-.site-main .table-of-contents {
-	float: right;
-	width: 250px;
-	border: 1px solid #eee;
-	margin: 0 0 15px 15px;
-	z-index: 1;
-	position: relative;
-	color: #555d66;
-	background-color: #fff;
-	box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-	border-radius: 3px;
+.site-main {
+	.table-of-contents {
+		width: 100%;
+		border: 1px solid #eee;
+		margin: 30px 0;
+		z-index: 1;
+		position: relative;
+		color: #555d66;
+		background-color: #fff;
+		box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+		border-radius: 3px;
 
-	@media (min-width: 971px) {
-		margin: 0 -30px 15px 15px;
+		h2 {
+			margin: 0;
+			padding: 0.7rem 1.2rem;
+			font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+			font-size: 1.3em;
+			color: #32373c;
+			text-transform: uppercase;
+			border-bottom: 1px solid #eee;
+			margin-bottom: 0;
+		}
 	}
 
-	h2 {
-		margin: 0;
-		padding: 0.7rem 1.2rem;
-		font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
-		font-size: 1.3em;
-		color: #32373c;
-		text-transform: uppercase;
-		border-bottom: 1px solid #eee;
-		margin-bottom: 0;
+	.summary + .table-of-contents {
+		margin-top: 15px;
 	}
 }
 
@@ -2068,12 +2069,6 @@ aside[id^="nav_menu"] .widget-title {
 .toc-heading a:active::before,
 .toc-heading a:focus::before {
 	color: get-color(blue-50);
-}
-
-@media (max-width: 480px) {
-	.table-of-contents {
-		display: none;
-	}
 }
 
 /** Menu */
@@ -2235,7 +2230,7 @@ div[class*="-table-of-contents-container"] {
 	}
 
 	#content {
-		max-width: 960px;
+		max-width: $single-handbook-content-width;
 		margin: 0 auto;
 		display: flex;
 		padding-top: 0;
@@ -2258,7 +2253,7 @@ div[class*="-table-of-contents-container"] {
 		padding: 4rem 0 4rem 4rem;
 		background: #fff;
 		box-sizing: border-box;
-		width: 72%;
+		width: $single-handbook-content-primary-width * 100%;
 
 		@media (max-width: 876px) {
 			padding: 4rem 20px;
@@ -2442,7 +2437,30 @@ body.responsive-show {
 			}
 		}
 	}
+}
 
+@media (min-width: 94em) {
+	.site-main {
+		.summary + .table-of-contents {
+			position: fixed;
+			width: 250px;
+			top: 180px;
+			left: calc( #{ $devhub-wrap-content-width } + ( ( 100vw - #{ $devhub-wrap-content-width } ) / 2 ) );
+		}
+	}
+}
+
+@media (min-width: 62em) {
+	.site-main .table-of-contents:not(.summary + .table-of-contents) {
+		position: fixed;
+		width: 250px;
+		top: 165px;
+		left: calc(
+			#{ $single-handbook-content-width } * #{ $single-handbook-content-primary-width } 
+			+ ( ( 100vw - #{ $single-handbook-content-width } ) / 2 ) 
+			+ 15px
+		);
+	}
 }
 
 @media ( min-width: 43em ) {

--- a/source/wp-content/themes/wporg-developer/scss/settings/_dimensions.scss
+++ b/source/wp-content/themes/wporg-developer/scss/settings/_dimensions.scss
@@ -1,0 +1,3 @@
+$single-handbook-content-width: 960px;
+$single-handbook-content-primary-width: 0.72;
+$devhub-wrap-content-width: 60em;

--- a/source/wp-content/themes/wporg-developer/scss/settings/_index.scss
+++ b/source/wp-content/themes/wporg-developer/scss/settings/_index.scss
@@ -16,3 +16,4 @@ $code-font:
 // stylelint-enable
 
 @import "colors";
+@import "dimensions";

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2686,22 +2686,15 @@ aside[id^="nav_menu"] .widget-title {
 
 /** Table of Contents */
 .site-main .table-of-contents {
-  float: right;
-  width: 250px;
+  width: 100%;
   border: 1px solid #eee;
-  margin: 0 0 15px 15px;
+  margin: 30px 0;
   z-index: 1;
   position: relative;
   color: #555d66;
   background-color: #fff;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   border-radius: 3px;
-}
-
-@media (min-width: 971px) {
-  .site-main .table-of-contents {
-    margin: 0 -30px 15px 15px;
-  }
 }
 
 .site-main .table-of-contents h2 {
@@ -2713,6 +2706,10 @@ aside[id^="nav_menu"] .widget-title {
   text-transform: uppercase;
   border-bottom: 1px solid #eee;
   margin-bottom: 0;
+}
+
+.site-main .summary + .table-of-contents {
+  margin-top: 15px;
 }
 
 .post-type-archive-handbook ul.items,
@@ -2772,12 +2769,6 @@ aside[id^="nav_menu"] .widget-title {
 .toc-heading a:active::before,
 .toc-heading a:focus::before {
   color: #2271b1;
-}
-
-@media (max-width: 480px) {
-  .table-of-contents {
-    display: none;
-  }
 }
 
 /** Menu */
@@ -3109,6 +3100,24 @@ body.responsive-show #o2-expand-editor {
   }
   .devhub-wrap.archive .meta a, .devhub-wrap.search .meta a {
     color: #21759b;
+  }
+}
+
+@media (min-width: 94em) {
+  .site-main .summary + .table-of-contents {
+    position: fixed;
+    width: 250px;
+    top: 180px;
+    left: calc( 60em + ( ( 100vw - 60em ) / 2 ));
+  }
+}
+
+@media (min-width: 62em) {
+  .site-main .table-of-contents:not(.summary + .table-of-contents) {
+    position: fixed;
+    width: 250px;
+    top: 165px;
+    left: calc( 960px * 0.72  + ( ( 100vw - 960px ) / 2 )  + 15px);
   }
 }
 


### PR DESCRIPTION
See #76 

Allows wider content including source.

Table of Contents is fixed to the right of the content on wide screens. On medium and small screens it's inline below the title and summary.

Code reference wide
<img width="1596" alt="Screen Shot 2022-06-16 at 7 11 46 PM" src="https://user-images.githubusercontent.com/1017872/174013131-dce6e5dd-d48f-409b-88f0-25ce13ed7dc4.png">

Code reference narrow
<img width="757" alt="Screen Shot 2022-06-16 at 7 15 39 PM" src="https://user-images.githubusercontent.com/1017872/174013993-a1bc337f-48ab-41db-922c-ab310fb9bbd8.png">

Rest API wide
<img width="1611" alt="Screen Shot 2022-06-16 at 7 16 59 PM" src="https://user-images.githubusercontent.com/1017872/174014143-2884b3c0-045e-47b1-a2df-a5e0c7588471.png">

Rest API narrow
<img width="638" alt="Screen Shot 2022-06-16 at 7 17 37 PM" src="https://user-images.githubusercontent.com/1017872/174014268-4bdfa0dc-86ba-4bed-b799-4d4544b071d6.png">


