### PR TITLE
Fix namespace for WP_Query usage

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -885,7 +885,7 @@ namespace DevHub {
 					'posts_per_page' => 1,
 				);
 			
-				$query = new WP_Query( $args );
+				$query = new \WP_Query( $args );
 			
 				if ( $query->have_posts() ) {
 					$_post = $query->posts[0];


### PR DESCRIPTION
See #206 

This fixes issues with namespaces for WP_Query, see https://github.com/WordPress/wporg-developer/pull/252#issuecomment-1672539753