### PR TITLE
Set the font-size of h3 correctly on single command page

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -356,6 +356,7 @@ body[class] {
 .single-command {
 	h3 {
 		margin-bottom: var(--wp--preset--spacing--20);
+		font-size: var(--wp--preset--font-size--heading-3) !important;
 	}
 
 	dt {


### PR DESCRIPTION
## Screenshots
|Before|After|
|------|-----|
| ![Screen Shot 2023-03-03 at 3 37 11 AM](https://user-images.githubusercontent.com/18050944/222534597-76968b45-e010-4bd1-b90a-85e80185dc08.png) | ![Screen Shot 2023-03-03 at 3 36 58 AM](https://user-images.githubusercontent.com/18050944/222534632-0bdf6ce4-b679-4028-b13b-10ce9f1a0e39.png) |

## Question
The font size of `h3` is broken because [this part](https://github.com/WordPress/wporg-developer/blob/trunk/source/wp-content/themes/wporg-developer-2023/theme.json#L202-L206) will have an effect like the image below shows. It sets a font size for the headings not only under the `.wp-block-wporg-table-of-contents` but all the `h2, h3, h4, h5`, and `h6` on the page. Is this expected originally?

<img width="491" alt="image" src="https://user-images.githubusercontent.com/18050944/222535194-c9c4386a-b3b4-4484-864c-5775a579321d.png">

