### PR TITLE
Fix code header overlap the bottom border on handbook

### DIFF
--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -248,11 +248,18 @@ pre.line-numbers > code {
 	}
 }
 
-/* Make the sticky wp-code-block-button-container not overlap its parent's border */
+/**
+ * Make the sticky wp-code-block-button-container not overlap its parent's border.
+ * A trikcy way is used here (plus and minus margin-bottom),
+ * as we can't just adjust the pre in _global.scss,
+ * or page like https://developer.wordpress.org/resource/dashicons/#randomize would be affected.
+ */
+
 .wporg-developer-code-block {
 	display: flex;
 	flex-direction: column;
 	margin-bottom: 1.6em;
+	font-size: 16px;
 
 	&::after {
 		content: "";

--- a/source/wp-content/themes/wporg-developer/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer/scss/prism.scss
@@ -248,7 +248,7 @@ pre.line-numbers > code {
 	}
 }
 
-/**
+/*
  * Make the sticky wp-code-block-button-container not overlap its parent's border.
  * A trikcy way is used here (plus and minus margin-bottom),
  * as we can't just adjust the pre in _global.scss,
@@ -263,6 +263,13 @@ pre.line-numbers > code {
 
 	&::after {
 		content: "";
+
+		/* Since the margin-bottom of the pre defined in _global.scss is 1.6em,
+		 * -1.63em is set here to make the shape of the rounded corners at the bottom of
+		 * the code block complete when the sticky wp-code-block-button-container is scolled there.
+		 *
+		 * See https://github.com/WordPress/wporg-developer/pull/148#issuecomment-1289595980
+		 */
 		margin-bottom: -1.63em;
 	}
 }

--- a/source/wp-content/themes/wporg-developer/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer/stylesheets/prism.css
@@ -240,11 +240,17 @@ pre.line-numbers > code {
   border-top-right-radius: 0;
 }
 
-/* Make the sticky wp-code-block-button-container not overlap its parent's border */
+/**
+ * Make the sticky wp-code-block-button-container not overlap its parent's border.
+ * A trikcy way is used here (plus and minus margin-bottom),
+ * as we can't just adjust the pre in main.css,
+ * or page like https://developer.wordpress.org/resource/dashicons/#randomize would be affected.
+ */
 .wporg-developer-code-block {
   display: flex;
   flex-direction: column;
   margin-bottom: 1.6em;
+  font-size: 16px;
 }
 
 .wporg-developer-code-block::after {


### PR DESCRIPTION
Fixes #147 

## Root Cause

Parent font-size on handbook pages: `13px`
Parent font-size on reference pabes: `16px`

## Screenshots of Result
#### Handbook https://developer.wordpress.org/themes/theme-security/using-nonces/

![handbook](https://user-images.githubusercontent.com/18050944/197598094-8bbd093d-96af-412e-8b7e-659ead942072.gif)

#### Reference https://developer.wordpress.org/reference/functions/apply_filters/
![reference](https://user-images.githubusercontent.com/18050944/197598146-1544b0e0-085a-4ff4-9e6a-65c9e0d3e83b.gif)

