### PR TITLE
Block: Code Parameters

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.php
@@ -68,7 +68,7 @@ function wporg_developer_code_reference_build_params( $params ) {
 			}
 
 			if ( ! empty( $param['required'] ) && 'wp-parser-hook' !== get_post_type() ) {
-				$output .= '<span class="required">' . esc_html( $param['required'] ) . '</span>';
+				$output .= '<span class="required">' . esc_html( strtolower( $param['required'] ) ) . '</span>';
 			}
 
 			$output .= '</dt>';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -13,14 +13,15 @@
 		}
 	}
 
+	dt > code,
+	li > code { // Nested parameters.
+		font-weight: 500;
+		color: var(--wp--preset--color--charcoal-1);
+	}
+
 	dd {
 		margin: 0;
 		padding-bottom: var(--wp--preset--spacing--20);
-	}
-
-	code {
-		font-weight: 500;
-		color: var(--wp--preset--color--charcoal-1);
 	}
 
 	.required {
@@ -28,6 +29,7 @@
 		font-size: var(--wp--preset--font-size--small);
 	}
 
+	// Nested parameter list.
 	.param-hash {
 		padding-left: var(--wp--preset--spacing--10);
 		border-left: 1px solid var(--wp--preset--color--light-grey-1);
@@ -38,6 +40,7 @@
 		}
 	}
 
+	// Default values.
 	.default {
 		margin-bottom: 0;
 	}
@@ -58,6 +61,7 @@
 		margin-left: 5px;
 	}
 
+	// Visible when parameters are imported from reference.
 	summary {
 		color: var(--wp--preset--color--blueberry-1);
 		cursor: pointer;

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -1,14 +1,4 @@
 .wp-block-wporg-code-reference-parameters {
-	code {
-		font-weight: 500;
-		color: var(--wp--preset--color--charcoal-1);
-	}
-
-	.required {
-		color: var(--wp--preset--color--charcoal-4);
-		font-size: var(--wp--preset--font-size--small);
-	}
-
 	dt {
 		display: flex;
 		align-items: center;
@@ -21,12 +11,21 @@
 			font-family: var(--wp--preset--font-family--monospace);
 			font-size: var(--wp--preset--font-size--small);
 		}
-
 	}
 
 	dd {
 		margin: 0;
 		padding-bottom: var(--wp--preset--spacing--20);
+	}
+
+	code {
+		font-weight: 500;
+		color: var(--wp--preset--color--charcoal-1);
+	}
+
+	.required {
+		color: var(--wp--preset--color--charcoal-4);
+		font-size: var(--wp--preset--font-size--small);
 	}
 
 	.param-hash {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -4,6 +4,7 @@
 		align-items: center;
 		gap: var(--wp--preset--spacing--10);
 
+		.int,
 		.string,
 		.array,
 		.callable,

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -61,6 +61,7 @@
 
 	// Visible when parameters are imported from reference.
 	summary {
+		margin-top: var(--wp--preset--spacing--10);
 		color: var(--wp--preset--color--blueberry-1);
 		cursor: pointer;
 		list-style: none;

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -33,7 +33,7 @@
 		border-left: 1px solid var(--wp--preset--color--light-grey-1);
 		list-style: none;
 
-		li:not(:last-child) {
+		> li:not(:last-child) {
 			padding-bottom: var(--wp--preset--spacing--20);
 		}
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -29,6 +29,7 @@
 	// Nested parameter list.
 	.param-hash {
 		padding-left: var(--wp--preset--spacing--10);
+		margin-top: var(--wp--preset--spacing--10);
 		border-left: 1px solid var(--wp--preset--color--light-grey-1);
 		list-style: none;
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -4,11 +4,7 @@
 		align-items: center;
 		gap: var(--wp--preset--spacing--10);
 
-		.int,
-		.string,
-		.array,
-		.callable,
-		span[class="string[]"] {
+		.type span {
 			font-family: var(--wp--preset--font-family--monospace);
 			font-size: var(--wp--preset--font-size--small);
 		}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -1,1 +1,68 @@
-/* css styles */
+.wp-block-wporg-code-reference-parameters {
+	code {
+		font-weight: 500;
+		color: var(--wp--preset--color--charcoal-1);
+	}
+
+	.required {
+		color: var(--wp--preset--color--charcoal-4);
+		font-size: var(--wp--preset--font-size--small);
+	}
+
+	dt {
+		display: flex;
+		align-items: center;
+		gap: var(--wp--preset--spacing--10);
+
+		.string,
+		.array,
+		.callable,
+		span[class="string[]"] {
+			font-family: var(--wp--preset--font-family--monospace);
+			font-size: var(--wp--preset--font-size--small);
+		}
+
+	}
+
+	dd {
+		margin: 0;
+		padding-bottom: var(--wp--preset--spacing--20);
+	}
+
+	.param-hash {
+		padding-left: var(--wp--preset--spacing--10);
+		border-left: 1px solid var(--wp--preset--color--light-grey-1);
+		list-style: none;
+
+		li:not(:last-child) {
+			padding-bottom: var(--wp--preset--spacing--20);
+		}
+	}
+
+	.default {
+		margin-bottom: 0;
+	}
+
+	// This needs to be a direct descendant or properties of nested objects will also get this style.
+	.description > code,
+	.default > code,
+	.desc > code,
+	.param-hash .type {
+		padding: 4px 6px;
+		background-color: var(--wp--preset--color--light-grey-2);
+		font-size: var(--wp--preset--font-size--small);
+		border-radius: 2px;
+	}
+
+	.default > code,
+	.param-hash .type {
+		margin-left: 5px;
+	}
+
+	summary {
+		color: var(--wp--preset--color--blueberry-1);
+		cursor: pointer;
+		list-style: none;
+		text-decoration: underline;
+	}
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -4,7 +4,7 @@
 		align-items: center;
 		gap: var(--wp--preset--spacing--10);
 
-		.type span {
+		.type {
 			font-family: var(--wp--preset--font-family--monospace);
 			font-size: var(--wp--preset--font-size--small);
 		}


### PR DESCRIPTION
Related to: #162 

This PR styles the parameters.

Link: [Designs](https://www.figma.com/file/2WxlJFzMJvqPfZL1EkAOVp/Developer-Pages?node-id=1160%3A10750&t=t7ekzK2bBZF5Ku9l-0)

**TODO**
- [x] Need to add Monospace bold `500` to mu-plugins. https://github.com/WordPress/wporg-mu-plugins/pull/327

## Screenshot

| Source | Image |
| --- | --- |
| [add_settings_section](http://localhost:8888/reference/functions/add_settings_section/) | <img width="400" alt="Screen Shot 2023-01-20 at 2 07 38 PM" src="https://user-images.githubusercontent.com/1657336/213621613-59ac7f05-f5c3-4bff-a9f6-eeba73745665.png"> |
| [get_the_posts_pagination](http://localhost:8888/reference/functions/get_the_posts_pagination/) | <img width="400" alt="Screen Shot 2023-01-20 at 2 20 20 PM" src="https://user-images.githubusercontent.com/1657336/213623017-97bedc69-bc72-493f-9191-45e8bf6e2f2c.png"> |


