### PR TITLE
Revert removing Table of Contents from Code Reference and fix outside content instead

### DIFF
--- a/source/wp-content/plugins/handbook/inc/table-of-contents.php
+++ b/source/wp-content/plugins/handbook/inc/table-of-contents.php
@@ -133,28 +133,15 @@ class WPorg_Handbook_TOC {
 	 * @return string Modified content.
 	 */
 	public function add_toc( $content ) {
-		$parts = $this->parse_content( $content );
-   		return $parts['toc'] . $parts['content'];
-	}
-
-	/**
-	 * Parses given content and returns modified content and the ToC.
-	 *
-	 * @access public
-	 *
-	 * @param string $content Content.
-	 * @return array toc => Table of Contents, content => Modified Content.
-	 */
-	public function parse_content( $content ) {
 		if ( ! in_the_loop() ) {
-			return array('content' => $content, 'toc' => null);
+			return $content;
 		}
 
 		$toc   = '';
 		$items = $this->get_tags( 'h(?P<level>[1-4])', $content );
 
 		if ( count( $items ) < 2 ) {
-			return array('content' => $content, 'toc' => null);
+			return $content;
 		}
 
 		// Remove any links we don't need.
@@ -180,7 +167,7 @@ class WPorg_Handbook_TOC {
 		$content = $this->add_ids_and_jumpto_links( $items, $content );
 
 		if ( ! apply_filters( 'handbook_display_toc', true ) ) {
-			return array('content' => $content, 'toc' => null);
+			return $content;
 		}
 
 		$contents_header = 'h' . reset( $items )['level']; // Duplicate the first <h#> tag in the document for the TOC header
@@ -206,7 +193,7 @@ class WPorg_Handbook_TOC {
 
 		$toc .= "</ul>\n</div>\n";
 
-		return array('toc' => $toc, 'content' => $content);
+		return $toc . $content;
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer/content-reference.php
+++ b/source/wp-content/themes/wporg-developer/content-reference.php
@@ -23,9 +23,7 @@
 			'header_text' => __( 'Contents', 'wporg' )
 		) );
 
-		$parts = $TOC->parse_content( $content );
-
-		$content = $parts['content'];
+		$content = $TOC->add_toc( $content );
 
 	endif;
 	?>

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -40,7 +40,7 @@
 
 	#content,
 	#content-area {
-		padding: 0 #{"max( 20px, 2% )"};
+		padding: 0 12px; // Matches .site-branding padding
 
 		table {
 			border: 1px solid #f0f0f0;
@@ -55,6 +55,16 @@
 				padding: 0.8em 1em;
 				border: 1px solid #f0f0f0;
 			}
+		}
+	}
+
+	@media ( min-width: 889px ) {
+		#content {
+			padding: 0;
+		}
+
+		#content-area {
+			padding: 0 24px;
 		}
 	}
 
@@ -1673,7 +1683,7 @@ a.screen-reader-text:focus,
 	box-sizing: border-box;
 	margin: 0 auto;
 	max-width: 960px;
