### PR TITLE
Close description tag later.

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer/inc/formatting.php
@@ -599,9 +599,9 @@ class DevHub_Formatting {
 				if ( $name ) {
 					$new_text .= "<code>{$name}</code>";
 				}
-				$new_text .= "<span class='type'>{$type}</span><div class='desc'>{$description}</div>";
+				$new_text .= "<span class='type'>{$type}</span><div class='desc'>{$description}";
 				if ( ! $skip_closing_li ) {
-					$new_text .= '</li>';
+					$new_text .= '</div></li>';
 				}
 				$new_text .= "\n";
 			}


### PR DESCRIPTION
Fixes: #136

The `<div class="desc">` container when we close the outer `<li>` because we may have nested list.

#### `reference/functions/wp_remote_request/`
| Before | After |
| --- | --- |
|<img width="1017" alt="Screen Shot 2022-09-06 at 1 37 25 PM" src="https://user-images.githubusercontent.com/1657336/188547987-638123ec-3137-4d7a-b8e3-714fae2d778a.png"> | <img width="970" alt="Screen Shot 2022-09-06 at 1 36 21 PM" src="https://user-images.githubusercontent.com/1657336/188547977-9e73ad76-f72a-40aa-b71e-3f959c803dbd.png"> |

#### `reference/functions/register_post_type/`
| Before | After |
| --- | --- |
| <img width="1103" alt="Screen Shot 2022-09-06 at 1 47 29 PM" src="https://user-images.githubusercontent.com/1657336/188549260-e72acfc9-530d-4129-a7eb-6717f7fe9ac0.png">  | <img width="946" alt="Screen Shot 2022-09-06 at 1 48 20 PM" src="https://user-images.githubusercontent.com/1657336/188549251-d4e2ca92-4bfe-472d-a7fc-8079453a58c1.png">  | 






