### PR TITLE
Block: Implement deprecated block.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1078,11 +1078,10 @@ namespace DevHub {
 	 * Retrieve deprecated notice.
 	 *
 	 * @param int  $post_id   Optional. Post ID. Default is the ID of the global `$post`.
-	 * @param bool $formatted Optional. Whether to format the deprecation message. Default true.
 	 * @return string Deprecated notice. If `$formatted` is true, will be output in markup
 	 *                for a callout box.
 	 */
-	function get_deprecated( $post_id = null, $formatted = true ) {
+	function get_deprecated( $post_id = null ) {
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
@@ -1136,22 +1135,7 @@ namespace DevHub {
 			$deprecation_info
 		);
 
-		if ( true === $formatted ) {
-			// Use the 'warning' callout box if it's available. Otherwise, fall back to a theme-supported div class.
-			if ( class_exists( 'WPorg_Handbook_Callout_Boxes' ) ) {
-				$callout = new \WPorg_Handbook_Callout_Boxes();
-				$message = $callout->warning_shortcode( array(), $contents );
-			} else {
-				$message  = '<div class="deprecated">';
-				/** This filter is documented in wp-includes/post-template.php */
-				$message .= apply_filters( 'the_content', $contents );
-				$message .= '</div>';
-			}
-		} else {
-			$message = $contents;
-		}
-
-		return $message;
+		return $contents;
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/parts/header.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/header.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|edge-space","bottom":"16px","left":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:wporg/site-breadcrumbs  /--></div>
+<div class="wp-block-group"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:navigation {"textColor":"white","backgroundColor":"blueberry-1","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} -->

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.json
@@ -14,6 +14,5 @@
 		}
 	},
 	"textdomain": "wporg",
-	"editorScript": "file:./index.js",
-	"style": "file:./style-index.css"
+	"editorScript": "file:./index.js"
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
@@ -35,7 +35,7 @@ function render() {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
-		'<section %s>%s</section>',
+		'<div %s>%s</div>',
 		$wrapper_attributes,
 		$deprecated_html
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
@@ -1,6 +1,8 @@
 <?php
 namespace WordPressdotorg\Theme\Developer_2023\Dynamic_Code_Deprecated;
 
+use function DevHub\get_deprecated;
+
 add_action( 'init', __NAMESPACE__ . '\init' );
 
 /**
@@ -25,11 +27,16 @@ function init() {
  * @return string Returns the block markup.
  */
 function render() {
+	$deprecated_html = get_deprecated();
+
+	if ( empty( $deprecated_html ) ) {
+		return '';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes();
-
-	$output = '<section ' . $wrapper_attributes . '>';
-	$output .= 'wporg:code-deprecated: Not implemented';
-	$output .= '</section>';
-
-	return $output;
+	return sprintf(
+		'<section %s>%s</section>',
+		$wrapper_attributes,
+		$deprecated_html
+	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
@@ -34,8 +34,8 @@ function render() {
 	}
 
 	$block_markup = <<<EOT
-	<!-- wp:wporg/notice {"type":"alert"} -->
-	<div class="wp-block-wporg-notice is-alert-notice">
+	<!-- wp:wporg/notice {"type":"warning"} -->
+	<div class="wp-block-wporg-notice is-warning-notice">
 	<div class="wp-block-wporg-notice__icon"></div>
 	<div class="wp-block-wporg-notice__content"><p>$deprecated_html</p></div></div>
 	<!-- /wp:wporg/notice -->

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
@@ -33,10 +33,18 @@ function render() {
 		return '';
 	}
 
+	$block_markup = <<<EOT
+	<!-- wp:wporg/notice {"type":"alert"} -->
+	<div class="wp-block-wporg-notice is-alert-notice">
+	<div class="wp-block-wporg-notice__icon"></div>
+	<div class="wp-block-wporg-notice__content"><p>$deprecated_html</p></div></div>
+	<!-- /wp:wporg/notice -->
+	EOT;
+
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
 		'<div %s>%s</div>',
 		$wrapper_attributes,
-		$deprecated_html
+		do_blocks( $block_markup )
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/index.js
@@ -1,5 +1,4 @@
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/style.scss
@@ -1,1 +1,3 @@
-/* css styles */
+.wp-block-wporg-code-reference-deprecated .callout:before {
+	top: 0.3em;
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/style.scss
@@ -1,3 +1,3 @@
-.wp-block-wporg-code-reference-deprecated .callout:before {
+.wp-block-wporg-code-reference-deprecated .callout::before {
 	top: 0.3em;
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/style.scss
@@ -1,3 +1,0 @@
-.wp-block-wporg-code-reference-deprecated .callout::before {
-	top: 0.3em;
-}


### PR DESCRIPTION
Related to #162 

This PR implements the deprecated code block.

## Screenshots
| Desktop | Mobile | 
| --- | --- |
| ![localhost_8888_reference_functions_absint_](https://user-images.githubusercontent.com/1657336/212662430-688199b6-b4c4-46a8-a3b9-604589b3df7d.png) |  ![localhost_8888_reference_functions_absint_(iPhone 12 Pro)](https://user-images.githubusercontent.com/1657336/212662423-af6fbabd-2dc0-4ce9-a656-a450b84a3859.png) |

## Testing
It's a bit tricky seeing that our local environment doesn't have deprecated functions. Here is how I tested.

1. Set [this](https://github.com/WordPress/wporg-developer/blob/c186671beab3622f3c11b632bd3e281963616b82/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php#L1096) to false.
2. You should now see the default banner.
3. To check that html rendering will work as expected, select HTML from the live site. [Example](https://developer.wordpress.org/reference/functions/get_blog_list/). Paste it in the DOM.

**Replace the content with this:**
```
<div class="callout callout-warning"><p><span class="screen-reader-text">Warning:</span> This function has been deprecated. Use <a href="https://developer.wordpress.org/reference/functions/wp_get_sites"></a><a href="https://developer.wordpress.org/reference/functions/wp_get_sites/" rel="function">wp_get_sites()</a>  instead.</p>
</div>
```