### PR TITLE
Add redirect for removed block editor tutorial.

### DIFF
--- a/source/wp-content/themes/wporg-developer/inc/import-block-editor.php
+++ b/source/wp-content/themes/wporg-developer/inc/import-block-editor.php
@@ -53,6 +53,7 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 			'reference-guides/block-api/versions' => 'reference-guides/block-api/block-api-versions',
 			'how-to-guides/block-theme' => 'how-to-guides/themes/create-block-theme',
 			'how-to-guides/block-based-theme' => 'how-to-guides/themes/block-theme-overview',
+			'how-to-guides/platform/custom-block-editor/tutorial' => 'how-to-guides/platform/custom-block-editor'
 
 			// After handbook restructuring, March 2021.
 			'handbook/versions-in-wordpress/' => 'contributors/versions-in-wordpress',


### PR DESCRIPTION
This PR replaces https://github.com/WordPress/wporg-developer/pull/254 and targets the `old` branch [as requested](https://github.com/WordPress/wporg-developer/pull/254#issuecomment-1661385518).

---

https://github.com/WordPress/gutenberg/pull/53159 consolidates the [Building a custom block editor](https://developer.wordpress.org/block-editor/how-to-guides/platform/custom-block-editor/) and [Tutorial: building a custom block editor](https://developer.wordpress.org/block-editor/how-to-guides/platform/custom-block-editor/tutorial/) into one doc. This PR adds a redirect from the removed tutorial doc to the main page.

Once #53159 is merged, this redirect will be needed.