### PR TITLE
Add Code Reference landing page template

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -175,6 +175,7 @@ require_once __DIR__ . '/src/command-content/block.php';
 require_once __DIR__ . '/src/command-github/block.php';
 require_once __DIR__ . '/src/command-title/block.php';
 require_once __DIR__ . '/src/command-subcommand/block.php';
+require_once __DIR__ . '/src/reference-new-updated/block.php';
 require_once __DIR__ . '/src/search-filters/index.php';
 require_once __DIR__ . '/src/search-results-context/index.php';
 require_once __DIR__ . '/src/version-select/index.php';

--- a/source/wp-content/themes/wporg-developer-2023/inc/redirects.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/redirects.php
@@ -23,7 +23,6 @@ class DevHub_Redirects {
 	public static function do_init() {
 		add_action( 'template_redirect', array( __CLASS__, 'redirect_single_search_match' ) );
 		add_action( 'template_redirect', array( __CLASS__, 'redirect_handbook' ) );
-		add_action( 'template_redirect', array( __CLASS__, 'redirect_reference_home' ) );
 		add_action( 'template_redirect', array( __CLASS__, 'redirect_resources' ) );
 		add_action( 'template_redirect', array( __CLASS__, 'redirect_singularized_handbooks' ), 1 );
 		add_action( 'template_redirect', array( __CLASS__, 'redirect_pluralized_reference_post_types' ), 1 );
@@ -78,16 +77,6 @@ class DevHub_Redirects {
 				wp_redirect( get_permalink( $post->ID ) );
 				exit();
 			}
-		}
-	}
-
-	/**
-	 * Redirects /reference/ to the home url.
-	 */
-	public static function redirect_reference_home() {
-		if ( isset( $_SERVER['REQUEST_URI'] ) && '/reference/' === esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) {
-			wp_safe_redirect( home_url( '/' ), 301 );
-			exit();
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
@@ -28,11 +28,11 @@
 			<div class="wp-block-group">
 				
 				<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
-				<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">API reference</h2>
+				<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'API reference', 'wporg' ); ?></h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph -->
-				<p><a href="https://developer.wordpress.org/apis/">View all</a></p>
+				<p><a href="https://developer.wordpress.org/apis/"><?php esc_html_e( 'View all', 'wporg' ); ?></a></p>
 				<!-- /wp:paragraph -->
 			
 			</div>

--- a/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Title: Reference Content
+ * Slug: wporg-developer-2023/reference-content
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-columns alignwide">
+		
+		<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+		<div class="wp-block-column">
+
+			<!-- wp:wporg/reference-new-updated /-->
+
+		</div>
+		<!-- /wp:column -->
+	
+		<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
+		<div class="wp-block-column">
+			
+			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+			<div class="wp-block-group">
+				
+				<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
+				<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">API reference</h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph -->
+				<p><a href="https://developer.wordpress.org/apis/">View all</a></p>
+				<!-- /wp:paragraph -->
+			
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20"}},"border":{"width":"1px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
+			
+				<!-- wp:list {"style":{"typography":{"lineHeight":"3"},"spacing":{"padding":{"left":"0"}}},"className":"wporg-reference-list","fontSize":"small"} -->
+				<ul class="wporg-reference-list has-small-font-size" style="padding-left:0;line-height:3">
+				
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/dashboard-widgets/">Dashboard widgets</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/database/">Database</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/making-http-requests/">HTTP API</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/filesystem/">Filesystem</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/global-variables/">Global Variables</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/metadata/">Metadata</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/options/">Options</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/plugins/">Plugins</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/quicktags/">Quicktags</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/rest-api/">REST API</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/rewrite/">Rewrite</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/settings/">Settings</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/shortcode/">Shortcode</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/themes/">Theme Modification</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/transients/">Transients</a></li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li><a href="https://developer.wordpress.org/apis/handbook/xml-rpc/">XML-RPC</a></li>
+				<!-- /wp:list-item -->
+			
+			</ul>
+			<!-- /wp:list -->
+		
+		</div>
+		<!-- /wp:group -->
+		
+		</div>
+		<!-- /wp:column -->
+	
+	</div>
+	<!-- /wp:columns -->
+
+</div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
@@ -38,78 +38,10 @@
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20"}},"border":{"width":"1px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
-			<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20"}},"border":{"width":"1px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
 			
-				<!-- wp:list {"style":{"typography":{"lineHeight":"3"},"spacing":{"padding":{"left":"0"}}},"className":"wporg-reference-list","fontSize":"small"} -->
-				<ul class="wporg-reference-list has-small-font-size" style="padding-left:0;line-height:3">
-				
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/dashboard-widgets/">Dashboard widgets</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/database/">Database</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/making-http-requests/">HTTP API</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/filesystem/">Filesystem</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/global-variables/">Global Variables</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/metadata/">Metadata</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/options/">Options</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/plugins/">Plugins</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/quicktags/">Quicktags</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/rest-api/">REST API</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/rewrite/">Rewrite</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/settings/">Settings</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/shortcode/">Shortcode</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/themes/">Theme Modification</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/transients/">Transients</a></li>
-				<!-- /wp:list-item -->
-
-				<!-- wp:list-item -->
-				<li><a href="https://developer.wordpress.org/apis/handbook/xml-rpc/">XML-RPC</a></li>
-				<!-- /wp:list-item -->
-			
-			</ul>
-			<!-- /wp:list -->
+				<!-- wp:navigation {"ref":144716,"overlayMenu":"never","className":"wporg-reference-list","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0"}},"fontSize":"small"} /-->
 		
 		</div>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/reference-new-updated",
