### PR TITLE
Expand a code block by default if it has the 'expanded' CSS class.

### DIFF
--- a/source/wp-content/themes/wporg-developer/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer/js/function-reference.js
@@ -77,7 +77,12 @@ jQuery( function ( $ ) {
 				}
 			} );
 
-			collapseCodeBlock( $element, $expandButton );
+			if ( $element.hasClass( 'expanded' ) ) {
+				expandCodeBlock( $element, $expandButton );
+			} else {
+				collapseCodeBlock( $element, $expandButton );
+			}
+
 			$container.append( $expandButton );
 		}
 


### PR DESCRIPTION
Some pages and code blocks should be expanded by default, for readability, this might be because it's 1 line over the line limit, or perhaps because it's the last entry on the page.

Or, it could be a page where the majority of the content is the code block itself:
https://developer.wordpress.org/plugins/settings/custom-settings-page/

This PR simply auto-expands the block upon load if the CSS class is applied.