### PR TITLE
Update `theme.json` to set up new heading font & sizes, add new colors

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -193,8 +193,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"66%","layout":{"inherit":false}} -->
-<div class="wp-block-column" style="flex-basis:66%"><!-- wp:group {"style":{"spacing":{"margin":{"top":"15px"}}}} -->
-<div class="wp-block-group" style="margin-top:15px"><!-- wp:wporg/latest-news {"blogId":719} /-->
+<div class="wp-block-column" style="flex-basis:66%"><!-- wp:group {"style":{"spacing":{"margin":{"top":"8px"}}}} -->
+<div class="wp-block-group" style="margin-top:8px"><!-- wp:wporg/latest-news {"blogId":719} /-->
 
 <!-- wp:spacer {"height":"20px"} -->
 <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -131,7 +131,7 @@
 <div class="wp-block-columns"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"className":"is-style-short-text"} -->
-<p class="is-style-short-text"><a href="https://learn.wordpress.org"><?php esc_attr_e( 'Learn Wordpress', 'wporg' ); ?></a></p>
+<p class="is-style-short-text"><a href="https://learn.wordpress.org"><?php esc_attr_e( 'Learn WordPress', 'wporg' ); ?></a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -74,7 +74,7 @@ function get_description_content( $post_id ) {
 	$output .= $description;
 
 	if ( $see_tags ) {
-		$output .= '<h3>' . __( 'See also', 'wporg' ) . '</h3>';
+		$output .= '<h3 class="has-heading-5-font-size">' . __( 'See also', 'wporg' ) . '</h3>';
 
 		$output .= '<ul>';
 		foreach ( $see_tags as $tag ) {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-short-title/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-short-title/style.scss
@@ -2,6 +2,7 @@
 	align-items: flex-start;
 	display: flex;
 	flex-direction: column;
+	font-family: var(--wp--preset--font-family--monospace);
 }
 
 @media (min-width: 350px) {
@@ -21,7 +22,6 @@
 .wp-block-wporg-code-short-title.class a,
 .wp-block-wporg-code-short-title.method a,
 .wp-block-wporg-code-short-title.hook a {
-	font-family: var(--wp--preset--font-family--monospace);
 	word-break: break-all;
 }
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/style.scss
@@ -22,14 +22,15 @@
 		color: var(--wp--preset--color--syntax-black);
 	}
 
-	a {
+	a,
+	.wp-block-post-content & a {
 		text-decoration: none;
 		color: inherit;
-	}
 
-	a:hover,
-	a:focus {
-		text-decoration: none;
-		border-bottom: 1px dotted var(--wp--preset--color--blueberry-1);
+		&:hover,
+		&:focus {
+			text-decoration: none;
+			border-bottom: 1px dotted var(--wp--preset--color--blueberry-1);
+		}
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -111,6 +111,14 @@ body[class] {
 	margin-top: 16px;
 }
 
+.is-toc-heading a::after {
+	/* stylelint-disable-next-line function-url-quotes */
+	background-image: url("data:image/svg+xml,%3Csvg width='24' height='13' viewBox='0 0 24 13' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.083 9.91H6.32a3.069 3.069 0 0 1 0-6.139h3.764v1.5H6.32a1.569 1.569 0 0 0 0 3.138h3.764v1.5Zm3.834-6.138h3.764a3.069 3.069 0 0 1 0 6.137h-3.764v-1.5h3.764a1.569 1.569 0 0 0 0-3.137h-3.764v-1.5ZM9.333 7.304h5.334v-1.5H9.333v1.5Z' fill='%233858E9'/%3E%3C/svg%3E%0A");
+	height: calc(var(--local--icon-size) * 0.75);
+	vertical-align: middle;
+	margin-top: -0.15em;
+}
+
 @media (max-width: 781px) {
 	.wp-block-column[style*="border-right-"] {
 		border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
@@ -207,10 +215,8 @@ body[class] {
 	}
 }
 
-
 .comment-form {
 	position: relative;
-
 
 	.tablist {
 		display: flex;

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -135,6 +135,13 @@
 						}
 					}
 				}
+			},
+			"latest-news": {
+				"title": {
+					"fontFamily": "var(--wp--preset--font-family--monospace)",
+					"fontSize": "var(--wp--preset--font-size--heading-4)",
+					"lineHeight": "var(--wp--custom--heading--level-4--typography--line-height)"
+				}
 			}
 		},
 		"typography": {

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -34,6 +34,136 @@
 					]
 				}
 			}