+	"version": "0.1.0",
+	"title": "Reference: New and updated",
+	"category": "widgets",
+	"icon": "smiley",
+	"description": "Show a list of the things that are new or updated for a release",
+	"supports": {},
+	"textdomain": "wporg",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.php
@@ -1,0 +1,97 @@
+<?php
+namespace WordPressdotorg\Theme\Developer_2023\Reference_New_Updated;
+
+use function DevHub\get_current_version_term;
+use function DevHub\get_parsed_post_types;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/reference-new-updated',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	$version = get_current_version_term();
+
+	if ( ! ( $version && ! is_wp_error( $version ) ) ) {
+		return '';
+	}
+
+	$list = new \WP_Query( array(
+		'posts_per_page' => 15,
+		'post_type'      => get_parsed_post_types(),
+		'orderby'        => 'title',
+		'order'          => 'ASC',
+		'tax_query'      => array( array(
+			'taxonomy' => 'wp-parser-since',
+			'field'    => 'ids',
+			'terms'    => $version->term_id,
+		) ),
+	) );
+
+	$content = '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20"}},"border":{"width":"1px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
+
+		<!-- wp:list {"style":{"typography":{"lineHeight":"3"},"spacing":{"padding":{"left":"0"}}},"className":"wporg-reference-list","fontSize":"small"} -->
+		<ul class="wporg-reference-list has-small-font-size" style="padding-left:0;line-height:3">';
+	
+	while ( $list->have_posts() ) : $list->the_post();
+
+		$content .= sprintf(
+			'<!-- wp:list-item --><li><a href="%s">%s</a></li><!-- /wp:list-item -->',
+			esc_url( get_permalink() ),
+			esc_html( get_the_title() )
+		);
+
+	endwhile;
+
+	$content .= '</ul><!-- /wp:list --></div><!-- /wp:group -->';
+
+	$title_block = sprintf(
+		'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+		<div class="wp-block-group">
+
+			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
+			<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">%s</h2>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph -->
+			<p><a href="%s">%s</a></p>
+			<!-- /wp:paragraph -->
+
+		</div>
+		<!-- /wp:group -->',
+		sprintf( __( 'New and updated in %s', 'wporg' ), substr( $version->name, 0, -2 ) ),
+		esc_attr( get_term_link( $version, 'wp-parser-since' ) ),
+		__( 'View all', 'wporg' )
+	);
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %s>%s %s</div>',
+		$wrapper_attributes,
+		do_blocks( $title_block ),
+		do_blocks( $content )
+	);
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.php
@@ -50,11 +50,11 @@ function render( $attributes, $content, $block ) {
 		) ),
 	) );
 
