### PR TITLE
Block: Add return type css.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.php
@@ -27,8 +27,6 @@ function init() {
  * @return string Returns the block markup.
  */
 function render() {
-	$wrapper_attributes = get_block_wrapper_attributes();
-
 	$content = get_return();
 
 	if ( empty( $content ) ) {
@@ -40,7 +38,7 @@ function render() {
 		__( 'Return', 'wporg' )
 	);
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wporg-has-embedded-code' ) );
 	return sprintf(
 		'<section %s>%s %s</section>',
 		$wrapper_attributes,

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
@@ -3,11 +3,4 @@
 		font-family: var(--wp--preset--font-family--monospace);
 		font-size: var(--wp--preset--font-size--small);
 	}
-
-	code {
-		padding: 4px 6px;
-		background-color: var(--wp--preset--color--light-grey-2);
-		font-size: var(--wp--preset--font-size--small);
-		border-radius: 2px;
-	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
@@ -1,4 +1,3 @@
-
 .wp-block-wporg-code-reference-return-value {
 	.return-type {
 		font-family: var(--wp--preset--font-family--monospace);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
@@ -1,1 +1,14 @@
-/* css styles */
+
+.wp-block-wporg-code-reference-return-value {
+	.return-type {
+		font-family: var(--wp--preset--font-family--monospace);
+		font-size: var(--wp--preset--font-size--small);
+	}
+
+	code {
+		padding: 4px 6px;
+		background-color: var(--wp--preset--color--light-grey-2);
+		font-size: var(--wp--preset--font-size--small);
+		border-radius: 2px;
+	}
+}


### PR DESCRIPTION
Related To: #162 

This PR adds some styles to the return value component so it looks like the parameters section. This relies on a global style that I hope we add in #177 ([Ref](https://github.com/WordPress/wporg-developer/pull/177/files#diff-5a967de023463491bebbfaca0909be4be783855fcace73f96a9a0e9c8060224aR94))

Also when viewing some of the returns summaries, not all code was parsed correctly and some variables are not wrapped in a `<code>` tag. I think getting the parsing right falls out of the scope of this PR.

## [get_post](http://localhost:8888/reference/functions/get_post/)
<img width="655" alt="Screen Shot 2023-01-26 at 10 13 00 AM" src="https://user-images.githubusercontent.com/1657336/214733227-531d1e72-bf6f-45a4-86ec-6339a1befb05.png">

_Note the $output is not styles because of it not being parsed._

## [get_link](http://localhost:8888/reference/functions/get_link/)
<img width="681" alt="Screen Shot 2023-01-26 at 10 12 20 AM" src="https://user-images.githubusercontent.com/1657336/214733230-44f46fe4-838a-4c40-97af-adccc6e904c3.png">

## [get_role](http://localhost:8888/reference/functions/get_role/)
<img width="565" alt="Screen Shot 2023-01-26 at 10 15 09 AM" src="https://user-images.githubusercontent.com/1657336/214733320-8e2c4af2-4d8b-4697-9f55-2655eb74ed71.png">
