### PR TITLE
Add table of contents to single.html.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -168,6 +168,10 @@ add_action( 'init', __NAMESPACE__ . '\\init' );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\add_handbook_templates' );
 
+// Priority must be lower than 5 to precede table of contents filter.
+// See: https://github.com/WordPress/wporg-mu-plugins/blob/trunk/mu-plugins/blocks/table-of-contents/index.php#L70
+add_filter( 'the_content', __NAMESPACE__ . '\filter_code_content', 4 );
+
 // Remove table of contents.
 add_filter( 'wporg_handbook_toc_should_add_toc', '__return_false' );
 
@@ -466,4 +470,33 @@ function add_handbook_templates( $templates ) {
 		array_unshift( $templates, 'single-handbook-github.php' );
 	}
 	return $templates;
+}
+
+/**
+ * Filters content for the code reference blocks so Table of Contents can be added.
+ *
+ * @param string $content
+ * @return string
+ */
+function filter_code_content( $content ) {
+	$post = get_post();
+
+	if ( ! is_single() && ! is_parsed_post_type( $post->post_type ) ) {
+		return $content;
+	}
+
+	return do_blocks(
+		'
+		<!-- wp:wporg/code-reference-summary /-->
+		<!-- wp:wporg/code-reference-description /-->
+		<!-- wp:wporg/code-reference-parameters /-->
+		<!-- wp:wporg/code-reference-return-value /-->
+		<!-- wp:wporg/code-reference-explanation /-->
+		<!-- wp:wporg/code-reference-source /-->
+		<!-- wp:wporg/code-reference-hooks /-->
+		<!-- wp:wporg/code-reference-related /-->
+		<!-- wp:wporg/code-reference-changelog /-->
+		<!-- wp:wporg/code-reference-comments /-->
+	'
+	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/patterns/single.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/single.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Title: Single Content
+ * Slug: wporg-developer-2023/single-content
+ * Inserter: no
+ */
+
+ // This content in filtered by `filter_code_content` in functions.php to add the post content.
+ // See: https://github.com/WordPress/wporg-developer/pull/194
+?>
+
+<!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -16,16 +16,7 @@
 			<!-- wp:wporg/code-reference-deprecated /-->
 			<!-- wp:wporg/code-reference-private-access /-->
 
-			<!-- wp:wporg/code-reference-summary /-->
-			<!-- wp:wporg/code-reference-description /-->
-			<!-- wp:wporg/code-reference-parameters /-->
-			<!-- wp:wporg/code-reference-return-value /-->
-			<!-- wp:wporg/code-reference-explanation /-->
-			<!-- wp:wporg/code-reference-source /-->
-			<!-- wp:wporg/code-reference-hooks /-->
-			<!-- wp:wporg/code-reference-related /-->
-			<!-- wp:wporg/code-reference-changelog /-->
-			<!-- wp:wporg/code-reference-comments /-->
+			<!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
 		</article>

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -16,7 +16,7 @@
 			<!-- wp:wporg/code-reference-deprecated /-->
 			<!-- wp:wporg/code-reference-private-access /-->
 
-			<!-- wp:post-content {"layout":{"inherit":true}} /-->
+			<!-- wp:pattern {"slug":"wporg-developer-2023/single-content"} /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
 		</article>


### PR DESCRIPTION
This PR updates the `single.html` template to be similar to the handbooks, adding the sidebar and the table of contents block.

### Why does this filter `the content`?
Our table-of-contents control pulls the content to generate itself and associate anchors. However, since the code blocks are generated dynamically, as part of the template, we don't have any post content. Therefore the approach here is to `do_blocks` the content when we are viewing code.

It feels like there should be a better way of doing it, but I can't think of anything else. 🤔 
