### PR TITLE
Blocks: Add spacing & line-height support to all blocks

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-changelog/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-changelog/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the changelog for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the deprecated message for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the description for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the explanation for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the hooks for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the code parameters for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-private-access/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-private-access/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the private access message for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-related/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-related/block.json
@@ -9,8 +9,16 @@
 	"description": "Show related code.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the return value for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the code source for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-summary/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-summary/block.json
@@ -9,8 +9,16 @@
 	"description": "Code summary for a function, method, or class.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/block.json
@@ -21,7 +21,10 @@
 	"supports": {
 		"html": false,
 		"spacing": {
-			"margin": [ "top", "bottom" ],
+			"margin": [
+				"top",
+				"bottom"
+			],
 			"padding": true
 		},
 		"typography": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/block.json
@@ -9,8 +9,16 @@
 	"description": "Show the code signature for a function, class, or method.",
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
 		"typography": {
-			"fontSize": true
+			"fontSize": true,
+			"lineHeight": true
 		}
 	},
 	"textdomain": "wporg",

--- a/source/wp-content/themes/wporg-developer-2023/src/search-filters/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/search-filters/block.json
@@ -9,7 +9,18 @@
 	"textdomain": "wporg",
 	"attributes": {},
 	"supports": {
-		"html": false
+		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
 	},
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css"

--- a/source/wp-content/themes/wporg-developer-2023/src/search-title/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/search-title/block.json
@@ -16,7 +16,10 @@
 			"link": true
 		},
 		"spacing": {
-			"margin": true,
+			"margin": [
+				"top",
+				"bottom"
+			],
 			"padding": true
 		},
 		"typography": {


### PR DESCRIPTION
This updates all the blocks to support top & bottom margin, and padding (all sides). It also updates the typography support to support changing the line height as well as font size, since usually when one changes, the other needs to change too.

Try adding spacing to any of the blocks, for example:

```
<!-- wp:wporg/code-reference-title {"style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} /-->
```

On `trunk`, that won't render any margins. On this branch, the margins are added to the element.