### PR TITLE
Block: Add code hooks.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
@@ -43,8 +43,8 @@ function render() {
 	while ( $hooks->have_posts() ) {
 		$hooks->the_post();
 		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"div","fontSize":"normal", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} /-->' );
-		wp_reset_postdata();
 	}
+	wp_reset_postdata();
 
 	$title_block = sprintf(
 		'<h2 class="wp-block-heading">%s</h2>',

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
@@ -29,10 +29,21 @@ function init() {
  * @return string Returns the block markup.
  */
 function render() {
-	$has_hooks   = ( post_type_has_hooks_info() && ( $hooks   = get_hooks() ) && $hooks->have_posts() );
-
-	if ( ! $has_hooks ) {
+	if ( ! post_type_has_hooks_info() ) {
 		return '';
+	}
+
+	$hooks = get_hooks();
+
+	if ( ! $hooks->have_posts() ) {
+		return '';
+	}
+
+	$content = array();
+	while ( $hooks->have_posts() ) {
+		$hooks->the_post();
+		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"h2","fontSize":"normal"} /-->' );
+		wp_reset_postdata();
 	}
 
 	$title_block = sprintf(
@@ -45,6 +56,6 @@ function render() {
 		'<section %s>%s %s</section>',
 		$wrapper_attributes,
 		do_blocks( $title_block ),
-		'Not Implemented'
+		join( '', $content )
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
@@ -42,7 +42,7 @@ function render() {
 	$content = array();
 	while ( $hooks->have_posts() ) {
 		$hooks->the_post();
-		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"h3","fontSize":"normal"} /-->' );
+		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"div","fontSize":"normal", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} /-->' );
 		wp_reset_postdata();
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
@@ -4,6 +4,7 @@ namespace WordPressdotorg\Theme\Developer_2023\Dynamic_Code_Hooks;
 use function DevHub\get_hooks;
 use function DevHub\post_type_has_hooks_info;
 use function DevHub\get_signature;
+use function DevHub\get_summary;
 
 add_action( 'init', __NAMESPACE__ . '\init' );
 
@@ -42,7 +43,9 @@ function render() {
 	$content = array();
 	while ( $hooks->have_posts() ) {
 		$hooks->the_post();
-		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"div","fontSize":"normal", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} /-->' );
+
+		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"dt","fontSize":"normal"} /-->' );
+		$content[] = '<dd>' . get_summary() . '</dd>';
 	}
 	wp_reset_postdata();
 
@@ -53,7 +56,7 @@ function render() {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
-		'<section %s>%s %s</section>',
+		'<section %s>%s <dl>%s</dl></section>',
 		$wrapper_attributes,
 		do_blocks( $title_block ),
 		join( '', $content )

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
@@ -42,7 +42,7 @@ function render() {
 	$content = array();
 	while ( $hooks->have_posts() ) {
 		$hooks->the_post();
-		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"h2","fontSize":"normal"} /-->' );
+		$content[] = do_blocks( '<!-- wp:wporg/code-reference-title {"isLink":true,"tagName":"h3","fontSize":"normal"} /-->' );
 		wp_reset_postdata();
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/index.js
@@ -1,5 +1,4 @@
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/style.scss
@@ -1,1 +1,4 @@
-/* css styles */
+.wp-block-wporg-code-reference-hooks p {
+	margin-top: var(--wp--preset--spacing--10);
+	margin-bottom: var(--wp--preset--spacing--30);
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/style.scss
@@ -1,4 +1,0 @@
-.wp-block-wporg-code-reference-hooks p {
-	margin-top: var(--wp--preset--spacing--10);
-	margin-bottom: var(--wp--preset--spacing--30);
-}


### PR DESCRIPTION
Related: #162

This PR makes use of the `code-reference-title` block to render hooks. We don't have a design for the hooks section so I just used the default normal-sized font and spacing I thought looked good.


## ScreenShot
<img width="757" alt="Screen Shot 2023-01-26 at 9 47 11 AM" src="https://user-images.githubusercontent.com/1657336/214729127-37e9cede-f549-44d6-8ab6-9db0da0759df.png">


## Generated HTML
```
<section class="wp-block-wporg-code-reference-hooks">
   <h2 class="wp-block-heading">Hooks</h2>
   <div style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20);" class="wp-block-wporg-code-reference-title has-normal-font-size">
      <a href="http://localhost:8888/reference/hooks/gettext/">
         <span class="hook-func">apply_filters</span>( ‘gettext’,  
         <nobr><span class="arg-type">string</span> <span class="arg-name">$translation</span></nobr>
         ,  
         <nobr><span class="arg-type">string</span> <span class="arg-name">$text</span></nobr>
         ,  
         <nobr><span class="arg-type">string</span> <span class="arg-name">$domain</span></nobr>
         )
      </a>
   </div>
   <div style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20);" class="wp-block-wporg-code-reference-title has-normal-font-size">
      <a href="http://localhost:8888/reference/hooks/gettext_domain/">
         <span class="hook-func">apply_filters</span>( “gettext_{$domain}”,  
         <nobr><span class="arg-type">string</span> <span class="arg-name">$translation</span></nobr>
         ,  
         <nobr><span class="arg-type">string</span> <span class="arg-name">$text</span></nobr>
         ,  
         <nobr><span class="arg-type">string</span> <span class="arg-name">$domain</span></nobr>
         )
      </a>
   </div>
</section>
```