### PR TITLE
Block: Fix explanation

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.php
@@ -38,7 +38,7 @@ function render() {
 		__( 'More Information', 'wporg' )
 	);
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wporg-has-embedded-code' ) );
 	return sprintf(
 		'<section %s>%s %s</section>',
 		$wrapper_attributes,

--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/index.js
@@ -1,5 +1,4 @@
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies

--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/style.scss
@@ -1,1 +1,0 @@
-/* css styles */

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -91,3 +91,10 @@
 		text-decoration: underline;
 	}
 }
+
+.wporg-has-embedded-code code {
+	padding: 4px 6px;
+	background-color: var(--wp--preset--color--light-grey-2);
+	font-size: var(--wp--preset--font-size--small);
+	border-radius: 2px;
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -92,7 +92,8 @@
 	}
 }
 
-.wporg-has-embedded-code code {
+// Style code tags but not ones inside of the code block.
+.wporg-has-embedded-code *:not(.wp-block-code) > code {
 	padding: 4px 6px;
 	background-color: var(--wp--preset--color--light-grey-2);
 	font-size: var(--wp--preset--font-size--small);


### PR DESCRIPTION
Related To: #162 

This PR styles the "More Information" section when viewing the code. This adds an style that styles `<code>` tags to be used by other components. This style seems to be common accross a few components.

## Screenshots
<img width="674" alt="Screen Shot 2023-01-26 at 11 28 52 AM" src="https://user-images.githubusercontent.com/1657336/214750945-aa18eef9-89ab-41f2-9911-0eac487acc66.png">

## How to test
Explanations are rich content explanations. I've gone through a number of them in production and nothing jumps out as complicated. They do include some basic HTML tags, including `<code>`

1. Visit http://localhost:8888/wp-admin/edit.php?post_type=wp-parser-function
2. Hover over item in the table, click "Add Explanation"
3. Add content into the explanation textarea and save.
4. Visit that `function`
5. Verify the "More Information" section appears

