### PR TITLE
Blocks: Add postId to all blocks, fix ServerSideRender display

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-changelog/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-changelog/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the changelog for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-changelog/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-changelog/block.php
@@ -22,9 +22,13 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
+function render( $attributes, $content, $block ) {
 	if ( empty( $content ) ) {
 		return '';
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-changelog/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-changelog/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-changelog/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-changelog/index.js
@@ -1,11 +1,14 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the deprecated message for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/block.php
@@ -24,10 +24,18 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	$deprecated_html = get_deprecated();
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$deprecated_html = get_deprecated( $block->context['postId'] );
 
 	if ( empty( $deprecated_html ) ) {
 		return '';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-deprecated/index.js
@@ -1,9 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
 
 registerBlockType( metadata.name, {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the description for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -25,10 +25,18 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	$content = wporg_developer_code_reference_description_render();
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$content = get_description_content( $block->context['postId'] );
 
 	if ( empty( $content ) ) {
 		return '';
@@ -53,10 +61,11 @@ function render() {
  *
  * @return string
  */
-function wporg_developer_code_reference_description_render() {
+function get_description_content( $post_id ) {
 	$output = '';
-	$description = get_description();
-	$see_tags    = get_see_tags();
+
+	$description = get_description( $post_id );
+	$see_tags    = get_see_tags( $post_id );
 
 	if ( ! $description && ! $see_tags ) {
 		return '';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/index.js
@@ -1,11 +1,14 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the explanation for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/block.php
@@ -24,10 +24,18 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	$explanation = get_explanation_content( get_the_ID() );
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$explanation = get_explanation_content( $block->context['postId'] );
 
 	if ( empty( $explanation ) ) {
 		return '';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-explanation/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-explanation/index.js
@@ -1,9 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
 
 registerBlockType( metadata.name, {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the hooks for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/block.php
@@ -27,14 +27,24 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	if ( ! post_type_has_hooks_info() ) {
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
 
-	$hooks = get_hooks();
+	$post_id = $block->context['postId'];
+
+	if ( ! post_type_has_hooks_info( get_post_type( $post_id ) ) ) {
+		return '';
+	}
+
+	$hooks = get_hooks( $post_id );
 
 	if ( ! $hooks->have_posts() ) {
 		return '';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-hooks/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-hooks/index.js
@@ -1,9 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
 
 registerBlockType( metadata.name, {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the code parameters for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/block.php
@@ -25,11 +25,18 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	$wrapper_attributes = get_block_wrapper_attributes();
-	$params = get_params();
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$params = get_params( $block->context['postId'] );
 
 	if ( empty( $params ) ) {
 		return '';
@@ -45,7 +52,7 @@ function render() {
 		'<section %s>%s %s</section>',
 		$wrapper_attributes,
 		$title_block,
-		wporg_developer_code_reference_build_params( $params )
+		get_param_content( $params )
 	);
 }
 
@@ -55,7 +62,7 @@ function render() {
  * @param [type] $params
  * @return string
  */
-function wporg_developer_code_reference_build_params( $params ) {
+function get_param_content( $params ) {
 	$output = '<dl>';
 
 	foreach ( $params as $param ) {
@@ -83,6 +90,7 @@ function wporg_developer_code_reference_build_params( $params ) {
 			if ( $extra ) {
 				$output .= '<span class="description">' . wp_kses_post( $param['content'] ) . '</span>';
 				$output .= '<details class="extended-description">';
+				/* translators: 1: function name, 2: variable name */
 				$output .= '<summary>' . esc_html( sprintf( __( 'More Arguments from %1$s( ... %2$s )', 'wporg' ), $extra['parent'], $extra['parent_var'] ) ) . '</summary>';
 				$output .= '<span class="description">' . wp_kses_post( $extra['content'] ) . '</span>';
 				$output .= '</details>';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/index.js
@@ -1,11 +1,14 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-private-access/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-private-access/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the private access message for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-private-access/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-private-access/block.php
@@ -24,10 +24,18 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	$html = get_private_access_message();
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$html = get_private_access_message( $block->context['postId'] );
 
 	if ( empty( $html ) ) {
 		return '';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-private-access/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-private-access/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-private-access/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-private-access/index.js
@@ -1,9 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
 
 registerBlockType( metadata.name, {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-related/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-related/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show related code.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-related/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-related/block.php
@@ -30,21 +30,32 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
 	$uses        = null;
 	$used_by     = null;
 	$has_uses    = false;
 	$has_used_by = false;
 
-	if ( post_type_has_uses_info() ) {
-		$uses     = get_uses();
+	$post_id   = $block->context['postId'];
+	$post_type = get_post_type( $post_id );
+
+	if ( post_type_has_uses_info( $post_type ) ) {
+		$uses     = get_uses( $post_id );
 		$has_uses = $uses->have_posts();
 	}
 
-	if ( post_type_has_usage_info() ) {
-		$used_by     = get_used_by();
+	if ( post_type_has_usage_info( $post_type ) ) {
+		$used_by     = get_used_by( $post_id );
 		$has_used_by = $used_by->have_posts();
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-related/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-related/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-related/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-related/index.js
@@ -1,9 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
 
 registerBlockType( metadata.name, {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the return value for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/block.php
@@ -24,10 +24,18 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	$content = get_return();
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$content = get_return( $block->context['postId'] );
 
 	if ( empty( $content ) ) {
 		return '';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/index.js
@@ -1,11 +1,14 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the code source for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/block.php
@@ -29,10 +29,18 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	$content = wporg_developer_code_reference_source_render();
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$content = get_source_content( $block->context['postId'] );
 
 	if ( empty( $content ) ) {
 		return '';
@@ -55,14 +63,17 @@ function render() {
 /**
  * Returns code sample html.
  *
+ * @param int $post_id
+ *
  * @return string
  */
-function wporg_developer_code_reference_source_render() {
-	$source_file = get_source_file();
-	$output = '';
+function get_source_content( $post_id ) {
+	$post_type   = get_post_type( $post_id );
+	$source_file = get_source_file( $post_id );
+	$output      = '';
 
 	if ( ! empty( $source_file ) ) {
-		$source_code = post_type_has_source_code() ? get_source_code() : '';
+		$source_code = post_type_has_source_code( $post_type ) ? get_source_code( $post_id ) : '';
 
 		$view_reference_button = sprintf(
 			'<a href="%s">%s</a>',
@@ -72,13 +83,13 @@ function wporg_developer_code_reference_source_render() {
 
 		$view_trac_button = sprintf(
 			'<a href="%s">%s</a>',
-			esc_url( get_source_file_link() ),
+			esc_url( get_source_file_link( $post_id ) ),
 			__( 'View on Trac', 'wporg' )
 		);
 
 		$view_github_button = sprintf(
 			'<a href="%s">%s</a>',
-			esc_url( get_github_source_file_link() ),
+			esc_url( get_github_source_file_link( $post_id ) ),
 			__( 'View on GitHub', 'wporg' )
 		);
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/index.js
@@ -1,11 +1,14 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-summary/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-summary/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Code summary for a function, method, or class.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-summary/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-summary/block.php
@@ -24,13 +24,21 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
 		'<section %1$s>%2$s</section>',
 		$wrapper_attributes,
-		get_summary()
+		get_summary( $block->context['postId'] )
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-summary/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-summary/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-summary/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-summary/index.js
@@ -1,11 +1,14 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/block.json
@@ -34,5 +34,6 @@
 	},
 	"textdomain": "wporg",
 	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css"
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.js
@@ -1,17 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function Edit( { attributes, setAttributes, name, context } ) {
+/**
+ * Internal dependencies
+ */
+import DynamicEdit from '../shared/dynamic-edit';
+import './edit.scss';
+
+export default function Edit( { ...props } ) {
+	const { attributes, setAttributes } = props;
 	const { isLink, tagName } = attributes;
-	const { postId } = context;
-	const blockProps = useBlockProps();
 	return (
-		<div { ...blockProps }>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'wporg' ) }>
 					<ToggleControl
@@ -38,12 +42,7 @@ export default function Edit( { attributes, setAttributes, name, context } ) {
 					onChange={ ( val ) => setAttributes( { tagName: val } ) }
 				/>
 			</InspectorControls>
-			<ServerSideRender
-				block={ name }
-				attributes={ attributes }
-				skipBlockSupportAttributes
-				urlQueryArgs={ { post_id: postId } }
-			/>
-		</div>
+			<DynamicEdit { ...props } />
+		</>
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.js
@@ -6,8 +6,9 @@ import ServerSideRender from '@wordpress/server-side-render';
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function Edit( { attributes, setAttributes, name } ) {
+export default function Edit( { attributes, setAttributes, name, context } ) {
 	const { isLink, tagName } = attributes;
+	const { postId } = context;
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
@@ -37,7 +38,12 @@ export default function Edit( { attributes, setAttributes, name } ) {
 					onChange={ ( val ) => setAttributes( { tagName: val } ) }
 				/>
 			</InspectorControls>
-			<ServerSideRender block={ name } skipBlockSupportAttributes attributes={ attributes } />
+			<ServerSideRender
+				block={ name }
+				attributes={ attributes }
+				skipBlockSupportAttributes
+				urlQueryArgs={ { post_id: postId } }
+			/>
 		</div>
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.scss
@@ -1,3 +1,3 @@
 .wp-block .wp-block-wporg-code-reference-title {
-    font-size: inherit !important;
+	font-size: inherit !important;
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/edit.scss
@@ -1,0 +1,3 @@
+.wp-block .wp-block-wporg-code-reference-title {
+    font-size: inherit !important;
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "smiley",
 	"description": "Show the code signature for a function, class, or method.",
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/block.php
@@ -22,9 +22,17 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
 	$title_block = sprintf(
 		'<h2 class="wp-block-heading">%s</h2>',
 		__( 'User Contributed Notes', 'wporg' )

--- a/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/edit.js
@@ -1,5 +1,0 @@
-import ServerSideRender from '@wordpress/server-side-render';
-
-export default function Edit( { name, attributes } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
-}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-user-notes/index.js
@@ -1,11 +1,14 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
-import './style.scss';
 
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
+import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/shared/dynamic-edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/shared/dynamic-edit.js
@@ -4,12 +4,11 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
-export default function Edit( { name, attributes, children, context } ) {
+export default function Edit( { name, attributes, context } ) {
 	const blockProps = useBlockProps();
 	const { postId } = context;
 	return (
 		<div { ...blockProps }>
-			{ children }
 			<ServerSideRender
 				block={ name }
 				attributes={ attributes }

--- a/source/wp-content/themes/wporg-developer-2023/src/shared/dynamic-edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/shared/dynamic-edit.js
@@ -4,12 +4,18 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
-export default function Edit( { name, attributes, children } ) {
+export default function Edit( { name, attributes, children, context } ) {
 	const blockProps = useBlockProps();
+	const { postId } = context;
 	return (
 		<div { ...blockProps }>
 			{ children }
-			<ServerSideRender block={ name } attributes={ attributes } skipBlockSupportAttributes />
+			<ServerSideRender
+				block={ name }
+				attributes={ attributes }
+				skipBlockSupportAttributes
+				urlQueryArgs={ { post_id: postId } }
+			/>
 		</div>
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/shared/dynamic-edit.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/shared/dynamic-edit.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
+
+export default function Edit( { name, attributes, children } ) {
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			{ children }
+			<ServerSideRender block={ name } attributes={ attributes } skipBlockSupportAttributes />
+		</div>
+	);
+}


### PR DESCRIPTION
There are updates here that touch every code-reference block:
- **Use a shared edit component to render dynamic blocks**
    Almost all the edit components were the same, and while I was going to just add the `skipBlockSupportAttributes` prop to all the `ServerSideRender`s (see https://github.com/WordPress/wporg-developer/pull/171#issuecomment-1399037104), I thought this might be better. Instead of each block with an edit file, there's now a single `shared/dynamic-edit.js` which each block can call (and it includes the `skipBlockSupportAttributes`).
- **Add postId context to blocks**
    Since blocks can be used in different contexts, this ensures the global `post` being used to show information is the correct post. This will let us use the blocks in, for example, a Query Loop, for archive views.
    For ServerSideRender to understand this value, we need to pass it through via `urlQueryArgs`, but since the dynamic edit component exists, this is a much simpler change.

**To test:**

- Check that there are no regressions on the code reference page
- Try these out in the editor with a Query Loop block, for example:

```html
<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":0,"offset":0,"postType":"wp-parser-hook","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"wp-parser-since":[103]},"parents":[]},"displayLayout":{"type":"list","columns":3}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:wporg/code-reference-title {"tagName":"p"} /-->

<!-- wp:wporg/code-reference-summary /-->
<!-- /wp:post-template --></div>
<!-- /wp:query -->
```

<img width="749" alt="Screenshot 2023-01-27 at 4 34 09 PM" src="https://user-images.githubusercontent.com/541093/215204880-9d73958c-40f2-4b66-b8f5-7e36f8311e70.png">

Note — if you display the functions in a Query Loop, an extra `()` is added [thanks to this filter](https://github.com/WordPress/wporg-developer/blob/6b10d20524048cfca6324b9509d1ad2e8bad8c1c/source/wp-content/themes/wporg-developer-2023/inc/extras.php#L39). This doesn't mess with anything real, yet, so I've left it alone.