### PR TITLE
New block: Chapter List for handbooks

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -142,6 +142,7 @@ require __DIR__ . '/inc/shortcodes.php';
 require __DIR__ . '/inc/block-hooks.php';
 
 // Block files
+require_once __DIR__ . '/src/chapter-list/block.php';
 require_once __DIR__ . '/src/code-changelog/block.php';
 require_once __DIR__ . '/src/code-deprecated/block.php';
 require_once __DIR__ . '/src/code-description/block.php';

--- a/source/wp-content/themes/wporg-developer-2023/images/chevron.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/chevron.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M.956 6.445 6.961.986l6.004 5.459-1.009 1.11-4.995-4.541-4.996 4.54L.956 6.446Z" fill="#000"/>
+</svg>

--- a/source/wp-content/themes/wporg-developer-2023/images/line.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/line.svg
@@ -1,3 +1,3 @@
-<svg width="15" height="2" viewBox="0 0 15 2" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M0 0h14v1.5h-14V0Z" fill="#000"/>
+<svg width="10" height="1" viewBox="0 0 10 1" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 0h10v1h-10V0Z" fill="#000"/>
 </svg>

--- a/source/wp-content/themes/wporg-developer-2023/images/line.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/line.svg
@@ -1,3 +1,3 @@
 <svg width="15" height="2" viewBox="0 0 15 2" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M.96.25h14v1.5h-14V.25Z" fill="#3858E9"/>
+  <path d="M0 0h14v1.5h-14V0Z" fill="#000"/>
 </svg>

--- a/source/wp-content/themes/wporg-developer-2023/images/line.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/line.svg
@@ -1,0 +1,3 @@
+<svg width="15" height="2" viewBox="0 0 15 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M.96.25h14v1.5h-14V.25Z" fill="#3858E9"/>
+</svg>

--- a/source/wp-content/themes/wporg-developer-2023/patterns/single-handbook.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/single-handbook.php
@@ -7,15 +7,17 @@
 
 ?>
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide"} -->
-	<div class="wp-block-group alignwide">
+	<!-- wp:group {"className":"has-three-columns","layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space"}}}} -->
+	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:wporg/chapter-list /-->
 
 		<!-- wp:group {"tagName":"article"} -->
 		<article class="wp-block-group">
-			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} /-->
+			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 
 			<!-- wp:group {"tagName":"aside","className":"sidebar-container"} -->
 			<aside class="wp-block-group sidebar-container">
@@ -30,56 +32,58 @@
 			<!-- /wp:group -->
 
 			<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|20"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+					<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'First published', 'wporg' ); ?></p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:post-date {"fontSize":"normal"} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+					<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Last updated', 'wporg' ); ?></p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+					<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Edit article', 'wporg' ); ?></p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:paragraph {"className":"external-link"} -->
+					<p class="external-link"><a href="#"><?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?></a></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+					<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Changelog', 'wporg' ); ?></p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:paragraph {"className":"external-link"} -->
+					<p class="external-link"><a href="#"><?php esc_html_e( 'See list of changes', 'wporg' ); ?></a></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+
 		</article>
 		<!-- /wp:group -->
 
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|20"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-		<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'First published', 'wporg' ); ?></p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:post-date {"fontSize":"normal"} /-->
-			</div>
-			<!-- /wp:group -->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Last updated', 'wporg' ); ?></p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
-			</div>
-			<!-- /wp:group -->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Edit article', 'wporg' ); ?></p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:paragraph {"className":"external-link"} -->
-				<p class="external-link"><a href="#"><?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?></a></p>
-				<!-- /wp:paragraph -->
-			</div>
-			<!-- /wp:group -->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Changelog', 'wporg' ); ?></p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:paragraph {"className":"external-link"} -->
-				<p class="external-link"><a href="#"><?php esc_html_e( 'See list of changes', 'wporg' ); ?></a></p>
-				<!-- /wp:paragraph -->
-			</div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-developer-2023/patterns/single-handbook.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/single-handbook.php
@@ -13,17 +13,17 @@
 	<!-- wp:group {"className":"has-three-columns","layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space"}}}} -->
 	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:wporg/chapter-list /-->
+		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|edge-space"}}}} /-->
 
