### PR TITLE
Code refs: Use the new custom filter in the Table of Contents block

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -173,6 +173,7 @@ add_filter( 'previous_post_link', __NAMESPACE__ . '\get_adjacent_handbook_post_l
 // Priority must be lower than 5 to precede table of contents filter.
 // See: https://github.com/WordPress/wporg-mu-plugins/blob/trunk/mu-plugins/blocks/table-of-contents/index.php#L70
 add_filter( 'the_content', __NAMESPACE__ . '\filter_code_content', 4 );
+add_filter( 'wporg_table_of_contents_post_content', __NAMESPACE__ . '\filter_code_content' );
 
 // Remove table of contents.
 add_filter( 'wporg_handbook_toc_should_add_toc', '__return_false' );


### PR DESCRIPTION
Relies on https://github.com/WordPress/wporg-mu-plugins/pull/334. That PR introduces a new filter for the heading-parsing, so we can simply add `filter_code_content` to that filter too.

The `filter_code_content` on `the_content` is still necessary for the main content replacement, and it still needs to run earlier than 5 so that the content is in place before the heading replacement is run on priority 5.

**To test**

Using both PRs, check that the Table of Contents still works on handbook pages & code references.