### PR TITLE
Fix `get_page_by_title` deprecation warnings

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
@@ -412,7 +412,17 @@ class DevHub_Formatting {
 								$name = str_replace( array( '->', '-&gt;' ), '::', $name );
 
 								// Only link actually parsed methods.
-								if ( $post = get_page_by_title( $name, OBJECT, 'wp-parser-method' ) ) {
+								$args = array(
+									'post_type' => 'wp-parser-method',
+									'name' => $name,
+									'posts_per_page' => 1,
+								);
+								
+								$query = new WP_Query( $args );
+								
+								if ( $query->have_posts() ) {
+									$post = $query->posts[0];
+
 									return sprintf(
 										'<a href="%s" rel="method">%s</a>' . $after,
 										get_permalink( $post->ID ),

--- a/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
@@ -485,7 +485,17 @@ class DevHub_Formatting {
 						}
 
 						// Only link actually parsed classes.
-						if ( $post = get_page_by_title( $matches[0], OBJECT, 'wp-parser-class' ) ) {
+						$args = array(
+							'post_type' => 'wp-parser-class',
+							'name' => $matches[0],
+							'posts_per_page' => 1,
+						);
+						
+						$query = new WP_Query( $args );
+						
+						if ( $query->have_posts() ) {
+							$post = $query->posts[0];
+
 							return sprintf(
 								'<a href="%s" rel="class">%s</a>',
 								get_permalink( $post->ID ),

--- a/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
@@ -433,7 +433,17 @@ class DevHub_Formatting {
 							// Reference to a function.
 							} else {
 								// Only link actually parsed functions.
-								if ( $post = get_page_by_title( $name, OBJECT, 'wp-parser-function' ) ) {
+								$args = array(
+									'post_type' => 'wp-parser-function',
+									'name' => $name,
+									'posts_per_page' => 1,
+								);
+								
+								$query = new WP_Query( $args );
+								
+								if ( $query->have_posts() ) {
+									$post = $query->posts[0];
+
 									return sprintf(
 										'<a href="%s" rel="function">%s</a>' . $after,
 										get_permalink( $post->ID ),

--- a/source/wp-content/themes/wporg-developer-2023/inc/redirects.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/redirects.php
@@ -65,8 +65,19 @@ class DevHub_Redirects {
 	 */
 	public static function redirect_resources() {
 		if ( is_page( 'resource' ) ) {
-			wp_redirect( get_permalink( get_page_by_title( 'dashicons' ) ) );
-			exit();
+			$args = array(
+				'post_type' => 'page',
+				'name' => 'dashicons',
+				'posts_per_page' => 1,
+			);
+		
+			$query = new WP_Query( $args );
+		
+			if ( $query->have_posts() ) {
+				$post = $query->posts[0];
+				wp_redirect( get_permalink( $post->ID ) );
+				exit();
+			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -879,7 +879,17 @@ namespace DevHub {
 	function get_param_reference( $param, $recursion_limit = 3 ) {
 		if ( $recursion_limit > 0 && preg_match_all( '#rel="(function|method)">([^<>()]+)[(][)]</a>#', $param[ 'content' ], $matches, PREG_SET_ORDER ) ) {
 			foreach ( $matches as $match ) {
-				if ( $_post = get_page_by_title( $match[2], OBJECT, 'wp-parser-' . $match[1] ) ) {
+				$args = array(
+					'post_type' => 'wp-parser-' . $match[1],
+					'name' => $match[2],
+					'posts_per_page' => 1,
+				);
+			
+				$query = new WP_Query( $args );
+			
+				if ( $query->have_posts() ) {
+					$_post = $query->posts[0];
+
 					if ( $_params = get_params( $_post->ID ) ) {
 
 						$arg_names_to_try = array_unique([


### PR DESCRIPTION
Fixes #206 

Removes warnings about `Deprecated: Function get_page_by_title is deprecated since version 6.2.0! Use WP_Query instead`.

### Testing

- Ensure you have a Resource page and a Resource/Dashicons page. Navigate to `/resource` and you should be redirected to `resource/dashicons`

I'm not sure how to test the usages in `/inc` as I'm not sure how to debug the parser. @tellyworth [it looks like you were the author of some of the original code](https://github.com/WordPress/wporg-developer/blame/old/source/wp-content/themes/wporg-developer/inc/template-tags.php#L890), any thoughts please?