### PR TITLE
Update edit & changelog links on handbook pages

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
@@ -4,7 +4,7 @@ namespace WordPressdotorg\Theme\Developer_2023;
 use function DevHub\get_current_version_term;
 
 /**
- * Get the current wordpress version.
+ * Get the current WordPress version.
  */
 add_shortcode(
 	'wordpress_version',
@@ -15,7 +15,7 @@ add_shortcode(
 );
 
 /**
- * Get the current wordpress version link.
+ * Get the current WordPress version link.
  */
 add_shortcode(
 	'wordpress_version_link',
@@ -25,4 +25,31 @@ add_shortcode(
 	}
 );
 
+/**
+ * Get the link to edit the page.
+ *
+ * The handbook code automatically swaps out the edit link for the github URL,
+ * if this is a github handbook.
+ */
+add_shortcode(
+	'article_edit_link',
+	function() {
+		return get_edit_post_link();
+	}
+);
 
+/**
+ * Get the link to the GH commit history.
+ */
+add_shortcode(
+	'article_changelog_link',
+	function() {
+		// If this is a github page, use the edit URL to generate the
+		// commit history URL
+		$edit_url = get_edit_post_link();
+		if ( str_contains( $edit_url, 'github.com' ) ) {
+			return str_replace( '/edit/', '/commits/', $edit_url );
+		}
+		return '#';
+	}
+);

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta-github.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta-github.php
@@ -36,7 +36,7 @@
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"className":"external-link"} -->
-		<p class="external-link"><a href="#"><?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?></a></p>
+		<p class="external-link"><a href="[article_edit_link]"><?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?></a></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -48,7 +48,7 @@
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"className":"external-link"} -->
-		<p class="external-link"><a href="#"><?php esc_html_e( 'See list of changes', 'wporg' ); ?></a></p>
+		<p class="external-link"><a href="[article_changelog_link]"><?php esc_html_e( 'See list of changes', 'wporg' ); ?></a></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
See #161 — In #169 the page template was added with placeholder content for the edit & changelog links below the handbook content. This PR adds in two new shortcodes to generate those URLs for handbooks that live on github.

For the other handbooks, non-WP users can't edit them, and they don't have changelogs, so they don't need these links. I've split the pattern into `single-handbook.php` and `single-github-handbook.php`, and show the edit/changelog links on `single-github-handbook.php`.

The handbooks:

- Common APIs
- Plugin
- Theme
- Block Editor — github
- Coding Standards — github
- REST API — github
- Advanced Admin (WIP) — github

| github handbook | non-gh handbook |
|-----|-----|
| <img width="711" alt="Screenshot 2023-02-01 at 5 43 08 PM" src="https://user-images.githubusercontent.com/541093/216180968-29d0619a-2df2-4098-9395-0f4546d9359c.png"> | <img width="715" alt="Screenshot 2023-02-01 at 5 43 37 PM" src="https://user-images.githubusercontent.com/541093/216180964-4b2c1bb2-2c9a-4df6-ad9c-ee67b5992767.png"> |

**To test**

Has links:
- Load a handbook page from one of the GH handbooks, like Block Editor
- The end of the article should have two links
- Clicking Edit will either take you to a edit screen on github or a button to fork the repo, depending on your permissions
- Clicking Changelog will take you to the commit history for that markdown file

No links:
- Load a page from one of the other handbooks (I manually exported some content from prod using the WP importer)
- There should be no edit or changelog link