-		<!-- wp:group {"tagName":"article"} -->
-		<article class="wp-block-group">
+		<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
+		<article class="wp-block-group" style="margin-top:0px">
 			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 
 			<!-- wp:group {"tagName":"aside","className":"sidebar-container"} -->
 			<aside class="wp-block-group sidebar-container">
 				<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"<?php esc_attr_e( 'Search in the documentation', 'wporg' ); ?>"} /-->
 
-				<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"blueberry-1"} /-->
+				<!-- wp:wporg/table-of-contents {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} /-->
 
 				<!-- wp:paragraph {"fontSize":"small","className":"is-link-to-top"} -->
 				<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target"><?php esc_html_e( '↑ Back to top', 'wporg' ); ?></a></p>

--- a/source/wp-content/themes/wporg-developer-2023/patterns/single-handbook.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/single-handbook.php
@@ -13,7 +13,7 @@
 	<!-- wp:group {"className":"has-three-columns","layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space"}}}} -->
 	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|edge-space"}}}} /-->
+		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"80px"}}}} /-->
 
 		<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 		<article class="wp-block-group" style="margin-top:0px">

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.json
@@ -30,5 +30,6 @@
 	},
 	"textdomain": "wporg",
 	"editorScript": "file:./index.js",
-	"style": "file:./style-index.css"
+	"style": "file:./style-index.css",
+	"viewScript": "file:./view.js"
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/chapter-list",
+	"version": "0.1.0",
+	"title": "Chapter Navigation",
+	"category": "widgets",
+	"icon": "smiley",
+	"description": "",
+	"usesContext": [ "postId" ],
+	"attributes": {
+		"postType": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"textdomain": "wporg",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
@@ -1,0 +1,81 @@
+<?php
+namespace WordPressdotorg\Theme\Developer_2023\Chapter_List;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/chapter-list',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_id   = $block->context['postId'];
+	$post_type = get_post_type( $post_id );
+
+	$args = array(
+		'title_li'    => '',
+		'echo'        => 0,
+		'sort_column' => 'menu_order',
+		'post_type'   => $post_type,
+	);
+
+	$post_type_obj = get_post_type_object( $post_type );
+
+	if ( $post_type_obj && current_user_can( $post_type_obj->cap->read_private_posts ) ) {
+		$args['post_status'] = array( 'publish', 'private' );
+	}
+
+	// Exclude root handbook page from the table of contents.
+	$page = get_page_by_path( $post_type, OBJECT, $post_type );
+	if ( ! $page ) {
+		$slug = str_replace( '-handbook', '', $post_type );
+		$page = get_page_by_path( $slug, OBJECT, $post_type );
+	}
+	if ( $page && ! $instance['show_home'] ) {
+		$args['exclude'] = rtrim( $page->ID . ',' . $args['exclude'], ',' );
+	}
+
+	// Use custom walker that excludes display of orphaned pages. (An ancestor
+	// of such a page is likely not published and thus this is not accessible.)
+	$args['walker'] = new \WPorg_Handbook_Walker;
+
+	$content = wp_list_pages( $args );
+
+	$title = do_blocks(
+		'<!-- wp:heading {"fontSize":"normal","fontFamily":"inter"} -->
+		<h2 class="wp-block-heading has-inter-font-family has-normal-font-size">' . __( 'Chapters', 'wporg' ) . '</h2>
+		<!-- /wp:heading -->'
+	);
+
+	$wrapper_attributes = get_block_wrapper_attributes([ 'class' => 'menu-table-of-contents-container' ]);
+	return sprintf(
+		'<nav %1$s>%2$s<ul>%3$s</ul></nav>',
+		$wrapper_attributes,
+		$title,
+		$content
+	);
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/class-chapter-walker.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/class-chapter-walker.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Custom walker for chapter block page list.
+ *
+ * Identical to `Walker_Page` except with a `walk()` that ignores orphaned
+ * pages, which are pages with an ancestor that is not published.
+ */
+
+namespace WordPressdotorg\Theme\Developer_2023\Chapter_List;
+
+class Chapter_Walker extends \Walker_Page {
+
+	/**
+	 * Display array of elements hierarchically.
+	 *
+	 * Does not assume any existing order of elements.
+	 *
+	 * $max_depth = -1 means flatly display every element.
+	 * $max_depth = 0 means display all levels.
+	 * $max_depth > 0 specifies the number of display levels.
+	 *
+	 * NOTE: This is identical to `Walker::walk()` except that it ignores orphaned
+	 * pages, which are essentially pages whose ancestor is not published.
+	 *
+	 * @param array $elements  An array of elements.
+	 * @param int   $max_depth The maximum hierarchical depth.
+	 * @param mixed ...$args   Optional additional arguments.
+	 * @return string The hierarchical item output.
+	 */
+	public function walk( $elements, $max_depth, ...$args ) {
+		$output = '';
+
+		//invalid parameter or nothing to walk
+		if ( $max_depth < -1 || empty( $elements ) ) {
+			return $output;
+		}
+
+		$parent_field = $this->db_fields['parent'];
+
+		// flat display
+		if ( -1 === $max_depth ) {
+			$empty_array = array();
+			foreach ( $elements as $e ) {
+				$this->display_element( $e, $empty_array, 1, 0, $args, $output );
+			}
+			return $output;
+		}
+
+		/*
+		 * Need to display in hierarchical order.
+		 * Separate elements into two buckets: top level and children elements.
+		 * Children_elements is two dimensional array, eg.
+		 * Children_elements[10][] contains all sub-elements whose parent is 10.
+		 */
+		$top_level_elements = array();
+		$children_elements  = array();
+		foreach ( $elements as $e ) {
+			if ( empty( $e->$parent_field ) ) {
+				$top_level_elements[] = $e;
+			} else {
+				$children_elements[ $e->$parent_field ][] = $e;
+			}
+		}
+
+		/*
+		 * When none of the elements is top level.
+		 * Assume the first one must be root of the sub elements.
+		 */
+		if ( empty( $top_level_elements ) ) {
+			$first = array_slice( $elements, 0, 1 );
+			$root  = $first[0];
+
+			$top_level_elements = array();
+			$children_elements  = array();
+			foreach ( $elements as $e ) {
+				if ( $root->$parent_field === $e->$parent_field ) {
+					$top_level_elements[] = $e;
+				} else {
+					$children_elements[ $e->$parent_field ][] = $e;
+				}
+			}
+		}
+
+		foreach ( $top_level_elements as $e ) {
+			$this->display_element( $e, $children_elements, $max_depth, 0, $args, $output );
+		}
+
+		/*
+		 * Here is where it differs from the original `walk()`. The original would
+		 * automatically display orphans.
+		 */
+
+		return $output;
+	}
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import ServerSideRender from '@wordpress/server-side-render';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: ( { name, attributes } ) => {
+		return <ServerSideRender block={ name } attributes={ attributes } skipBlockSupportAttributes />;
+	},
+} );

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/index.js
@@ -2,16 +2,14 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import ServerSideRender from '@wordpress/server-side-render';
 
 /**
  * Internal dependencies
  */
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
 import './style.scss';
 
 registerBlockType( metadata.name, {
-	edit: ( { name, attributes } ) => {
-		return <ServerSideRender block={ name } attributes={ attributes } skipBlockSupportAttributes />;
-	},
+	edit: Edit,
 } );

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -1,0 +1,18 @@
+.wp-block-wporg-chapter-list {
+	> ul {
+		padding-left: 0;
+		list-style-type: none;
+	}
+
+	li li {
+		display: none;
+	}
+
+	li:nth-child(2) li {
+		display: revert;
+
+		li {
+			display: none;
+		}
+	}
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -67,7 +67,6 @@
 		display: inline-block;
 		mask-image: url(../../images/line.svg);
 		mask-repeat: no-repeat;
-		mask-size: 0.8em 0.2em;
 		mask-position: center;
 		background-color: var(--wp--preset--color--light-grey-1);
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -69,7 +69,7 @@
 		mask-repeat: no-repeat;
 		mask-size: 0.8em 0.2em;
 		mask-position: center;
-		background-color: var(--wp--preset--color--blueberry-1);
+		background-color: var(--wp--preset--color--light-grey-1);
 	}
 
 	.wporg-chapter-list--button-group > button {
@@ -84,6 +84,7 @@
 			mask-image: url(../../images/chevron.svg);
 			mask-size: 0.8em 0.4em;
 			transform: rotate(180deg);
+			background-color: var(--wp--preset--color--blueberry-1);
 		}
 
 		&[aria-expanded="true"]::before {

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -1,18 +1,101 @@
 .wp-block-wporg-chapter-list {
-	> ul {
-		padding-left: 0;
+	--local--line-height: var(--wp--custom--body--small--typography--line-height);
+	line-height: var(--local--line-height);
+
+	h2 {
+		margin-top: 16px;
+		margin-bottom: var(--wp--preset--spacing--20);
+	}
+
+	ul {
+		margin-top: 0;
+		margin-bottom: 0;
 		list-style-type: none;
 	}
 
-	li li {
-		display: none;
+	ul ul {
+		margin-left: 0.4em;
+		padding-left: calc(var(--wp--preset--spacing--20) / 2);
+		border-left: 1px solid var(--wp--preset--color--light-grey-1);
 	}
 
-	li:nth-child(2) li {
-		display: revert;
+	li {
+		margin-block: calc(var(--wp--preset--spacing--20) / 4);
+	}
 
-		li {
-			display: none;
+	> ul {
+		padding-left: 0;
+
+		> li {
+			margin-block: calc(var(--wp--preset--spacing--20) / 2);
 		}
+	}
+
+	&.has-js-control ul ul {
+		display: none;
+
+		&.is-open {
+			display: revert;
+		}
+	}
+
+	// Style the dash & chevron, most of the styles can be shared.
+	&.has-js-control li:not(.page_item_has_children),
+	.wporg-chapter-list--button-group {
+		display: flex;
+		align-items: flex-start;
+	}
+
+	&.has-js-control li:not(.page_item_has_children)::before,
+	.wporg-chapter-list--button-group > button {
+		// Optically center the icon with the first line of text.
+		margin-block-start: calc(var(--local--line-height) * 0.5em - 0.5em);
+		// Add space between button & link.
+		margin-inline-end: 0.25em;
+		font-size: inherit;
+		height: 1em;
+		width: 1em;
+	}
+
+	&.has-js-control li:not(.page_item_has_children)::before,
+	.wporg-chapter-list--button-group > button::before {
+		content: "";
+		display: inline-block;
+		mask-image: url(../../images/line.svg);
+		mask-repeat: no-repeat;
+		mask-size: 0.8em 0.2em;
+		mask-position: center;
+		background-color: var(--wp--preset--color--blueberry-1);
+	}
+
+	.wporg-chapter-list--button-group > button {
+		background-color: transparent;
+		border: none;
+		padding: 0;
+
+		&::before {
+			height: 1em;
+			width: 1em;
+			mask-image: url(../../images/chevron.svg);
+			mask-size: 0.8em 0.4em;
+			transform: rotate(180deg);
+		}
+
+		&[aria-expanded="true"]::before {
+			transform: revert;
+		}
+
+		&:focus-visible {
+			outline: 1px dashed var(--wp--preset--color--blueberry-1);
+			outline-offset: 2px;
+		}
+	}
+
+	// Descendent is `span` if there are children, or `a` if not.
+	.current_page_ancestor > span,
+	.current_page_ancestor > a,
+	.current_page_item > span,
+	.current_page_item > a {
+		font-weight: 600;
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -3,7 +3,6 @@
 	line-height: var(--local--line-height);
 
 	h2 {
-		margin-top: 16px;
 		margin-bottom: var(--wp--preset--spacing--20);
 	}
 
@@ -14,7 +13,7 @@
 	}
 
 	ul ul {
-		margin-left: 0.4em;
+		margin-left: 0.46em;
 		padding-left: calc(var(--wp--preset--spacing--20) / 2);
 		border-left: 1px solid var(--wp--preset--color--light-grey-1);
 	}
@@ -46,6 +45,7 @@
 		align-items: flex-start;
 	}
 
+	&:not(.has-js-control) li::before,
 	&.has-js-control li:not(.page_item_has_children)::before,
 	.wporg-chapter-list--button-group > button {
 		// Optically center the icon with the first line of text.
@@ -57,6 +57,12 @@
 		width: 1em;
 	}
 
+	&:not(.has-js-control) li::before {
+		margin-block-start: 0;
+		height: 0.8em;
+	}
+
+	&:not(.has-js-control) li::before,
 	&.has-js-control li:not(.page_item_has_children)::before,
 	.wporg-chapter-list--button-group > button::before {
 		content: "";

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -1,5 +1,6 @@
 .wp-block-wporg-chapter-list {
 	--local--line-height: var(--wp--custom--body--small--typography--line-height);
+	--local--button-size: calc(var(--local--line-height) * 1em);
 	line-height: var(--local--line-height);
 
 	h2 {
@@ -13,8 +14,8 @@
 	}
 
 	ul ul {
-		margin-left: 0.46em;
-		padding-left: calc(var(--wp--preset--spacing--20) / 2);
+		margin-left: calc(var(--local--button-size) / 2);
+		padding-left: calc(var(--wp--preset--spacing--20) / 4);
 		border-left: 1px solid var(--wp--preset--color--light-grey-1);
 	}
 
@@ -48,17 +49,14 @@
 	&:not(.has-js-control) li::before,
 	&.has-js-control li:not(.page_item_has_children)::before,
 	.wporg-chapter-list--button-group > button {
-		// Optically center the icon with the first line of text.
-		margin-block-start: calc(var(--local--line-height) * 0.5em - 0.5em);
 		// Add space between button & link.
 		margin-inline-end: 0.25em;
 		font-size: inherit;
-		height: 1em;
-		width: 1em;
+		height: var(--local--button-size);
+		width: var(--local--button-size);
 	}
 
 	&:not(.has-js-control) li::before {
-		margin-block-start: 0;
 		height: 0.8em;
 	}
 
@@ -78,10 +76,11 @@
 		background-color: transparent;
 		border: none;
 		padding: 0;
+		cursor: pointer;
 
 		&::before {
-			height: 1em;
-			width: 1em;
+			height: var(--local--button-size);
+			width: var(--local--button-size);
 			mask-image: url(../../images/chevron.svg);
 			mask-size: 0.8em 0.4em;
 			transform: rotate(180deg);
@@ -93,7 +92,6 @@
 
 		&:focus-visible {
 			outline: 1px dashed var(--wp--preset--color--blueberry-1);
-			outline-offset: 2px;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/view.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/view.js
@@ -1,0 +1,44 @@
+const init = () => {
+	const container = document.querySelector( '.wp-block-wporg-chapter-list > ul' );
+	if ( container ) {
+		container.parentNode.classList.toggle( 'has-js-control' );
+
+		const parents = container.querySelectorAll( '.page_item_has_children' );
+		parents.forEach( ( item ) => {
+			// Get link, remove (will re-ad later).
+			const link = item.querySelector( ':scope > a' );
+			link.remove();
+
+			// Get submenu
+			const submenu = item.querySelector( ':scope > ul' );
+
+			// Create the toggle button.
+			const button = document.createElement( 'button' );
+			button.setAttribute( 'aria-expanded', false );
+			// button.setAttribute( 'aria-label', '' );
+			button.onclick = () => {
+				submenu.classList.toggle( 'is-open' );
+				// This attribute returns a string.
+				const isOpen = button.getAttribute( 'aria-expanded' );
+				button.setAttribute( 'aria-expanded', isOpen === 'false' );
+			};
+
+			const buttonGroup = document.createElement( 'span' );
+			buttonGroup.className = 'wporg-chapter-list--button-group';
+			buttonGroup.append( button, link );
+
+			item.insertBefore( buttonGroup, submenu );
+
+			// Automatically open the trail to the current page.
+			if (
+				item.classList.contains( 'current_page_item' ) ||
+				item.classList.contains( 'current_page_ancestor' )
+			) {
+				submenu.classList.toggle( 'is-open' );
+				button.setAttribute( 'aria-expanded', true );
+			}
+		} );
+	}
+};
+
+window.addEventListener( 'load', init );

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/view.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/view.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
 const init = () => {
 	const container = document.querySelector( '.wp-block-wporg-chapter-list > ul' );
 	if ( container ) {
@@ -15,12 +20,26 @@ const init = () => {
 			// Create the toggle button.
 			const button = document.createElement( 'button' );
 			button.setAttribute( 'aria-expanded', false );
-			// button.setAttribute( 'aria-label', '' );
+			// translators: %s link title.
+			button.setAttribute( 'aria-label', sprintf( __( 'Open %s submenu', 'wporg' ), link.innerText ) );
 			button.onclick = () => {
 				submenu.classList.toggle( 'is-open' );
 				// This attribute returns a string.
 				const isOpen = button.getAttribute( 'aria-expanded' );
 				button.setAttribute( 'aria-expanded', isOpen === 'false' );
+				if ( isOpen === 'false' ) {
+					button.setAttribute(
+						'aria-label',
+						// translators: %s link title.
+						sprintf( __( 'Close %s submenu', 'wporg' ), link.innerText )
+					);
+				} else {
+					button.setAttribute(
+						'aria-label',
+						// translators: %s link title.
+						sprintf( __( 'Open %s submenu', 'wporg' ), link.innerText )
+					);
+				}
 			};
 
 			const buttonGroup = document.createElement( 'span' );
@@ -36,6 +55,11 @@ const init = () => {
 			) {
 				submenu.classList.toggle( 'is-open' );
 				button.setAttribute( 'aria-expanded', true );
+				button.setAttribute(
+					'aria-label',
+					// translators: %s link title.
+					sprintf( __( 'Close %s submenu', 'wporg' ), link.innerText )
+				);
 			}
 		} );
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -27,13 +27,13 @@ body[class] {
 // Slot the search & table of contents into a floating sidebar on large screens.
 @media (min-width: 1200px) {
 	.sidebar-container {
-		--local--sidebar-width: 340px;
+		--local--block-end-sidebar--width: 340px;
 
 		position: absolute;
 		top: calc(var(--wp-global-header-offset, 0px) + var(--wp-local-header-offset, 0px));
 		// Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered.
 		right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
-		width: var(--local--sidebar-width);
+		width: var(--local--block-end-sidebar--width);
 		margin-top: var(--wp--preset--spacing--edge-space) !important;
 
 		&.is-fixed-sidebar {
@@ -53,14 +53,15 @@ body[class] {
 
 @media (min-width: 1440px) {
 	.has-three-columns .sidebar-container {
-		--local--sidebar-width: 300px;
+		--local--block-end-sidebar--width: 300px;
 		--wp--style--global--wide-size: 1280px;
 	}
 
 	.has-three-columns {
+		--local--block-start-sidebar--width: 260px;
 		display: grid;
-		grid-template-columns: 260px 1fr;
-		gap: 20px;
+		grid-template-columns: var(--local--block-start-sidebar--width) 1fr;
+		gap: var(--wp--preset--spacing--20);
 	}
 }
 
@@ -95,6 +96,10 @@ body[class] {
 .wp-block-search.is-style-secondary-search-control {
 	// Update border color in secondary search style, this site uses a light grey.
 	--local--border-color: var(--wp--preset--color--light-grey-1);
+}
+
+.wp-block-search.is-style-secondary-search-control,
+.wp-block-wporg-chapter-list h2 {
 	// Add offset spacing above the search box to optically align with title.
 	// See https://github.com/WordPress/wporg-documentation-2022/issues/36.
 	margin-top: 16px;

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -27,16 +27,13 @@ body[class] {
 // Slot the search & table of contents into a floating sidebar on large screens.
 @media (min-width: 1200px) {
 	.sidebar-container {
-		// Size of remaining space in the wide center column.
-		--local--size-diff: calc(var(--wp--style--global--wide-size) - var(--wp--style--global--content-size));
-		// This is a little bit of a magic number, the max space between content & sidebar.
-		--local--content-gap: 145px;
+		--local--sidebar-width: 340px;
 
 		position: absolute;
 		top: calc(var(--wp-global-header-offset, 0px) + var(--wp-local-header-offset, 0px));
 		// Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered.
 		right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
-		width: calc(var(--local--size-diff) - var(--local--content-gap));
+		width: var(--local--sidebar-width);
 		margin-top: var(--wp--preset--spacing--edge-space) !important;
 
 		&.is-fixed-sidebar {
@@ -51,6 +48,19 @@ body[class] {
 		&.is-bottom-sidebar .is-link-to-top {
 			display: block;
 		}
+	}
+}
+
+@media (min-width: 1440px) {
+	.has-three-columns .sidebar-container {
+		--local--sidebar-width: 300px;
+		--wp--style--global--wide-size: 1280px;
+	}
+
+	.has-three-columns {
+		display: grid;
+		grid-template-columns: 260px 1fr;
+		gap: 20px;
 	}
 }
 

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -50,15 +50,15 @@
 					},
 					"link": {
 						"color": {
-							"text": "var:preset|color|blueberry-1"
+							"text": "var(--wp--preset--color--blueberry-1)"
 						}
 					}
 				}
 			},
 			"wporg/table-of-contents": {
 				"color": {
-					"background": "var:preset|color|blueberry-4",
-					"text": "var:preset|color|blueberry-1"
+					"background": "var(--wp--preset--color--blueberry-4)",
+					"text": "var(--wp--preset--color--blueberry-1)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -3,35 +3,77 @@
 	"version": 2,
 	"settings": {
 		"blocks": {
-            "wporg/code-reference-title": {
+			"wporg/code-reference-title": {
 				"color": {
-                    "palette": [
+					"palette": [
 						{
-                            "slug": "syntax-black",
-                            "color": "#000000",
-                            "name": "Black"
-                        },
-                        {
-                            "slug": "syntax-red",
-                            "color": "#d63638",
-                            "name": "Red"
-                        },
+							"slug": "syntax-black",
+							"color": "#000000",
+							"name": "Black"
+						},
 						{
-                            "slug": "syntax-green",
-                            "color": "#008a20",
-                            "name": "Green"
-                        },
+							"slug": "syntax-red",
+							"color": "#d63638",
+							"name": "Red"
+						},
 						{
-                            "slug": "syntax-blue",
-                            "color": "#135e96",
-                            "name": "Blue"
-                        },
+							"slug": "syntax-green",
+							"color": "#008a20",
+							"name": "Green"
+						},
 						{
-                            "slug": "syntax-grey",
-                            "color": "#646970",
-                            "name": "Grey"
-                        }
+							"slug": "syntax-blue",
+							"color": "#135e96",
+							"name": "Blue"
+						},
+						{
+							"slug": "syntax-grey",
+							"color": "#646970",
+							"name": "Grey"
+						}
 					]
+				}
+			}
+		}
+	},
+	"styles": {
+		"blocks": {
+			"wporg/chapter-list": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"heading": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--normal) !important"
+						}
+					},
+					"link": {
+						"color": {
+							"text": "var:preset|color|blueberry-1"
+						}
+					}
+				}
+			},
+			"wporg/table-of-contents": {
+				"color": {
+					"background": "var:preset|color|blueberry-4",
+					"text": "var:preset|color|blueberry-1"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"heading": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--normal) !important"
+						}
+					},
+					"link": {
+						"color": {
+							"text": "inherit"
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
See #161 — This PR adds the Chapter List block, which is used on the handbook pages to display the navigation in a given handbook. It uses the current post type to list all items in that post type, using the page hierarchy to build up a menu with submenus. 

It also adds styles to the theme to create the three-column layout when the screen is wider than 1440px, and a two col layout from 1200px and up (see https://github.com/WordPress/wporg-developer/issues/161#issuecomment-1406782932).

**Screenshots**

| Small screen (mobile) | Medium (small-mid desktop) | Large (large desktop) |
|---------------|-----------|--------------|
| ![wpcs-small](https://user-images.githubusercontent.com/541093/215607767-ea93d12c-1084-4b18-a41e-25754ec3e079.png) | ![wpcs-mid](https://user-images.githubusercontent.com/541093/215607766-a00287d8-bc1d-4b67-a817-ac2f617edacf.png) | ![wpcs-large](https://user-images.githubusercontent.com/541093/215607762-802c9c62-a9d7-430f-93a1-9ce6341fbb01.png) |

Other handbooks - on production, the Block Editor handbook also uses the page hierarchy, but Plugins & REST API use a navigation menu… so the chapter list on these is a little wonky. For consistency, I'd like to use this same block on all the handbooks, but I'm not sure if there's a reason to use a nav menu instead on these other pages. For now, all are using the Chapter List block.

| Block Editor | Plugins | REST API |
|----------|-----------|--------|
| ![block-editor](https://user-images.githubusercontent.com/541093/215609848-e1dc099a-2ce8-4d03-97f7-1653ab63594e.png) | ![plugins](https://user-images.githubusercontent.com/541093/215609850-8e8377a4-2678-44aa-8148-957e36d37313.png) | ![rest-api](https://user-images.githubusercontent.com/541093/215609855-3e8eb6db-0646-4183-9adc-cbb5957c191e.png) |

**To test**

- Make sure you have handbook content, either by exporting from the production site or by running the parser (`yearn wp-env run cli "wp cron event run --all"` has worked for me).
- View some pages in a handbook
- The menu should appear, and clicking through it should work
- Expanding & collapsing sections should work
- If you land on a nested page, the menu should be open to that page - ex, http://localhost:8888/block-editor/how-to-guides/platform/custom-block-editor/tutorial/