### PR TITLE
Fix content in code block escape the container

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -15,7 +15,7 @@ body[class] {
 		max-width: 100%;
 	}
 
-	pre:not(.line-numbers) {
+	pre:not(.wp-block-code) {
 		padding: 20px;
 		background-color: #f7f7f7;
 		border: 1px solid var(--wp--preset--color--light-grey-1);

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -8,10 +8,20 @@ body[class] {
 	--wp-local-header-offset: 57px;
 }
 
-// Parsed handbook content doesn't use image blocks, so large images are
-// missing the max-width and break out of the page container.
-.entry-content p > img {
-	max-width: 100%;
+.entry-content {
+	// Parsed handbook content doesn't use image blocks, so large images are
+	// missing the max-width and break out of the page container.
+	p > img {
+		max-width: 100%;
+	}
+
+	pre:not(.line-numbers) {
+		padding: 20px;
+		background-color: #f7f7f7;
+		border: 1px solid var(--wp--preset--color--light-grey-1);
+		border-radius: 2px;
+		overflow: scroll;
+	}
 }
 
 .search-results .wp-block-post-excerpt {
@@ -360,14 +370,6 @@ body[class] {
 
 	dt {
 		font-weight: 700;
-	}
-
-	pre {
-		padding: 20px;
-		background: #f7f7f7;
-		border: 1px solid var(--wp--preset--color--light-grey-1);
-		border-radius: 2px;
-		overflow: scroll;
 	}
 
 	table {


### PR DESCRIPTION
Fixes #198 

Fix the issue based on how it works in production. Here also tries to avoid affecting the style of code blocks that already have specific classes assigned to them on the [code page](http://localhost:8888/reference/functions/get_rss/). An alternative idea for this issue is to apply the same class to the `<pre>` tags to the whole site as the code blocks on the code page to maintain consistency in styling, not sure if it makes sense as it's not the case in production, probably for some reasons.

## Screencast
![Screen Capture on 2023-03-03 at 07-26-38](https://user-images.githubusercontent.com/18050944/222587032-3c2a8824-70c1-4c5e-bf94-fd20913e9e4c.gif)