+		},
+		"color": {
+			"palette": [
+				{
+					"slug": "aquamarine",
+					"color": "#6ec9ae",
+					"name": "Aquamarine"
+				}
+			]
+		},
+		"custom": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--monospace)",
+					"fontWeight": 400,
+					"lineHeight": 1.2
+				},
+				"level-1": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "26px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-2": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "24px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-3": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "22px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-4": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "20px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-5": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "18px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				},
+				"level-6": {
+					"typography": {
+						"lineHeight": 1.2
+					},
+					"breakpoint": {
+						"small-only": {
+							"typography": {
+								"fontSize": "16px",
+								"lineHeight": 1.2
+							}
+						}
+					}
+				}
+			}
+		},
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Heading 6",
+					"size": "18px",
+					"slug": "heading-6"
+				},
+				{
+					"name": "Heading 5",
+					"size": "20px",
+					"slug": "heading-5"
+				},
+				{
+					"name": "Heading 4",
+					"size": "22px",
+					"slug": "heading-4"
+				},
+				{
+					"name": "Heading 3",
+					"size": "28px",
+					"slug": "heading-3"
+				},
+				{
+					"name": "Heading 2",
+					"size": "32px",
+					"slug": "heading-2"
+				},
+				{
+					"name": "Heading 1",
+					"size": "38px",
+					"slug": "heading-1"
+				}
+			]
 		}
 	},
 	"styles": {

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -41,6 +41,12 @@
 					"slug": "aquamarine",
 					"color": "#6ec9ae",
 					"name": "Aquamarine"
+				},
+				{
+					"slug": "linen",
+					"color": "#fbfaf7",
+					"name": "Linen"
+
 				}
 			]
 		},


### PR DESCRIPTION
Fixes #214 — This implements the changes in `i3` of the Figma, specifically from the styles artboard.

- Add two new colors, `linen` and `aquamarine` (but not used anywhere yet)
- Update the headings font to `monospace`
- Update the heading fontSize presets, and the custom line heights & mobile font sizes
- Latest News headings have been updated too
- Add new link icon for the heading hovers to match monospace font

Paragraph font sizes are unchanged.

I also cleaned up a few things I saw while testing the fonts.

**Screenshots**

| Big screen | Small screen |
|-----|----|
| ![home](https://user-images.githubusercontent.com/541093/218159648-ce1f7296-56e4-4985-a442-f99f2ce65d24.png) | ![home-small](https://user-images.githubusercontent.com/541093/218159786-fda0565b-d8e8-4433-9dcc-19b81ce12dcd.png) |
| ![archive-functions](https://user-images.githubusercontent.com/541093/218159404-e692339f-9ded-436e-a71b-2bf0c3f024b3.png) | ![archive-functions-small](https://user-images.githubusercontent.com/541093/218159880-9f7d6014-5ae9-46a6-adbb-e2c02838998e.png) |
| ![single-function](https://user-images.githubusercontent.com/541093/218159412-55e273ce-a31c-469a-a4a3-969bf2fbc0e3.png) | ![single-function-small](https://user-images.githubusercontent.com/541093/218160010-0da8f77b-6960-4e3c-a039-7bca48fbfee6.png) |
| ![single-handbook](https://user-images.githubusercontent.com/541093/218159413-dd66075e-49cc-43a6-9135-107ef440926f.png) | ![single-handbook-small](https://user-images.githubusercontent.com/541093/218160215-34cc6237-e089-48c7-b3e6-21acef3a84f2.png) |
| ![search-handbook](https://user-images.githubusercontent.com/541093/218159408-f73afd2a-c581-4b99-9a41-297e9ed10954.png) | ![search-handbook-small](https://user-images.githubusercontent.com/541093/218160300-e0499cdb-5736-439a-8b69-3337c77d8e46.png) |