### PR TITLE
Block: Add a version dropdown.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -163,6 +163,7 @@ require_once __DIR__ . '/src/search-filters/index.php';
 require_once __DIR__ . '/src/search-results-context/index.php';
 require_once __DIR__ . '/src/search-title/index.php';
 require_once __DIR__ . '/src/search-usage-info/index.php';
+require_once __DIR__ . '/src/version-select/index.php';
 
 add_action( 'init', __NAMESPACE__ . '\\init' );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/block.json
@@ -12,19 +12,16 @@
 		"html": false,
 		"color": {
 			"text": true,
-			"background": true,
-			"link": true
+			"background": true
 		},
 		"spacing": {
 			"margin": [
 				"top",
 				"bottom"
-			],
-			"padding": true
+			]
 		},
 		"typography": {
-			"fontSize": true,
-			"lineHeight": true
+			"fontSize": true
 		}
 	},
 	"usesContext": [ "postId" ],

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/block.json
@@ -24,7 +24,6 @@
 			"fontSize": true
 		}
 	},
-	"usesContext": [ "postId" ],
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css"
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/block.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/version-select",
+	"title": "Version Select",
+	"category": "layout",
+	"description": "Displays version in a select element.",
+	"keywords": [ "post" ],
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"usesContext": [ "postId" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/index.js
@@ -2,17 +2,13 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
 import './style.scss';
-
-function Edit() {
-	return <div { ...useBlockProps() }>Version Select</div>;
-}
 
 registerBlockType( metadata.name, {
 	edit: Edit,

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+function Edit() {
+	return <div { ...useBlockProps() }>Version Select</div>;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
@@ -36,10 +36,6 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes, $content, $block ) {
-	if ( ! isset( $block->context['postId'] ) ) {
-		return '';
-	}
-
 	$versions = get_terms( 'wp-parser-since', array( 'order' => 'DESC' ) );
 
 	if ( is_wp_error( $versions ) || empty( $versions ) ) {
@@ -68,11 +64,22 @@ function render( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
 		'<div %1$s>
-			<label class="screen-reader-text" for="version-select">%2$s</label>
-			<select name="version-select" id="version-select">%3$s</select>
+			<label class="screen-reader-text" for="%2$s">%3$s</label>
+			<select name="%2$s" id="%2$s">%4$s</select>
 		</div>',
 		$wrapper_attributes,
+		esc_attr( generate_id( $block->parsed_block ) ),
 		esc_html( __( 'Select version', 'wporg' ) ),
 		$options,
 	);
+}
+
+/**
+ * Generates a unique identifier.
+ *
+ * @param array $block Block object.
+ * @return string      The unique identifier.
+ */
+function generate_id( $block ) {
+	return 'wporg-version-select-' . md5( serialize( $block ) );
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
@@ -68,7 +68,7 @@ function render( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes();
 
 	return sprintf(
-		'<select name="version-select" id="version-select" %1$s>%2$s</select>',
+		'<div %1$s><select name="version-select" id="version-select">%2$s</select></dov>',
 		$wrapper_attributes,
 		$options,
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Block Name: Version Select
- * Description: Displays version in a select element.
+ * Description: Displays WordPress versions in a select element.
  *
  * @package wporg
  */
@@ -66,10 +66,13 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-
 	return sprintf(
-		'<div %1$s><select name="version-select" id="version-select">%2$s</select></dov>',
+		'<div %1$s>
+			<label class="screen-reader-text" for="version-select">%2$s</label>
+			<select name="version-select" id="version-select">%3$s</select>
+		</div>',
 		$wrapper_attributes,
+		esc_html( __( 'Select version', 'wporg' ) ),
 		$options,
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/index.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Block Name: Version Select
+ * Description: Displays version in a select element.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Developer_2023\Dynamic_Version_Select;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/version-select',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$versions = get_terms( 'wp-parser-since', array( 'order' => 'DESC' ) );
+
+	if ( is_wp_error( $versions ) || empty( $versions ) ) {
+		return '';
+	}
+
+	$mu_versions = array_filter(
+		$versions,
+		function( $version ) {
+			return strpos( $version->name, 'MU' ) === 0;
+		}
+	);
+
+	$versions = array_filter(
+		$versions,
+		function( $version ) {
+			return strpos( $version->name, 'MU' ) !== 0;
+		}
+	);
+
+	$options = '';
+	foreach ( array_merge( $versions, $mu_versions ) as $version ) {
+		$options .= '<option value="' . $version->name . '">' . $version->name . '</option>';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	return sprintf(
+		'<select name="version-select" id="version-select" %1$s>%2$s</select>',
+		$wrapper_attributes,
+		$options,
+	);
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
@@ -1,0 +1,74 @@
+.wp-block-wporg-search-title {
+	align-items: flex-start;
+	display: flex;
+	flex-direction: column;
+}
+
+@media (min-width: 350px) {
+	.wp-block-wporg-search-title {
+		align-items: center;
+		display: flex;
+		flex-direction: row;
+	}
+}
+
+.wp-block-wporg-search-title a {
+	display: block;
+	font-size: var(--wp--preset--font-size--extra-large);
+	font-family: var(--wp--preset--font-family--monospace);
+	word-break: break-all;
+}
+
+.function {
+	&.wp-block-wporg-search-title,
+	a {
+		color: #008a20;
+	}
+
+	.wp-block-wporg-search-title__type {
+		background: rgba(0, 138, 32, 0.1);
+	}
+}
+
+.hook {
+	&.wp-block-wporg-search-title,
+	a {
+		color: #d63638;
+	}
+
+	.wp-block-wporg-search-title__type {
+		background: rgba(214, 54, 56, 0.1);
+	}
+}
+
+.class {
+	&.wp-block-wporg-search-title,
+	a {
+		color: #bd8600;
+	}
+
+	.wp-block-wporg-search-title__type {
+		background: rgba(189, 134, 0, 0.05);
+	}
+}
+
+.method {
+	&.wp-block-wporg-search-title,
+	a {
+		color: #135e96;
+	}
+
+	.wp-block-wporg-search-title__type {
+		background: rgba(19, 94, 150, 0.1);
+	}
+}
+
+.wp-block-wporg-search-title__type {
+	background: var(--wp--preset--color--light-grey-2);
+	border-radius: 2px;
+	margin-right: 8px;
+	padding: 2px 8px;
+	font-family: var(--wp--preset--font-family--monospace);
+	font-size: var(--wp--preset--font-size--small);
+	word-break: keep-all;
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
@@ -9,6 +9,8 @@
 		font-size: inherit;
 		max-width: none;
 		cursor: pointer;
+		color: inherit;
+		background: inherit;
 		overflow: hidden;
 		white-space: nowrap;
 		width: 100%;

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
@@ -1,74 +1,36 @@
-.wp-block-wporg-search-title {
-	align-items: flex-start;
-	display: flex;
-	flex-direction: column;
-}
+.wp-block-wporg-version-select {
+	position: relative;
 
-@media (min-width: 350px) {
-	.wp-block-wporg-search-title {
-		align-items: center;
-		display: flex;
-		flex-direction: row;
-	}
-}
-
-.wp-block-wporg-search-title a {
-	display: block;
-	font-size: var(--wp--preset--font-size--extra-large);
-	font-family: var(--wp--preset--font-family--monospace);
-	word-break: break-all;
-}
-
-.function {
-	&.wp-block-wporg-search-title,
-	a {
-		color: #008a20;
+	select {
+		appearance: none;
+		border: 1px solid var(--wp--preset--color--charcoal-4);
+		display: block;
+		font-family: inherit;
+		font-size: inherit;
+		max-width: none;
+		cursor: pointer;
+		overflow: hidden;
+		white-space: nowrap;
+		width: 100%;
+		text-overflow: ellipsis;
+		padding: 12px;
+		border-radius: 2px;
 	}
 
-	.wp-block-wporg-search-title__type {
-		background: rgba(0, 138, 32, 0.1);
+	&::after {
+		content: "";
+		display: block;
+		position: absolute;
+		right: 12px;
+		top: 0;
+		height: 100%;
+		width: 0.8em;
+		mask-image: url(../../images/chevron.svg);
+		mask-repeat: no-repeat;
+		mask-position: center;
+		mask-size: contain;
+		transform: rotate(180deg);
+		background-color: var(--wp--preset--color--charcoal-1);
+		pointer-events: none; // Allows clicking on the select element.
 	}
-}
-
-.hook {
-	&.wp-block-wporg-search-title,
-	a {
-		color: #d63638;
-	}
-
-	.wp-block-wporg-search-title__type {
-		background: rgba(214, 54, 56, 0.1);
-	}
-}
-
-.class {
-	&.wp-block-wporg-search-title,
-	a {
-		color: #bd8600;
-	}
-
-	.wp-block-wporg-search-title__type {
-		background: rgba(189, 134, 0, 0.05);
-	}
-}
-
-.method {
-	&.wp-block-wporg-search-title,
-	a {
-		color: #135e96;
-	}
-
-	.wp-block-wporg-search-title__type {
-		background: rgba(19, 94, 150, 0.1);
-	}
-}
-
-.wp-block-wporg-search-title__type {
-	background: var(--wp--preset--color--light-grey-2);
-	border-radius: 2px;
-	margin-right: 8px;
-	padding: 2px 8px;
-	font-family: var(--wp--preset--font-family--monospace);
-	font-size: var(--wp--preset--font-size--small);
-	word-break: keep-all;
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
@@ -1,5 +1,6 @@
 .wp-block-wporg-version-select {
 	position: relative;
+	min-width: 4em;
 
 	select {
 		appearance: none;

--- a/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/version-select/style.scss
@@ -13,7 +13,7 @@
 		white-space: nowrap;
 		width: 100%;
 		text-overflow: ellipsis;
-		padding: 12px;
+		padding: 1em 1.25em 1em 1em;
 		border-radius: 2px;
 	}
 
@@ -21,7 +21,7 @@
 		content: "";
 		display: block;
 		position: absolute;
-		right: 12px;
+		right: 1em;
 		top: 0;
 		height: 100%;
 		width: 0.8em;

--- a/source/wp-content/themes/wporg-developer-2023/templates/archive.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/archive.html
@@ -1,8 +1,3 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
-
-<!-- wp:group {"tagName":"main","layout":{"type":"default","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<main class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:wporg/version-select /-->
-</main>
-<!-- /wp:group -->
+archive
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/archive.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/archive.html
@@ -1,3 +1,8 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
-archive
+
+<!-- wp:group {"tagName":"main","layout":{"type":"default","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<main class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:wporg/version-select /-->
+</main>
+<!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Related: #201

We need a dropdown for the page that lists changes. Once we have the archive template setup in #201, we can use this control for the following design:

<img src="https://user-images.githubusercontent.com/1657336/217153253-dccd47d7-5cdd-4530-ad28-cd9418e73f97.png" width="400">


## Considerations
I'm not sure if the select HTML should be generalized and moved to the parent or a mu-plugin but for now, I have it here.


## Screenshot
 | Default |  Font size: 12px | Font size: 24px |
| --- | --- |  --- | 
| <img width="201" alt="Screen Shot 2023-02-07 at 1 10 17 PM" src="https://user-images.githubusercontent.com/1657336/217146374-faef2ae3-9944-4915-80ce-99896d1f3826.png"> | <img width="195" alt="Screen Shot 2023-02-07 at 1 10 23 PM" src="https://user-images.githubusercontent.com/1657336/217146371-cb6d856b-689c-45f1-852e-1f074dc067e3.png"> | <img width="222" alt="Screen Shot 2023-02-07 at 1 10 30 PM" src="https://user-images.githubusercontent.com/1657336/217146365-5c47bad6-a1ca-4b3a-ad69-dc826c1cede2.png"> |  

| Truncated |
| --- | 
| <img width="102" alt="Screen Shot 2023-02-07 at 1 08 47 PM" src="https://user-images.githubusercontent.com/1657336/217146376-ded1c269-e64a-424a-8a49-07cd18b65e47.png"> |  

## How To Test
1. Add `<!-- wp:wporg/version-select /-->` to any template.