-	padding: 0 10px;
+	padding: 0 24px;
 	position: relative;
 
 	&.has-actions {
@@ -2241,7 +2251,7 @@ div[class*="-table-of-contents-container"] {
 		max-width: $single-handbook-content-width;
 		margin: 0 auto;
 		display: flex;
-		padding-top: 0;
+		padding: 0 #{"max( 20px, 2% )"};
 	}
 
 	header {

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1997,7 +1997,7 @@ aside[id^="nav_menu"] .widget-title {
 	.table-of-contents {
 		display: flex;
 		flex-direction: column;
-		width: 100%;
+		min-width: 230px;
 		border: 1px solid #eee;
 		margin: 30px 0;
 		z-index: 1;
@@ -2008,7 +2008,9 @@ aside[id^="nav_menu"] .widget-title {
 		border-radius: 3px;
 
 		.code-reference & {
+			float: right;
 			margin-top: 15px;
+			margin-left: 15px;
 		}
 
 		h2 {
@@ -2445,31 +2447,32 @@ body.responsive-show {
 	}
 }
 
-@media (min-width: 94em) {
+@media (min-width: 90em) {
 	.site-main .table-of-contents {
 		position: fixed;
-		width: 250px;
-
+		width: 15vw;
+		
 		.code-reference & {
-			top: $devhub-wrap-toc-position-top;
+			margin-left: 0;
 			left: calc( #{ $devhub-wrap-content-width } + ( ( 100vw - #{ $devhub-wrap-content-width } ) / 2 ) );
+			top: $devhub-wrap-toc-position-top;
 			max-height: calc(90vh - #{ $devhub-wrap-toc-position-top });
 		}
 
 		// Pages with sidebar
 		.widget-area + & {
-			top: $single-handbook-toc-position-top;
 			left: calc( #{ $single-handbook-content-width } + ( ( 100vw - #{ $single-handbook-content-width } ) / 2 ) );
+			top: $single-handbook-toc-position-top;
 			max-height: calc(90vh - #{ $single-handbook-toc-position-top });
 		}
 	}
 }
 
-@media (min-width: 62em) {
+@media (min-width: 877px) {
 	// Pages which are not code reference and without a sidebar
 	.site-main .table-of-contents:not(.code-reference .site-main .table-of-contents):not(.widget-area + .site-main .table-of-contents) {
 		position: fixed;
-		width: 250px;
+		width: 15vw;
 		top: $single-handbook-toc-position-top;
 		left: calc(
 			#{ $single-handbook-content-width } * #{ $single-handbook-content-primary-width } 
@@ -2492,6 +2495,15 @@ body.responsive-show {
 				float: left;
 			}
 		}
+	}
+}
+
+// Matches global header breakpoint
+@media ( max-width: 889px ) {
+	.code-reference .site-main .table-of-contents {
+		float: none;
+		margin-left: 0;
+		width: 100%;
 	}
 }
 
@@ -2519,12 +2531,6 @@ body.responsive-show {
 	}
 
 	.devhub-wrap {
-		.table-of-contents {
-			float: none;
-			margin-left: 0;
-			width: 100%;
-		}
-
 		.three-columns .box,
 		.section .box,
 		.home-primary-content,

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -1995,6 +1995,8 @@ aside[id^="nav_menu"] .widget-title {
 /** Table of Contents */
 .site-main {
 	.table-of-contents {
+		display: flex;
+		flex-direction: column;
 		width: 100%;
 		border: 1px solid #eee;
 		margin: 30px 0;
@@ -2019,6 +2021,10 @@ aside[id^="nav_menu"] .widget-title {
 			border-bottom: 1px solid #eee;
 			margin-bottom: 0;
 		}
+
+		.items {
+			overflow-y: scroll;
+		} 
 	}
 }
 
@@ -2440,24 +2446,37 @@ body.responsive-show {
 }
 
 @media (min-width: 94em) {
-	.code-reference .site-main .table-of-contents {
+	.site-main .table-of-contents {
 		position: fixed;
 		width: 250px;
-		top: 210px;
-		left: calc( #{ $devhub-wrap-content-width } + ( ( 100vw - #{ $devhub-wrap-content-width } ) / 2 ) );
+
+		.code-reference & {
+			top: $devhub-wrap-toc-position-top;
+			left: calc( #{ $devhub-wrap-content-width } + ( ( 100vw - #{ $devhub-wrap-content-width } ) / 2 ) );
+			max-height: calc(90vh - #{ $devhub-wrap-toc-position-top });
+		}
+
+		// Pages with sidebar
+		.widget-area + & {
+			top: $single-handbook-toc-position-top;
+			left: calc( #{ $single-handbook-content-width } + ( ( 100vw - #{ $single-handbook-content-width } ) / 2 ) );
+			max-height: calc(90vh - #{ $single-handbook-toc-position-top });
+		}
 	}
 }
 
 @media (min-width: 62em) {
-	.site-main .table-of-contents:not(.code-reference .site-main .table-of-contents) {
+	// Pages which are not code reference and without a sidebar
+	.site-main .table-of-contents:not(.code-reference .site-main .table-of-contents):not(.widget-area + .site-main .table-of-contents) {
 		position: fixed;
 		width: 250px;
-		top: 200px;
+		top: $single-handbook-toc-position-top;
 		left: calc(
 			#{ $single-handbook-content-width } * #{ $single-handbook-content-primary-width } 
 			+ ( ( 100vw - #{ $single-handbook-content-width } ) / 2 ) 
 			+ 15px
 		);
+		max-height: calc(90vh - #{ $single-handbook-toc-position-top });
 	}
 }
 

--- a/source/wp-content/themes/wporg-developer/scss/main.scss
+++ b/source/wp-content/themes/wporg-developer/scss/main.scss
@@ -61,7 +61,7 @@
 	#content-area,
 	.inner-wrap {
 		margin: 2rem auto 0;
-		max-width: 60em;
+		max-width: $devhub-wrap-content-width;
 	}
 
 	.page-header {
@@ -1554,7 +1554,7 @@
 	#content-area.has-sidebar {
 		float: none;
 		margin: 0 auto;
-		width: 60em;
+		width: $devhub-wrap-content-width;
 	}
 
 	.has-sidebar {
@@ -1993,31 +1993,32 @@ aside[id^="nav_menu"] .widget-title {
 }
 
 /** Table of Contents */
-.site-main .table-of-contents {
-	float: right;
-	width: 250px;
-	border: 1px solid #eee;
-	margin: 0 0 15px 15px;
-	z-index: 1;
-	position: relative;
-	color: #555d66;
-	background-color: #fff;
-	box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-	border-radius: 3px;
+.site-main {
+	.table-of-contents {
+		width: 100%;
+		border: 1px solid #eee;
+		margin: 30px 0;
+		z-index: 1;
+		position: relative;
+		color: #555d66;
+		background-color: #fff;
+		box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+		border-radius: 3px;
 
-	@media (min-width: 971px) {
-		margin: 0 -30px 15px 15px;
-	}
+		.code-reference & {
+			margin-top: 15px;
+		}
 
-	h2 {
-		margin: 0;
-		padding: 0.7rem 1.2rem;
-		font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
-		font-size: 1.3em;
-		color: #32373c;
-		text-transform: uppercase;
-		border-bottom: 1px solid #eee;
-		margin-bottom: 0;
+		h2 {
+			margin: 0;
+			padding: 0.7rem 1.2rem;
+			font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+			font-size: 1.3em;
+			color: #32373c;
+			text-transform: uppercase;
+			border-bottom: 1px solid #eee;
+			margin-bottom: 0;
+		}
 	}
 }
 
@@ -2229,7 +2230,7 @@ div[class*="-table-of-contents-container"] {
 	}
 
 	#content {
-		max-width: 960px;
+		max-width: $single-handbook-content-width;
 		margin: 0 auto;
 		display: flex;
 		padding-top: 0;
@@ -2252,7 +2253,7 @@ div[class*="-table-of-contents-container"] {
 		padding: 4rem 0 4rem 4rem;
 		background: #fff;
 		box-sizing: border-box;
-		width: 72%;
+		width: $single-handbook-content-primary-width * 100%;
 
 		@media (max-width: 876px) {
 			padding: 4rem 20px;
@@ -2436,7 +2437,28 @@ body.responsive-show {
 			}
 		}
 	}
+}
 
+@media (min-width: 94em) {
+	.code-reference .site-main .table-of-contents {
+		position: fixed;
+		width: 250px;
+		top: 210px;
+		left: calc( #{ $devhub-wrap-content-width } + ( ( 100vw - #{ $devhub-wrap-content-width } ) / 2 ) );
+	}
+}
+
+@media (min-width: 62em) {
+	.site-main .table-of-contents:not(.code-reference .site-main .table-of-contents) {
+		position: fixed;
+		width: 250px;
+		top: 200px;
+		left: calc(
+			#{ $single-handbook-content-width } * #{ $single-handbook-content-primary-width } 
+			+ ( ( 100vw - #{ $single-handbook-content-width } ) / 2 ) 
+			+ 15px
+		);
+	}
 }
 
 @media ( min-width: 43em ) {

--- a/source/wp-content/themes/wporg-developer/scss/settings/_dimensions.scss
+++ b/source/wp-content/themes/wporg-developer/scss/settings/_dimensions.scss
@@ -1,3 +1,6 @@
 $single-handbook-content-width: 960px;
 $single-handbook-content-primary-width: 0.72;
+$single-handbook-toc-position-top: 200px;
+
 $devhub-wrap-content-width: 60em;
+$devhub-wrap-toc-position-top: 210px;

--- a/source/wp-content/themes/wporg-developer/scss/settings/_dimensions.scss
+++ b/source/wp-content/themes/wporg-developer/scss/settings/_dimensions.scss
@@ -1,0 +1,3 @@
+$single-handbook-content-width: 960px;
+$single-handbook-content-primary-width: 0.72;
+$devhub-wrap-content-width: 60em;

--- a/source/wp-content/themes/wporg-developer/scss/settings/_index.scss
+++ b/source/wp-content/themes/wporg-developer/scss/settings/_index.scss
@@ -16,3 +16,4 @@ $code-font:
 // stylelint-enable
 
 @import "colors";
+@import "dimensions";

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -329,7 +329,7 @@ img {
 
 .devhub-wrap #content,
 .devhub-wrap #content-area {
-  padding: 0 max( 20px, 2% );
+  padding: 0 12px;
 }
 
 .devhub-wrap #content table,
@@ -348,6 +348,15 @@ img {
 .devhub-wrap #content-area table td {
   padding: 0.8em 1em;
   border: 1px solid #f0f0f0;
+}
+
+@media (min-width: 889px) {
+  .devhub-wrap #content {
+    padding: 0;
+  }
+  .devhub-wrap #content-area {
+    padding: 0 24px;
+  }
 }
 
 .devhub-wrap #content-area,
@@ -2366,7 +2375,7 @@ a.screen-reader-text:focus,
   box-sizing: border-box;
   margin: 0 auto;
   max-width: 960px;
-  padding: 0 10px;
+  padding: 0 24px;
   position: relative;
 }
 
@@ -2926,7 +2935,7 @@ div[class*="-table-of-contents-container"] .sub-menu {
   max-width: 960px;
   margin: 0 auto;
   display: flex;
-  padding-top: 0;
+  padding: 0 max( 20px, 2% );
 }
 
 .single-handbook header {

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2688,7 +2688,7 @@ aside[id^="nav_menu"] .widget-title {
 .site-main .table-of-contents {
   display: flex;
   flex-direction: column;
-  width: 100%;
+  min-width: 230px;
   border: 1px solid #eee;
   margin: 30px 0;
   z-index: 1;
@@ -2700,7 +2700,9 @@ aside[id^="nav_menu"] .widget-title {
 }
 
 .code-reference .site-main .table-of-contents {
+  float: right;
   margin-top: 15px;
+  margin-left: 15px;
 }
 
 .site-main .table-of-contents h2 {
@@ -3109,27 +3111,28 @@ body.responsive-show #o2-expand-editor {
   }
 }
 
-@media (min-width: 94em) {
+@media (min-width: 90em) {
   .site-main .table-of-contents {
     position: fixed;
-    width: 250px;
+    width: 15vw;
   }
   .code-reference .site-main .table-of-contents {
-    top: 210px;
+    margin-left: 0;
     left: calc( 60em + ( ( 100vw - 60em ) / 2 ));
+    top: 210px;
     max-height: calc(90vh - 210px);
   }
   .widget-area + .site-main .table-of-contents {
-    top: 200px;
     left: calc( 960px + ( ( 100vw - 960px ) / 2 ));
+    top: 200px;
     max-height: calc(90vh - 200px);
   }
 }
 
-@media (min-width: 62em) {
+@media (min-width: 877px) {
   .site-main .table-of-contents:not(.code-reference .site-main .table-of-contents):not(.widget-area + .site-main .table-of-contents) {
     position: fixed;
-    width: 250px;
+    width: 15vw;
     top: 200px;
     left: calc( 960px * 0.72  + ( ( 100vw - 960px ) / 2 )  + 15px);
     max-height: calc(90vh - 200px);
@@ -3142,6 +3145,14 @@ body.responsive-show #o2-expand-editor {
   }
   .devhub-wrap.archive .sourcefile, .devhub-wrap.search .sourcefile {
     float: left;
+  }
+}
+
+@media (max-width: 889px) {
+  .code-reference .site-main .table-of-contents {
+    float: none;
+    margin-left: 0;
+    width: 100%;
   }
 }
 
@@ -3161,11 +3172,6 @@ body.responsive-show #o2-expand-editor {
     clear: both;
   }
   #content-area.has-sidebar .widget-area .widget {
-    width: 100%;
-  }
-  .devhub-wrap .table-of-contents {
-    float: none;
-    margin-left: 0;
     width: 100%;
   }
   .devhub-wrap .three-columns .box,

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2686,10 +2686,9 @@ aside[id^="nav_menu"] .widget-title {
 
 /** Table of Contents */
 .site-main .table-of-contents {
-  float: right;
-  width: 250px;
+  width: 100%;
   border: 1px solid #eee;
-  margin: 0 0 15px 15px;
+  margin: 30px 0;
   z-index: 1;
   position: relative;
   color: #555d66;
@@ -2698,10 +2697,8 @@ aside[id^="nav_menu"] .widget-title {
   border-radius: 3px;
 }
 
-@media (min-width: 971px) {
-  .site-main .table-of-contents {
-    margin: 0 -30px 15px 15px;
-  }
+.code-reference .site-main .table-of-contents {
+  margin-top: 15px;
 }
 
 .site-main .table-of-contents h2 {
@@ -3103,6 +3100,24 @@ body.responsive-show #o2-expand-editor {
   }
   .devhub-wrap.archive .meta a, .devhub-wrap.search .meta a {
     color: #21759b;
+  }
+}
+
+@media (min-width: 94em) {
+  .code-reference .site-main .table-of-contents {
+    position: fixed;
+    width: 250px;
+    top: 210px;
+    left: calc( 60em + ( ( 100vw - 60em ) / 2 ));
+  }
+}
+
+@media (min-width: 62em) {
+  .site-main .table-of-contents:not(.code-reference .site-main .table-of-contents) {
+    position: fixed;
+    width: 250px;
+    top: 200px;
+    left: calc( 960px * 0.72  + ( ( 100vw - 960px ) / 2 )  + 15px);
   }
 }
 

--- a/source/wp-content/themes/wporg-developer/stylesheets/main.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/main.css
@@ -2686,6 +2686,8 @@ aside[id^="nav_menu"] .widget-title {
 
 /** Table of Contents */
 .site-main .table-of-contents {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   border: 1px solid #eee;
   margin: 30px 0;
@@ -2710,6 +2712,10 @@ aside[id^="nav_menu"] .widget-title {
   text-transform: uppercase;
   border-bottom: 1px solid #eee;
   margin-bottom: 0;
+}
+
+.site-main .table-of-contents .items {
+  overflow-y: scroll;
 }
 
 .post-type-archive-handbook ul.items,
@@ -3104,20 +3110,29 @@ body.responsive-show #o2-expand-editor {
 }
 
 @media (min-width: 94em) {
-  .code-reference .site-main .table-of-contents {
+  .site-main .table-of-contents {
     position: fixed;
     width: 250px;
+  }
+  .code-reference .site-main .table-of-contents {
     top: 210px;
     left: calc( 60em + ( ( 100vw - 60em ) / 2 ));
+    max-height: calc(90vh - 210px);
+  }
+  .widget-area + .site-main .table-of-contents {
+    top: 200px;
+    left: calc( 960px + ( ( 100vw - 960px ) / 2 ));
+    max-height: calc(90vh - 200px);
   }
 }
 
 @media (min-width: 62em) {
-  .site-main .table-of-contents:not(.code-reference .site-main .table-of-contents) {
+  .site-main .table-of-contents:not(.code-reference .site-main .table-of-contents):not(.widget-area + .site-main .table-of-contents) {
     position: fixed;
     width: 250px;
     top: 200px;
     left: calc( 960px * 0.72  + ( ( 100vw - 960px ) / 2 )  + 15px);
+    max-height: calc(90vh - 200px);
   }
 }
 


### PR DESCRIPTION
See #76 

We initially tried removing the Table of Contents entirely on Code Reference pages, however [this proved controversial](https://make.wordpress.org/meta/2022/07/01/exploration-improving-devhub/#comment-9329), so I want to put this solution out for comment.

This PR makes the ToC fixed to the right of the content on wide screens for all handbooks. On medium and small screens it's displayed inline below the title.

Code Reference wide
![Screen Shot 2022-07-14 at 3 43 13 PM](https://user-images.githubusercontent.com/1017872/178893450-96217192-84fc-434e-a280-f60f19a5116d.jpg)

Code reference wide scrolled
![Screen Shot 2022-07-14 at 3 44 14 PM](https://user-images.githubusercontent.com/1017872/178893537-f3d3f400-92a3-40d3-b95d-aa0d19fef7b9.jpg)

Code Reference iPad
![Screen Shot 2022-07-14 at 3 44 58 PM](https://user-images.githubusercontent.com/1017872/178893632-09312fb9-2161-4ff7-ab62-81202530b15c.jpg)

Rest API wide
![Screen Shot 2022-07-14 at 3 46 05 PM](https://user-images.githubusercontent.com/1017872/178893791-64634ce5-2c21-4b2f-92df-982ff2525a75.jpg)

Rest API iPad
![Screen Shot 2022-07-14 at 3 45 47 PM](https://user-images.githubusercontent.com/1017872/178893771-4b3d949f-b059-484e-8754-2423566f9f7d.jpg)


