### PR TITLE
Fix homepage RTL layout

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -52,8 +52,8 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"entry-content"} -->
-<div class="wp-block-group alignfull entry-content"><!-- wp:group {"align":"full","className":"home-section-docs-api has-linen-background-color has-background","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull home-section-docs-api has-linen-background-color has-background"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-group alignfull entry-content"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"className":"home-section-docs-api has-linen-background-color has-background","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull home-section-docs-api has-linen-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"right":{"color":"var:preset|color|linen","width":"1px"}}}} -->
 <div class="wp-block-column" style="border-right-color:var(--wp--preset--color--linen);border-right-width:1px;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"className":"wp-block-heading is-style-default"} -->
 <h2 class="wp-block-heading is-style-default has-link-color" style="margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Documentation', 'wporg' ); ?></h2>

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -86,6 +86,10 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} -->
+<p style="margin-top:0"><a href="https://developer.wordpress.org/reference" data-type="helphub_article"><?php esc_attr_e( 'Code reference', 'wporg' ); ?></a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} -->
 <p style="margin-top:0"><a href="https://developer.wordpress.org/rest-api/" data-type="helphub_article"><?php esc_attr_e( 'REST API', 'wporg' ); ?></a></p>
 <!-- /wp:paragraph -->
 

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -54,8 +54,8 @@
 <!-- wp:group {"align":"full","className":"entry-content"} -->
 <div class="wp-block-group alignfull entry-content"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"className":"home-section-docs-api has-linen-background-color has-background","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull home-section-docs-api has-linen-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"right":{"color":"var:preset|color|linen","width":"1px"}}}} -->
-<div class="wp-block-column" style="border-right-color:var(--wp--preset--color--linen);border-right-width:1px;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"className":"wp-block-heading is-style-default"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"className":"wp-block-heading is-style-default"} -->
 <h2 class="wp-block-heading is-style-default has-link-color" style="margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Documentation', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -24,8 +24,8 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"aquamarine","className":"has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color has-aquamarine-background-color" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"aquamarine","className":"has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color has-aquamarine-background-color" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"level":1,"textColor":"charcoal-1"} -->
 <h1 class="wp-block-heading has-charcoal-1-color has-text-color"><?php echo wp_kses_post( '<strong>Dev Resources</strong>/The freedom to build', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
@@ -36,8 +36,8 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"backgroundColor":"blueberry-4","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-blueberry-4-background-color has-background" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><!-- wp:paragraph {"align":"center","fontSize":"extra-small"}  -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}},"backgroundColor":"blueberry-4","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-blueberry-4-background-color has-background" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><!-- wp:paragraph {"align":"center","fontSize":"extra-small"} -->
 <p class="has-text-align-center has-extra-small-font-size">
 <?php echo wp_kses_post(
 	sprintf(
@@ -51,16 +51,13 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"className":"entry-content"} -->
-<div class="wp-block-group entry-content">
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"background":"linen","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-linen-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","right":"var:preset|spacing|60"}},"border":{"right":{"width":"1px","style":"solid","color":"transparent"}}}} -->
-<div class="wp-block-column" style="border-right-color:transparent;border-right-style:solid;border-right-width:1px;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
-<div class="wp-block-group"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"className":"wp-block-heading is-style-default"} -->
+<!-- wp:group {"align":"full","className":"entry-content"} -->
+<div class="wp-block-group alignfull entry-content"><!-- wp:group {"align":"full","className":"home-section-docs-api has-linen-background-color has-background","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull home-section-docs-api has-linen-background-color has-background"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}},"border":{"right":{"color":"var:preset|color|linen","width":"1px"}}}} -->
+<div class="wp-block-column" style="border-right-color:var(--wp--preset--color--linen);border-right-width:1px;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"className":"wp-block-heading is-style-default"} -->
 <h2 class="wp-block-heading is-style-default has-link-color" style="margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Documentation', 'wporg' ); ?></h2>
-<!-- /wp:heading --></div>
-<!-- /wp:group -->
+<!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} -->
 <p style="margin-top:0"><a href="https://developer.wordpress.org/block-editor" data-type="helphub_article"><?php esc_attr_e( 'Block Editor', 'wporg' ); ?></a></p>
@@ -83,8 +80,8 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}}} -->
-<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"className":"wp-block-heading is-style-default"} -->
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} -->
 <h2 class="wp-block-heading has-link-color" style="margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'API Reference', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
