### PR TITLE
Fix extra top border when there are no comments.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2570,12 +2570,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "e07b6db810900dfd71c121b84d9a45d26da91767"
+                "reference": "c6254d6e42a6f458417077a40fb73221915a1148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/e07b6db810900dfd71c121b84d9a45d26da91767",
-                "reference": "e07b6db810900dfd71c121b84d9a45d26da91767",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/c6254d6e42a6f458417077a40fb73221915a1148",
+                "reference": "c6254d6e42a6f458417077a40fb73221915a1148",
                 "shasum": ""
             },
             "require-dev": {
@@ -2613,7 +2613,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2023-02-10T16:04:07+00:00"
+            "time": "2023-02-14T20:33:27+00:00"
         },
         {
             "name": "wporg/wporg-parent-2021",

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -510,6 +510,7 @@ function filter_code_content( $content ) {
 		<!-- wp:wporg/code-reference-related /-->
 		<!-- wp:wporg/code-reference-changelog /-->
 		<!-- wp:wporg/code-reference-comments /-->
+		<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
 	'
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -312,3 +312,8 @@ body[class] {
 .wp-block-wporg-site-breadcrumbs a {
 	color: var(--wp--preset--color--charcoal-1);
 }
+
+.wp-block-wporg-code-reference-changelog + .entry-meta {
+	padding-top: 0 !important;
+	border-top: none;
+}

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -18,7 +18,6 @@
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/single-content"} /-->
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
 		</article>
 		<!-- /wp:group -->
 


### PR DESCRIPTION
Fixes: #205 

When we don't have user comments, the changelog bottom border combines with the article-meta border and makes it look broken.

This PR moves the article-meta into the filter so we can use a simple CSS statement to hide the top border when there are no comments. Alternatively, we could create separate templates or something like this, but this seems simpler.

| Before | After |
| --- | --- |
| <img width="779" alt="Screen Shot 2023-02-14 at 11 35 50 AM" src="https://user-images.githubusercontent.com/1657336/218624417-ac6fecec-5925-4b77-ae35-06a335b77a5f.png"> | <img width="735" alt="Screen Shot 2023-02-14 at 9 31 12 AM" src="https://user-images.githubusercontent.com/1657336/218624206-293dcedb-d7ef-48d4-8b42-3920af95d38a.png"> |



