### PR TITLE
Updating heading spacing to function single page.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -146,3 +146,8 @@ body[class] {
 	font-size: var(--wp--preset--font-size--small);
 	border-radius: 2px;
 }
+
+.single .entry-content section > h2 {
+	margin-top: var(--wp--preset--spacing--40);
+	font-size: var(--wp--preset--font-size--huge);
+}


### PR DESCRIPTION
This PR adds margin and font size to the headings on a single page. The headings themselves exist in the respective blocks and are consistently applied across all of them. All the blocks are not complete but this could still probably merge ahead of that.

Lastly, the designs have a custom size of `26px` for the headings. I've bumped that up to `30px` so it stays consistent across .org. 

**Question**
Is this a good approach for updating the headings for a specific page?

## Screenshot
<img width="500" src="https://user-images.githubusercontent.com/1657336/215928817-9542ed1f-60e9-4fb1-bf6c-c9caf32b2f0d.png" />
