### PR TITLE
Add post navigation links to handbooks

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -518,10 +518,12 @@ function filter_code_content( $content ) {
  * @return string Updated link tag.
  */
 function get_adjacent_handbook_post_link( $output, $format, $link, $post, $adjacent ) {
-	$post_id   = get_the_ID();
-	$parent    = get_post_parent( $post_id );
-	$parent_id = $parent ? $parent->ID : 0;
-	$pages     = get_pages(
+	if ( wporg_is_handbook() ) {
+		return $output;
+	}
+
+	$post_id = get_the_ID();
+	$pages   = get_pages(
 		array(
 			'sort_column' => 'menu_order, title',
 			'post_type'   => get_post_type( $post_id ),

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -518,7 +518,7 @@ function filter_code_content( $content ) {
  * @return string Updated link tag.
  */
 function get_adjacent_handbook_post_link( $output, $format, $link, $post, $adjacent ) {
-	if ( wporg_is_handbook() ) {
+	if ( ! wporg_is_handbook() ) {
 		return $output;
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -30,7 +30,7 @@ require __DIR__ . '/inc/jetpack.php';
 /**
  * Class for editing parsed content on the Function, Class, Hook, and Method screens.
  */
-require_once( __DIR__ . '/inc/parsed-content.php' );
+require_once __DIR__ . '/inc/parsed-content.php';
 
 if ( ! function_exists( 'loop_pagination' ) ) {
 	require __DIR__ . '/inc/loop-pagination.php';
@@ -85,7 +85,7 @@ if ( class_exists( '\\WordPressdotorg\\Markdown\\Importer' ) ) {
 /**
  * Explanations for functions. hooks, classes, and methods.
  */
-require( __DIR__ . '/inc/explanations.php' );
+require __DIR__ . '/inc/explanations.php';
 
 /**
  * Handbooks.
@@ -167,6 +167,8 @@ require_once __DIR__ . '/src/search-usage-info/index.php';
 add_action( 'init', __NAMESPACE__ . '\\init' );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 add_filter( 'single_template_hierarchy', __NAMESPACE__ . '\add_handbook_templates' );
+add_filter( 'next_post_link', __NAMESPACE__ . '\get_adjacent_handbook_post_link', 10, 5 );
+add_filter( 'previous_post_link', __NAMESPACE__ . '\get_adjacent_handbook_post_link', 10, 5 );
 
 // Priority must be lower than 5 to precede table of contents filter.
 // See: https://github.com/WordPress/wporg-mu-plugins/blob/trunk/mu-plugins/blocks/table-of-contents/index.php#L70
@@ -292,7 +294,7 @@ function breadcrumb_trail_for_note_edit( $items ) {
 	}
 
 	$comment_id  = get_query_var( 'edit_user_note' );
-	$comment  = get_comment( $comment_id );
+	$comment     = get_comment( $comment_id );
 	$post        = get_queried_object();
 	$post_id     = get_queried_object_id();
 	$post_url    = get_permalink( $post_id );
@@ -342,8 +344,8 @@ function pre_get_posts( $query ) {
 function register_nav_menus() {
 	\register_nav_menus(
 		array(
-			'devhub-menu' => __( 'Developer Resources Menu', 'wporg' ),
-			'devhub-cli-menu' => __( 'WP-CLI Commands Menu', 'wporg' ),
+			'devhub-menu'        => __( 'Developer Resources Menu', 'wporg' ),
+			'devhub-cli-menu'    => __( 'WP-CLI Commands Menu', 'wporg' ),
 			'reference-home-api' => __( 'Reference API Menu', 'wporg' ),
 		)
 	);
@@ -502,4 +504,54 @@ function filter_code_content( $content ) {
 		<!-- wp:wporg/code-reference-comments /-->
 	'
 	);
+}
+
+/**
+ * Switch out the destination for next/prev links to mirror the Chapter List order.
+ *
+ * @param string  $output   The adjacent post link.
+ * @param string  $format   Link anchor format.
+ * @param string  $link     Link permalink format.
+ * @param WP_Post $post     The adjacent post.
+ * @param string  $adjacent Whether the post is previous or next.
+ *
+ * @return string Updated link tag.
+ */
+function get_adjacent_handbook_post_link( $output, $format, $link, $post, $adjacent ) {
+	$post_id   = get_the_ID();
+	$parent    = get_post_parent( $post_id );
+	$parent_id = $parent ? $parent->ID : 0;
+	$pages     = get_pages(
+		array(
+			'sort_column' => 'menu_order, title',
+			'post_type'   => get_post_type( $post_id ),
+		)
+	);
+
+	foreach ( $pages as $i => $page ) {
+		if ( $page->ID === $post_id ) {
+			$adj_index = 'previous' === $adjacent ? $i - 1 : $i + 1;
+			break;
+		}
+	}
+
+	if ( $adj_index < count( $pages ) && $adj_index > 0 ) {
+		$post = $pages[ $adj_index ];
+	} else {
+		return '';
+	}
+
+	$title = apply_filters( 'the_title', $post->post_title, $post->ID );
+	$url   = get_permalink( $post );
+
+	$inlink = sprintf(
+		'<a href="%1$s" rel="%2$s">%3$s</a>',
+		$url,
+		'previous' === $adjacent ? 'prev' : 'next',
+		str_replace( '%title', $title, $link )
+	);
+
+	$output = str_replace( '%link', $inlink, $format );
+
+	return $output;
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
@@ -41,7 +41,7 @@ function render( $attributes, $content, $block ) {
 	$args = array(
 		'title_li'    => '',
 		'echo'        => 0,
-		'sort_column' => 'menu_order',
+		'sort_column' => 'menu_order, title',
 		'post_type'   => $post_type,
 
 		// Use custom walker that excludes display of orphaned pages. (An ancestor

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
@@ -29,4 +29,11 @@
 </main>
 <!-- /wp:group -->
 
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"},"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:post-navigation-link {"type":"previous","label":"Previous ","showTitle":true,"linkLabel":true} /-->
+	<!-- wp:post-navigation-link {"label":"Next ","showTitle":true,"linkLabel":true} /-->
+</div>
+<!-- /wp:group -->
+
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -29,4 +29,11 @@
 </main>
 <!-- /wp:group -->
 
+<!-- wp:group {"align":"full","style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"},"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:post-navigation-link {"type":"previous","label":"Previous ","showTitle":true,"linkLabel":true} /-->
+	<!-- wp:post-navigation-link {"label":"Next ","showTitle":true,"linkLabel":true} /-->
+</div>
+<!-- /wp:group -->
+
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
See #161 — This adds the post navigation links to the bottom of handbooks. It needs to use the handbook hierarchy for determining which is next/previous, so I had to filter those links to use the correct post. The links should now reflect the next or previous item in the Chapter List sidebar.

On the production site, this navigates through the items slightly differently — the previous item will take you to the previous section at the same level you're on, not the previous item in the list. For example, the previous link on [Design Contributions](https://developer.wordpress.org/block-editor/contributors/design/) is "Code Contributions", but on this PR it's "How To Get Your Pull Request Reviewed". I can't get that working right now, but I might just need fresh eyes.

| block-editor | coding-standards | plugins | rest-api | 
|----|----|----|---|
| ![](https://user-images.githubusercontent.com/541093/216472980-537cf1a7-f0c5-48ae-8bba-01d0d9e243b0.png) | ![](https://user-images.githubusercontent.com/541093/216472985-c63bd14e-8aae-43a6-8da9-11ee5650c103.png) | ![](https://user-images.githubusercontent.com/541093/216472989-d7a34592-1afd-450d-a916-9456a1d37471.png) | ![](https://user-images.githubusercontent.com/541093/216472991-9aab33e1-2a2b-4148-888e-63e3f3df7345.png) |

**To test**

- Navigate through a few different handbook pages
- The next/prev buttons should work
- The path they take you should match the Chapter List order
- The first item should have no "previous", and the last item should have no "Next"