@@ -100,7 +97,7 @@
 <p style="margin-top:0"><a href="https://developer.wordpress.org/cli/commands" data-type="URL" data-id="https://developers.wordpress.org/cli/commands"><?php esc_attr_e( 'WP-CLI', 'wporg' ); ?></a></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} -->
 <p style="margin-top:0"><a href="https://developer.wordpress.org/coding-standards/" data-type="URL" data-id="https://developers.wordpress.org/coding-standards/"><?php esc_attr_e( 'Coding Standards', 'wporg' ); ?></a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
@@ -169,30 +166,19 @@
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
-<!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"constrained"},"anchor":"news"} -->
 <div class="wp-block-group alignfull has-white-background-color has-background" id="news" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"0px"}},"className":"is-style-default"} -->
 <div class="wp-block-columns alignwide is-style-default" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:column {"verticalAlignment":"top","width":"33%","className":"is-left-column","layout":{"inherit":false}} -->
-<div class="wp-block-column is-vertically-aligned-top is-left-column" style="flex-basis:33%"><!-- wp:group {"style":{"spacing":{"padding":{"right":"80px"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group" style="padding-right:80px"><!-- wp:heading {"fontSize":"heading-2"} -->
-<h2 class="wp-block-heading has-heading-2-font-size"><?php esc_attr_e( 'Latest Posts', 'wporg' ); ?></h2>
-<!-- /wp:heading -->
-
-<!-- wp:spacer {"height":"20px"} -->
-<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
-<!-- /wp:group --></div>
+<div class="wp-block-column is-vertically-aligned-top is-left-column" style="flex-basis:33%"><!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}},"fontSize":"heading-2"} -->
+<h2 class="wp-block-heading has-heading-2-font-size" style="margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Latest Posts', 'wporg' ); ?></h2>
+<!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"66%","layout":{"inherit":false}} -->
 <div class="wp-block-column" style="flex-basis:66%"><!-- wp:group {"style":{"spacing":{"margin":{"top":"8px"}}}} -->
 <div class="wp-block-group" style="margin-top:8px"><!-- wp:wporg/latest-news {"blogId":719} /-->
-
-<!-- wp:spacer {"height":"20px"} -->
-<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
 
 <!-- wp:paragraph -->
 <p><a href="https://developer.wordpress.org/news/"><?php esc_attr_e( 'View all', 'wporg' ); ?></a></p>
@@ -200,10 +186,11 @@
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"aquamarine","layout":{"type":"default"}} -->
-<div class="wp-block-group has-aquamarine-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"aquamarine","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-aquamarine-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"70%"} -->
 <div class="wp-block-column" style="flex-basis:70%"><!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"textColor":"charcoal-1"} -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -184,20 +184,19 @@
 <div class="wp-block-column" style="flex-basis:66%"><!-- wp:group {"style":{"spacing":{"margin":{"top":"8px"}}}} -->
 <div class="wp-block-group" style="margin-top:8px"><!-- wp:wporg/latest-news {"blogId":719} /-->
 
