### PR TITLE
Import the Advanced Admin handbook

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2570,12 +2570,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "a1e17210abb50564cc40d2db558d979ce45c71ad"
+                "reference": "422a594dea072b1ac642e6af18dc985f2745b0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/a1e17210abb50564cc40d2db558d979ce45c71ad",
-                "reference": "a1e17210abb50564cc40d2db558d979ce45c71ad",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/422a594dea072b1ac642e6af18dc985f2745b0f9",
+                "reference": "422a594dea072b1ac642e6af18dc985f2745b0f9",
                 "shasum": ""
             },
             "require-dev": {
@@ -2613,7 +2613,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2023-04-26T15:39:37+00:00"
+            "time": "2023-05-04T04:18:58+00:00"
         },
         {
             "name": "wporg/wporg-parent-2021",

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -80,6 +80,9 @@ if ( class_exists( '\\WordPressdotorg\\Markdown\\Importer' ) ) {
 
 	// REST API handbook.
 	require __DIR__ . '/inc/rest-api.php';
+
+	// Advanced Administration handbook.
+	require __DIR__ . '/inc/import-advanced-admin.php';
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/inc/import-advanced-admin.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-advanced-admin.php
@@ -6,7 +6,7 @@ class DevHub_Advanced_Admin extends DevHub_Docs_Importer {
 	 */
 	public function init() {
 		parent::do_init(
-			'adv-admin',
+			'adv-admin', // 'advanced-administration' makes for too long of a post type slug when appended with '-handbook'
 			'advanced-administration',
 			'https://raw.githubusercontent.com/WordPress/Advanced-administration-handbook/main/bin/handbook-manifest.json'
 		);

--- a/source/wp-content/themes/wporg-developer-2023/inc/import-advanced-admin.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-advanced-admin.php
@@ -1,0 +1,35 @@
+<?php
+
+class DevHub_Advanced_Admin extends DevHub_Docs_Importer {
+	/**
+	 * Initializes object.
+	 */
+	public function init() {
+		parent::do_init(
+			'adv-admin',
+			'advanced-administration',
+			'https://raw.githubusercontent.com/WordPress/Advanced-administration-handbook/main/bin/handbook-manifest.json'
+		);
+
+		add_filter( 'handbook_label', array( $this, 'change_handbook_label' ), 10, 2 );
+	}
+
+	/**
+	 * Overrides the default handbook label since post type name does not directly
+	 * translate to post type label.
+	 *
+	 * @param string $label     The default label, which is merely a sanitized
+	 *                          version of the handbook name.
+	 * @param string $post_type The handbook post type.
+	 * @return string
+	 */
+	public function change_handbook_label( $label, $post_type ) {
+		if ( $this->get_post_type() === $post_type ) {
+			$label = __( 'Advanced Administration Handbook', 'wporg' );
+		}
+
+		return $label;
+	}
+}
+
+DevHub_Advanced_Admin::instance()->init();


### PR DESCRIPTION
See https://meta.trac.wordpress.org/ticket/6411

This has been committed to production for the old theme, creating this to import it with the new theme.

I haven't tested this in this theme, but it appears that it should work.