-	$content = '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20"}},"border":{"width":"1px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
-	<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
+	$content = '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20"}},"border":{"width":"1px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;margin-top:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
 
-		<!-- wp:list {"style":{"typography":{"lineHeight":"3"},"spacing":{"padding":{"left":"0"}}},"className":"wporg-reference-list","fontSize":"small"} -->
-		<ul class="wporg-reference-list has-small-font-size" style="padding-left:0;line-height:3">';
+		<!-- wp:list {"style":{"spacing":{"padding":{"left":"0"}}},"className":"wporg-reference-list","fontSize":"small"} -->
+		<ul class="wporg-reference-list has-small-font-size" style="padding-left:0">';
 	
 	while ( $list->have_posts() ) : $list->the_post();
 

--- a/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../shared/dynamic-edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -304,8 +304,22 @@ body[class] {
 	}
 }
 
-.wporg-reference-list {
+.wporg-reference-list,
+.wp-block-navigation .wporg-reference-list {
 	list-style: none;
+
+	> li,
+	.wp-block-navigation-item {
+		&:not(:last-child) {
+			margin-bottom: var(--wp--preset--spacing--20);
+		}
+	}
+
+	> a,
+	.wp-block-navigation-item__content {
+		color: var(--wp--custom--link--color--text);
+		text-decoration: underline;
+	}
 }
 
 .single-command {

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -304,6 +304,10 @@ body[class] {
 	}
 }
 
+.wporg-reference-list {
+	list-style: none;
+}
+
 .single-command {
 	h3 {
 		margin-bottom: var(--wp--preset--spacing--20);

--- a/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
@@ -1,0 +1,31 @@
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-columns alignwide"><!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
+	<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">New and updated in 6.3</h2>
+	<!-- /wp:heading -->
+	
+	<!-- wp:paragraph -->
+	<p>View all</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:column -->
+	
+	<!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
+	<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">API reference</h2>
+	<!-- /wp:heading -->
+	
+	<!-- wp:paragraph -->
+	<p>View all</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:column --></div>
+	<!-- /wp:columns --></div>
+	<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
@@ -1,31 +1,5 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"}}}} -->
-	<div class="wp-block-columns alignwide"><!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
-	<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">New and updated in 6.3</h2>
-	<!-- /wp:heading -->
-	
-	<!-- wp:paragraph -->
-	<p>View all</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group --></div>
-	<!-- /wp:column -->
-	
-	<!-- wp:column -->
-	<div class="wp-block-column"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
-	<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">API reference</h2>
-	<!-- /wp:heading -->
-	
-	<!-- wp:paragraph -->
-	<p>View all</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group --></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns --></div>
-	<!-- /wp:group -->
+<!-- wp:pattern {"slug":"wporg-developer-2023/reference-content"} /-->
 
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Closes #283 

### Screenshots

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_reference_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/8e189807-5df8-4727-8aec-125a7c7f1b74) | ![localhost_8888_reference_(iPad)](https://github.com/WordPress/wporg-developer/assets/1017872/bd4e8a61-f76e-49c0-b4c5-5c8ff8d0c13c) | ![localhost_8888_reference_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-developer/assets/1017872/61e78558-afd5-4d8c-8763-025c50092d59) |

### Testing

1. Add a page at `/reference`
2. Add a menu with some items and generate a navigation from it. Take note of the ref id and replace [this ref](https://github.com/WordPress/wporg-developer/pull/286/files#diff-b291dab96cc345cd7115307afa5566f7414cde09313dad796ec6ef71cfe68264R44)
3. Load the page, check responsive layout
4. The local nav item 'Code Reference' should be bold
5. Test the 'View all' links and a selection of reference links