### PR TITLE
Remove Table of Contents from Code Reference

### DIFF
--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -130,7 +130,7 @@ class WPorg_Handbook_TOC {
 	 * @access public
 	 *
 	 * @param string $content Content.
-	 * @return string toc => Modified Content.
+	 * @return string Modified content.
 	 */
 	public function add_toc( $content ) {
 		$parts = $this->parse_content( $content );

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -130,7 +130,7 @@ class WPorg_Handbook_TOC {
 	 * @access public
 	 *
 	 * @param string $content Content.
-	 * @return string Modified content.
+	 * @return array toc => Table of Contents, content => Modified Content.
 	 */
 	public function add_toc( $content ) {
 		if ( ! in_the_loop() ) {
@@ -193,7 +193,7 @@ class WPorg_Handbook_TOC {
 
 		$toc .= "</ul>\n</div>\n";
 
-		return $toc . $content;
+		return array('toc' => $toc, 'content' => $content);
 	}
 
 	/**

--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -130,18 +130,31 @@ class WPorg_Handbook_TOC {
 	 * @access public
 	 *
 	 * @param string $content Content.
-	 * @return array toc => Table of Contents, content => Modified Content.
+	 * @return string toc => Modified Content.
 	 */
 	public function add_toc( $content ) {
+		$parts = $this->parse_content( $content );
+   		return $parts['toc'] . $parts['content'];
+	}
+
+	/**
+	 * Parses given content and returns modified content and the ToC.
+	 *
+	 * @access public
+	 *
+	 * @param string $content Content.
+	 * @return array toc => Table of Contents, content => Modified Content.
+	 */
+	public function parse_content( $content ) {
 		if ( ! in_the_loop() ) {
-			return $content;
+			return array('content' => $content, 'toc' => null);
 		}
 
 		$toc   = '';
 		$items = $this->get_tags( 'h(?P<level>[1-4])', $content );
 
 		if ( count( $items ) < 2 ) {
-			return $content;
+			return array('content' => $content, 'toc' => null);
 		}
 
 		// Remove any links we don't need.
@@ -167,7 +180,7 @@ class WPorg_Handbook_TOC {
 		$content = $this->add_ids_and_jumpto_links( $items, $content );
 
 		if ( ! apply_filters( 'handbook_display_toc', true ) ) {
-			return $content;
+			return array('content' => $content, 'toc' => null);
 		}
 
 		$contents_header = 'h' . reset( $items )['level']; // Duplicate the first <h#> tag in the document for the TOC header

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -13,7 +13,6 @@
 		$parts = $TOC->parse_content( $content );
 
 		$content = $parts['content'];
-		$toc = $parts['toc'];
 	endif;
 
 endif; ?>
@@ -33,11 +32,6 @@ endif; ?>
 				<?php echo get_summary(); ?>
 			</section>
 		</div>
-		<?php if ( is_single() ) :
-
-			echo $toc;
-
-		endif; ?>
 	</header>
 
 <?php if ( is_single() ) :  

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -10,10 +10,10 @@
 			'header_text' => __( 'Contents', 'wporg' )
 		) );
 		
-		$TOC_parts = $TOC->add_toc( $content );
+		$parts = $TOC->parse_content( $content );
 
-		$content = $TOC_parts['content'];
-		$toc = $TOC_parts['toc'];
+		$content = $parts['content'];
+		$toc = $parts['toc'];
 	endif;
 
 endif; ?>

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -1,20 +1,7 @@
 <?php namespace DevHub; ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<?php if ( is_single() ) : 
 
-	<?php echo get_deprecated(); ?>
-
-	<?php echo get_private_access_message(); ?>
-
-	<h1><?php echo get_signature(); ?></h1>
-
-	<section class="summary">
-		<?php echo get_summary(); ?>
-	</section>
-
-<?php if ( is_single() ) : ?>
-
-	<?php
 	$content = get_reference_template_parts();
 
 	// If the Handbook TOC is available, use it.
@@ -22,14 +9,41 @@
 		$TOC = new \WPorg_Handbook_TOC( get_parsed_post_types(), array(
 			'header_text' => __( 'Contents', 'wporg' )
 		) );
+		
+		$TOC_parts = $TOC->add_toc( $content );
 
-		$content = '<div class="content-toc">' . $TOC->add_toc( $content ) . '</div>';
-
+		$content = $TOC_parts['content'];
+		$toc = $TOC_parts['toc'];
 	endif;
-	?>
 
-	<?php echo $content; ?>
+endif; ?>
 
-<?php endif; ?>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<?php echo get_deprecated(); ?>
+
+	<?php echo get_private_access_message(); ?>
+
+	<header class="post-header">
+		<div class="post-title">
+
+			<h1><?php echo get_signature(); ?></h1>
+			
+			<section class="summary">
+				<?php echo get_summary(); ?>
+			</section>
+		</div>
+		<?php if ( is_single() ) :
+
+			echo $toc;
+
+		endif; ?>
+	</header>
+
+<?php if ( is_single() ) :  
+
+	echo '<div class="content">' . $content . '</div>'; 
+
+endif; ?>
 
 </article>

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -1,7 +1,20 @@
 <?php namespace DevHub; ?>
 
-<?php if ( is_single() ) : 
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
+	<?php echo get_deprecated(); ?>
+
+	<?php echo get_private_access_message(); ?>
+
+	<h1><?php echo get_signature(); ?></h1>
+
+	<section class="summary">
+		<?php echo get_summary(); ?>
+	</section>
+
+<?php if ( is_single() ) : ?>
+
+	<?php
 	$content = get_reference_template_parts();
 
 	// If the Handbook TOC is available, use it.
@@ -9,35 +22,16 @@
 		$TOC = new \WPorg_Handbook_TOC( get_parsed_post_types(), array(
 			'header_text' => __( 'Contents', 'wporg' )
 		) );
-		
+
 		$parts = $TOC->parse_content( $content );
 
 		$content = $parts['content'];
+
 	endif;
+	?>
 
-endif; ?>
+	<?php echo $content; ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-
-	<?php echo get_deprecated(); ?>
-
-	<?php echo get_private_access_message(); ?>
-
-	<header class="post-header">
-		<div class="post-title">
-
-			<h1><?php echo get_signature(); ?></h1>
-			
-			<section class="summary">
-				<?php echo get_summary(); ?>
-			</section>
-		</div>
-	</header>
-
-<?php if ( is_single() ) :  
-
-	echo '<div class="content">' . $content . '</div>'; 
-
-endif; ?>
+<?php endif; ?>
 
 </article>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1992,32 +1992,51 @@ aside[id^="nav_menu"] .widget-title {
 	background-color: #fff;
 }
 
-/** Table of Contents */
-.site-main .table-of-contents {
-	float: right;
-	width: 250px;
-	border: 1px solid #eee;
-	margin: 0 0 15px 15px;
-	z-index: 1;
-	position: relative;
-	color: #555d66;
-	background-color: #fff;
-	box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-	border-radius: 3px;
-
-	@media (min-width: 971px) {
-		margin: 0 -30px 15px 15px;
+/** Header layout: H1, Summary and Table of Contents **/
+.site-main {
+	.post-header {
+		display: flex;
+		
+		.post-title {
+			flex: 1;
+		}
 	}
+	
+	.table-of-contents {
+		position: fixed;
+		top: 210px;
+		right: 30px;
+		width: 250px;
+		border: 1px solid #eee;
+		// Top margin matches H1
+		margin: 24px 0 15px 15px;
+		z-index: 1;
+		color: #555d66;
+		background-color: #fff;
+		box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+		border-radius: 3px;
+		
+		@media (max-width: 1475px) {
+			position: static;
+			top: initial;
+			right: initial;
+		}
 
-	h2 {
-		margin: 0;
-		padding: 0.7rem 1.2rem;
-		font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
-		font-size: 1.3em;
-		color: #32373c;
-		text-transform: uppercase;
-		border-bottom: 1px solid #eee;
-		margin-bottom: 0;
+		@media (max-width: 970px) {
+			position: fixed;
+			visibility: hidden;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 0.7rem 1.2rem;
+			font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+			font-size: 1.3em;
+			color: #32373c;
+			text-transform: uppercase;
+			border-bottom: 1px solid #eee;
+			margin-bottom: 0;
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1992,51 +1992,32 @@ aside[id^="nav_menu"] .widget-title {
 	background-color: #fff;
 }
 
-/** Header layout: H1, Summary and Table of Contents **/
-.site-main {
-	.post-header {
-		display: flex;
-		
-		.post-title {
-			flex: 1;
-		}
+/** Table of Contents */
+.site-main .table-of-contents {
+	float: right;
+	width: 250px;
+	border: 1px solid #eee;
+	margin: 0 0 15px 15px;
+	z-index: 1;
+	position: relative;
+	color: #555d66;
+	background-color: #fff;
+	box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+	border-radius: 3px;
+
+	@media (min-width: 971px) {
+		margin: 0 -30px 15px 15px;
 	}
-	
-	.table-of-contents {
-		position: fixed;
-		top: 210px;
-		right: 30px;
-		width: 250px;
-		border: 1px solid #eee;
-		// Top margin matches H1
-		margin: 24px 0 15px 15px;
-		z-index: 1;
-		color: #555d66;
-		background-color: #fff;
-		box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-		border-radius: 3px;
-		
-		@media (max-width: 1475px) {
-			position: static;
-			top: initial;
-			right: initial;
-		}
 
-		@media (max-width: 970px) {
-			position: fixed;
-			visibility: hidden;
-		}
-
-		h2 {
-			margin: 0;
-			padding: 0.7rem 1.2rem;
-			font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
-			font-size: 1.3em;
-			color: #32373c;
-			text-transform: uppercase;
-			border-bottom: 1px solid #eee;
-			margin-bottom: 0;
-		}
+	h2 {
+		margin: 0;
+		padding: 0.7rem 1.2rem;
+		font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-size: 1.3em;
+		color: #32373c;
+		text-transform: uppercase;
+		border-bottom: 1px solid #eee;
+		margin-bottom: 0;
 	}
 }
 
@@ -2087,12 +2068,6 @@ aside[id^="nav_menu"] .widget-title {
 .toc-heading a:active::before,
 .toc-heading a:focus::before {
 	color: get-color(blue-50);
-}
-
-@media (max-width: 480px) {
-	.table-of-contents {
-		display: none;
-	}
 }
 
 /** Menu */
@@ -2503,6 +2478,12 @@ body.responsive-show {
 	}
 
 	.devhub-wrap {
+		.table-of-contents {
+			float: none;
+			margin-left: 0;
+			width: 100%;
+		}
+
 		.three-columns .box,
 		.section .box,
 		.home-primary-content,
@@ -2556,12 +2537,6 @@ body.responsive-show {
 
 @media (max-width: 32em) {
 	.devhub-wrap {
-		.table-of-contents {
-			float: none;
-			margin-left: 0;
-			width: 100%;
-		}
-
 		section {
 			overflow: inherit;
 		}

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2684,41 +2684,23 @@ aside[id^="nav_menu"] .widget-title {
   background-color: #fff;
 }
 
-/** Header layout: H1, Summary and Table of Contents **/
-.site-main .post-header {
-  display: flex;
-}
-
-.site-main .post-header .post-title {
-  flex: 1;
-}
-
+/** Table of Contents */
 .site-main .table-of-contents {
-  position: fixed;
-  top: 210px;
-  right: 30px;
+  float: right;
   width: 250px;
   border: 1px solid #eee;
-  margin: 24px 0 15px 15px;
+  margin: 0 0 15px 15px;
   z-index: 1;
+  position: relative;
   color: #555d66;
   background-color: #fff;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   border-radius: 3px;
 }
 
-@media (max-width: 1475px) {
+@media (min-width: 971px) {
   .site-main .table-of-contents {
-    position: static;
-    top: initial;
-    right: initial;
-  }
-}
-
-@media (max-width: 970px) {
-  .site-main .table-of-contents {
-    position: fixed;
-    visibility: hidden;
+    margin: 0 -30px 15px 15px;
   }
 }
 
@@ -2790,12 +2772,6 @@ aside[id^="nav_menu"] .widget-title {
 .toc-heading a:active::before,
 .toc-heading a:focus::before {
   color: #2271b1;
-}
-
-@media (max-width: 480px) {
-  .table-of-contents {
-    display: none;
-  }
 }
 
 /** Menu */
@@ -3157,6 +3133,11 @@ body.responsive-show #o2-expand-editor {
   #content-area.has-sidebar .widget-area .widget {
     width: 100%;
   }
+  .devhub-wrap .table-of-contents {
+    float: none;
+    margin-left: 0;
+    width: 100%;
+  }
   .devhub-wrap .three-columns .box,
   .devhub-wrap .section .box,
   .devhub-wrap .home-primary-content,
@@ -3199,11 +3180,6 @@ body.responsive-show #o2-expand-editor {
 }
 
 @media (max-width: 32em) {
-  .devhub-wrap .table-of-contents {
-    float: none;
-    margin-left: 0;
-    width: 100%;
-  }
   .devhub-wrap section {
     overflow: inherit;
   }

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2684,23 +2684,41 @@ aside[id^="nav_menu"] .widget-title {
   background-color: #fff;
 }
 
-/** Table of Contents */
+/** Header layout: H1, Summary and Table of Contents **/
+.site-main .post-header {
+  display: flex;
+}
+
+.site-main .post-header .post-title {
+  flex: 1;
+}
+
 .site-main .table-of-contents {
-  float: right;
+  position: fixed;
+  top: 210px;
+  right: 30px;
   width: 250px;
   border: 1px solid #eee;
-  margin: 0 0 15px 15px;
+  margin: 24px 0 15px 15px;
   z-index: 1;
-  position: relative;
   color: #555d66;
   background-color: #fff;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   border-radius: 3px;
 }
 
-@media (min-width: 971px) {
+@media (max-width: 1475px) {
   .site-main .table-of-contents {
-    margin: 0 -30px 15px 15px;
+    position: static;
+    top: initial;
+    right: initial;
+  }
+}
+
+@media (max-width: 970px) {
+  .site-main .table-of-contents {
+    position: fixed;
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
See #76 

This PR removes the Table of Contents from the Code Reference pages of the dev docs, but leaves the jump to links on content headings.

This allows more space in the upper section of the page for source and other important info.

Before:
<img width="1600" alt="Screen Shot 2022-06-17 at 12 03 57 PM" src="https://user-images.githubusercontent.com/1017872/174197243-454cbe61-7153-4734-aa0e-4c8b9ababaa1.png">

After:
<img width="1601" alt="Screen Shot 2022-06-17 at 12 06 00 PM" src="https://user-images.githubusercontent.com/1017872/174197402-3b64488f-951f-4c4d-a49a-2ec4f794f52e.png">

Also included is a change to [improve display of the ToC on small screens as suggested](https://github.com/WordPress/wporg-developer/pull/93#issuecomment-1152525768) by @iandunn :
- Stop hiding it on really small screens (< 480px wide) as this is where it is very useful for jumping down a long page
- Make it full width on small screens (< 43em wide) so that it better handles really long ToC titles, eg. https://developer.wordpress.org/rest-api/frequently-asked-questions/

Before:
<img width="600" alt="Screen Shot 2022-06-21 at 4 30 52 PM" src="https://user-images.githubusercontent.com/1017872/174716463-ab110956-a924-4424-8ee5-9471c44a1c67.png">

After:
<img width="602" alt="Screen Shot 2022-06-21 at 4 31 33 PM" src="https://user-images.githubusercontent.com/1017872/174716546-7ed90cb6-0aa0-4a48-9532-9ec8dd1176de.png">
