### PR TITLE
Templates: Use the new global Sidebar Container block

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-sidebar.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-sidebar.php
@@ -7,14 +7,8 @@
 
 ?>
 
-<!-- wp:group {"tagName":"aside","className":"sidebar-container"} -->
-<aside class="wp-block-group sidebar-container">
 	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"<?php esc_attr_e( 'Search in the documentation', 'wporg' ); ?>"} /-->
+<!-- wp:wporg/sidebar-container -->
 
-	<!-- wp:wporg/table-of-contents {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} /-->
-
-	<!-- wp:paragraph {"fontSize":"small","className":"is-link-to-top"} -->
-	<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target"><?php esc_html_e( '↑ Back to top', 'wporg' ); ?></a></p>
-	<!-- /wp:paragraph -->
-</aside>
-<!-- /wp:group -->
+	<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"blueberry-1"} /-->
+<!-- /wp:wporg/sidebar-container -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-sidebar.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-sidebar.php
@@ -7,8 +7,8 @@
 
 ?>
 
-	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"<?php esc_attr_e( 'Search in the documentation', 'wporg' ); ?>"} /-->
 <!-- wp:wporg/sidebar-container -->
+	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"width":100,"widthUnit":"%","buttonText":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"<?php esc_attr_e( 'Search in the documentation', 'wporg' ); ?>"} /-->
 
 	<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"blueberry-1"} /-->
 <!-- /wp:wporg/sidebar-container -->

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -36,10 +36,6 @@ body[class] {
 	display: block;
 }
 
-.sidebar-container .is-link-to-top {
-	display: none;
-}
-
 [dir="rtl"] {
 	.is-sticky .wp-block-navigation.is-style-dropdown-on-mobile {
 		.wp-block-navigation__responsive-container-open {
@@ -54,35 +50,8 @@ body[class] {
 	}
 }
 
-// Slot the search & table of contents into a floating sidebar on large screens.
-@media (min-width: 1200px) {
-	.sidebar-container {
-		--local--block-end-sidebar--width: 340px;
-
-		position: absolute;
-		top: calc(var(--wp-global-header-offset, 0px) + var(--wp-local-header-offset, 0px));
-		// Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered.
-		right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
-		width: var(--local--block-end-sidebar--width);
-		margin-top: var(--wp--preset--spacing--edge-space) !important;
-
-		&.is-fixed-sidebar {
-			position: fixed;
-		}
-
-		&.is-bottom-sidebar {
-			position: absolute;
-		}
-
-		&.is-fixed-sidebar .is-link-to-top,
-		&.is-bottom-sidebar .is-link-to-top {
-			display: block;
-		}
-	}
-}
-
 @media (min-width: 1440px) {
-	.has-three-columns .sidebar-container {
+	.has-three-columns .wp-block-wporg-sidebar-container {
 		--local--block-end-sidebar--width: 300px;
 		--wp--style--global--wide-size: 1280px;
 	}


### PR DESCRIPTION
In https://github.com/WordPress/wporg-mu-plugins/pull/397, the sticky sidebar behavior was moved to the Sidebar Container block, out of the Table of Contents block. This PR adds in the Sidebar Container, so that the sticky sidebar works again. This also removes the unnecessary CSS for two-column layouts, this is now provided by the global block. We still need the CSS for the 3 col layout, so that's left alone.

Additionally, this fixes #242 by adding the 100% width to the search bar.

**Screenshots**

| Trunk | Branch |
|---|---|
| ![trunk-2-col](https://user-images.githubusercontent.com/541093/236893432-4b220ca9-2608-4ede-a3c6-72f0dd46dd33.png) | ![pr-2-col](https://user-images.githubusercontent.com/541093/236893423-fb89225a-cca4-4665-82e3-0d11d1b4b3e8.png) |
| ![trunk-3-col](https://user-images.githubusercontent.com/541093/236893434-2ac2ce55-d3a0-4645-9806-25ef7287d3df.png) | ![pr-3-col](https://user-images.githubusercontent.com/541093/236893427-e42e101f-2b6a-457f-a495-349d6055423d.png) |

