### PR TITLE
Fix related section collapsing issue

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer/inc/template-tags.php
@@ -1448,7 +1448,7 @@ namespace DevHub {
 	 * Rearrange the results of get_uses() so that frequent functions are pushed to the bottom.
 	 * Sorts the array in-place.
 	 *
-	 * @return int The number of infrequent items in the list (ie the cutoff point for show/hide).
+	 * @return int The number of infrequent items in the list.
 	 */
 	function split_uses_by_frequent_funcs( &$posts ) {
 

--- a/source/wp-content/themes/wporg-developer/reference/template-related.php
+++ b/source/wp-content/themes/wporg-developer/reference/template-related.php
@@ -13,11 +13,12 @@ if ( show_usage_info() ) :
 	$has_uses    = ( post_type_has_uses_info()  && ( $uses    = get_uses()    ) && $uses->have_posts()    );
 	$has_used_by = ( post_type_has_usage_info() && ( $used_by = get_used_by() ) && $used_by->have_posts() );
 
-	$uses_to_show    = 5;
-	$used_by_to_show = 5;
+	$uses_to_show     = 5;
+	$min_uses_to_show = 2;
+	$used_by_to_show  = 5;
 
 	if ( $has_uses ) {
-		$uses_to_show = min( $uses_to_show, split_uses_by_frequent_funcs( $uses->posts ) );
+		$uses_to_show = min( $uses_to_show, max( split_uses_by_frequent_funcs( $uses->posts ), $min_uses_to_show ) );
 	}
 
 	if ( $has_uses || $has_used_by ) :


### PR DESCRIPTION
Fixes #142 

Originally, the Uses table in the Related section would be collapsed and show 0 records even though there are actually some records existing. After the fix, if the amount of records <= 5, it would never be collapsed.

**Reason for changing from min to max**

The return value of `split_uses_by_frequent_funcs` is `infrequent_count`, and the purpose of the function is to _Rearrange the results of get_uses() so that frequent functions are pushed to the bottom._ I'm not 100% sure why we want to show infrequently used functions to users first here (maybe I misunderstood the real purpose of the function), but according to the function's goal and its [doc comment](https://github.com/WordPress/wporg-developer/blob/f528ed07ab2a6d32945d4e52ffb3f38ed396407f/source/wp-content/themes/wporg-developer/inc/template-tags.php#L1451), I'm thinking that we can change from `min` to `max` here so that we can show as many infrequently used functions to users as possible.

Or if we still want it to show five records at most, we can specify the least records to show as well.
Perhaps:
```php
$uses_to_show = min( $uses_to_show, max( split_uses_by_frequent_funcs( $uses->posts ), $least_uses_to_show) );
```