### PR TITLE
wp-cli json: Switch from the 'master' branch to the 'main' branch 

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/cli.php
+++ b/source/wp-content/themes/wporg-developer/inc/cli.php
@@ -2,7 +2,7 @@
 
 class DevHub_CLI {
 
-	private static $commands_manifest = 'https://raw.githubusercontent.com/wp-cli/handbook/master/bin/commands-manifest.json';
+	private static $commands_manifest = 'https://raw.githubusercontent.com/wp-cli/handbook/main/bin/commands-manifest.json';
 	private static $meta_key = 'wporg_cli_markdown_source';
 	private static $supported_post_types = array( 'command' );
 	private static $posts_per_page = -1;


### PR DESCRIPTION
setting the branch name properly as per `wp-cli handbook` repo: https://github.com/wp-cli/handbook
`commands-manifest.json` blob: https://github.com/wp-cli/handbook/blob/main/bin/commands-manifest.json

may be related:👇
svn commit: [11951](https://meta.trac.wordpress.org/changeset/11951) ,
meta ticket: [6394](https://meta.trac.wordpress.org/ticket/6394)