### PR TITLE
Always update the wporg composer packages to avoid lint and build failures

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -19,7 +19,7 @@ jobs:
 
             - name: Install all dependencies
               run: |
-                  composer install || composer update wporg/wporg-mu-plugins
+                  composer install || composer update wporg/*
                   yarn
             - name: Build
               run: yarn workspaces run build

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -17,10 +17,18 @@ jobs:
                   node-version-file: '.nvmrc'
                   cache: 'yarn'
 
+            - name: Setup PHP with PECL extension
+              uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
+              with:
+                php-version: '7.4'
+             env:
+                COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Install all dependencies
               run: |
                   composer install || composer update wporg/*
                   yarn
+
             - name: Build
               run: yarn workspaces run build
 
@@ -32,9 +40,11 @@ jobs:
                   git rm -rfq .
                   rm -rf *
                   mv $RUNNER_TEMP/wporg-developer-2023/* .
+
             - name: Add all the theme files
               run: |
                   git add * --force
+
             - name: Commit and push
               uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
               with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
             - name: Install all dependencies
               run: |
-                  composer install || composer update wporg/wporg-mu-plugins
+                  composer install || composer update wporg/*
                   yarn
 
             - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,13 @@ jobs:
                   node-version-file: '.nvmrc'
                   cache: 'yarn'
 
+            - name: Setup PHP with PECL extension
+              uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
+              with:
+                php-version: '7.4'
+             env:
+                COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Install all dependencies
               run: |
                   composer install || composer update wporg/*

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -29,6 +29,7 @@ jobs:
 
             - name: Install dependencies & setup configs
               run: |
+                  composer install || composer update wporg/*
                   yarn setup:tools
             - name: Lint CSS
               run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,6 +26,8 @@ jobs:
               uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
               with:
                 php-version: '7.4'
+             env:
+                COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install dependencies & setup configs
               run: |


### PR DESCRIPTION
This is intentionally duplicative for the linters, but aims to reduce the need for commits like b0d79f5074defce9ab82bb26f81fe3eb6bb9143a and 36c7a0a4639959887ee31c58715f407b8297a250 to make PRs pass linting.

Adding the `COMPOSER_TOKEN` should allow the `composer update` command to proceed, as currently it's running into rate limits.

Using composer as we are, requiring frequent updates to the `composer.json` is frustrating, but at least with this the build and lint should pass.