-<!-- wp:paragraph -->
-<p><a href="https://developer.wordpress.org/news/"><?php esc_attr_e( 'View all', 'wporg' ); ?></a></p>
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<p style="margin-top:var(--wp--preset--spacing--50)"><a href="https://developer.wordpress.org/news/"><?php esc_attr_e( 'View all', 'wporg' ); ?></a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
-<!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"aquamarine","layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull has-aquamarine-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"70%"} -->
-<div class="wp-block-column" style="flex-basis:70%"><!-- wp:heading {"level":2,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"textColor":"charcoal-1"} -->
+<div class="wp-block-column" style="flex-basis:70%"><!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"textColor":"charcoal-1"} -->
 <h2 class="wp-block-heading has-charcoal-1-color has-text-color" style="margin-bottom:var(--wp--preset--spacing--50)"><?php esc_attr_e( 'Are you passionate about web development? Join the WordPress community and help shape the future of the web', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
@@ -212,5 +211,6 @@
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -110,6 +110,9 @@ body[class] {
 
 @media (max-width: 781px) {
 	.home-section-docs-api {
+		padding-left: 0 !important;
+		padding-right: 0 !important;
+
 		.wp-block-column {
 			padding-left: var(--wp--preset--spacing--edge-space) !important;
 			padding-right: var(--wp--preset--spacing--edge-space) !important;

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -95,20 +95,16 @@ body[class] {
 }
 
 @media (max-width: 781px) {
-	.wp-block-column[style*="border-right-"] {
-		border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
-		border-right: none !important;
-	}
-
-	.wp-block-column[style*="border-right-"][style*="padding-right"] {
-		margin-left: calc(-1 * var(--wp--preset--spacing--edge-space)) !important;
-		margin-right: calc(-1 * var(--wp--preset--spacing--edge-space)) !important;
-		padding-left: var(--wp--preset--spacing--edge-space) !important;
-		padding-right: var(--wp--preset--spacing--edge-space) !important;
-	}
-
-	.wp-block-column[style*="border-right-"] + .wp-block-column[style*="padding-left"] {
-		padding-left: 0 !important;
+	.home-section-docs-api {
+		.wp-block-column {
+			padding-left: var(--wp--preset--spacing--edge-space) !important;
+			padding-right: var(--wp--preset--spacing--edge-space) !important;
+			
+			&[style*="border-right-"] {
+				border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+				border-right: none !important;
+			}
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -117,9 +117,8 @@ body[class] {
 			padding-left: var(--wp--preset--spacing--edge-space) !important;
 			padding-right: var(--wp--preset--spacing--edge-space) !important;
 
-			&[style*="border-right-"] {
+			&:first-child {
 				border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
-				border-right: none !important;
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -99,7 +99,7 @@ body[class] {
 		.wp-block-column {
 			padding-left: var(--wp--preset--spacing--edge-space) !important;
 			padding-right: var(--wp--preset--spacing--edge-space) !important;
-			
+
 			&[style*="border-right-"] {
 				border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
 				border-right: none !important;

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -40,6 +40,20 @@ body[class] {
 	display: none;
 }
 
+[dir="rtl"] {
+	.is-sticky .wp-block-navigation.is-style-dropdown-on-mobile {
+		.wp-block-navigation__responsive-container-open {
+			right: unset;
+			left: 0;
+		}
+
+		.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-close {
+			right: unset;
+			left: var(--wp--preset--spacing--60);
+		}
+	}
+}
+
 // Slot the search & table of contents into a floating sidebar on large screens.
 @media (min-width: 1200px) {
 	.sidebar-container {


### PR DESCRIPTION
Fixes #165 

Several things are addressed in this PR:

1. Vertical alignment of the columns
2. Overflow of the mobile sub nav
3. Consistent vertical spacing within each section

## How to test

1. Load the homepage
2. Check normal LTR responsive layout
3. Add attribute `dir="rtl"` to the root page element
4. Check RTL responsive layout
5. Use the mobile dropdown sub nav, and ensure buttons and input text are laid out correctly, with no overflow in both directions

## Screenshots

### Desktop

#### LTR

| Before | After |
|-|-|
| ![localhost_8888_(Desktop) before ltr](https://user-images.githubusercontent.com/1017872/219996805-6a959a77-2618-4f1a-b880-b9ed41209948.png) | ![localhost_8888_(Desktop) after ltr](https://user-images.githubusercontent.com/1017872/220001543-cfa6f38f-f621-4f91-a911-13c18ee81b2e.png) |

NOTE: The [designs](https://www.figma.com/file/2WxlJFzMJvqPfZL1EkAOVp/Developer-Resources?node-id=2014%3A17011&t=rfauehWRGoOWR6Cs-1) show the right 'API Reference' column horizontally centered on large screens, but not on a regular desktop. For simplicity I've opted to keep it centered all the time.

#### RTL

| Before | After |
|-|-|
| ![localhost_8888_(Desktop)](https://user-images.githubusercontent.com/1017872/219996099-f36b51c1-1dda-46a1-aba2-e17458773e75.png) | ![localhost_8888_(Desktop) after rtl](https://user-images.githubusercontent.com/1017872/220001582-a2b0a7dd-9e17-436f-bacc-b0ea24af5374.png) |

### Mobile

| LTR Before | LTR After | RTL Before | RTL After |
|-|-|-|-|
| ![localhost_8888_(Samsung Galaxy S20 Ultra) before ltr](https://user-images.githubusercontent.com/1017872/219997938-1aec6416-7581-48d3-98ac-40fdba542346.png) | ![localhost_8888_(Samsung Galaxy S20 Ultra) after ltr](https://user-images.githubusercontent.com/1017872/220001234-a96635a5-5e9f-4c59-b90b-99fada55262c.png) | ![localhost_8888_(Samsung Galaxy S20 Ultra) before rtl](https://user-images.githubusercontent.com/1017872/219998003-fd0ba9bf-fc7b-4355-a607-0f1dfe8a2506.png) | ![localhost_8888_(Samsung Galaxy S20 Ultra) after rtl](https://user-images.githubusercontent.com/1017872/220001257-d8f6ed89-0102-4b94-b3bb-147f53718786.png) |

