### PR TITLE
Update CLI commands page layout

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -188,7 +188,7 @@ add_filter( 'next_post_link', __NAMESPACE__ . '\get_adjacent_handbook_post_link'
 add_filter( 'previous_post_link', __NAMESPACE__ . '\get_adjacent_handbook_post_link', 10, 5 );
 
 // Priority must be lower than 5 to precede table of contents filter.
-// See: https://github.com/WordPress/wporg-mu-plugins/blob/trunk/mu-plugins/blocks/table-of-contents/index.php#L70
+// See: https://github.com/WordPress/wporg-mu-plugins/blob/3867a4ff6fa81de5f1e2e7b1ed4b123e4b4915b3/mu-plugins/blocks/table-of-contents/index.php#L94
 add_filter( 'the_content', __NAMESPACE__ . '\filter_code_content', 4 );
 add_filter( 'wporg_table_of_contents_post_content', __NAMESPACE__ . '\filter_code_content' );
 add_filter( 'the_content', __NAMESPACE__ . '\filter_command_content', 4 );

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -583,7 +583,8 @@ function filter_code_content( $content ) {
 function filter_command_content( $content ) {
 	$post_type = get_post_type();
 
-	// Feed the static content from the CLI archive template into the ToC
+	// Feed the static content from the CLI archive template to generate the ToC
+	// Note: ids must be added to the cli-commands-content pattern manually
 	if ( is_archive() && '/cli/commands/' === $_SERVER['REQUEST_URI'] ) {
 		// Stop infinite loop
 		remove_filter( 'the_content', 'DevHub\filter_command_content', 4 );

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -583,6 +583,18 @@ function filter_code_content( $content ) {
 function filter_command_content( $content ) {
 	$post_type = get_post_type();
 
+	// Feed the static content from the CLI archive template into the ToC
+	if ( is_archive() && '/cli/commands/' === $_SERVER['REQUEST_URI'] ) {
+		// Stop infinite loop
+		remove_filter( 'the_content', 'DevHub\filter_command_content', 4 );
+
+		$content = do_blocks('<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->');
+		
+		add_filter( 'the_content', 'DevHub\filter_command_content', 4 );
+
+		return $content;
+	}
+
 	if ( ! is_single() || ! ( 'command' == $post_type ) ) {
 		return $content;
 	}

--- a/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
@@ -35,26 +35,6 @@ function filter_search_block( $block_content, $block ) {
 add_filter( 'render_block', __NAMESPACE__ . '\\filter_search_block', 10, 2 );
 
 /**
- * Filters the search block and updates the placeholder.
- *
- * @param string $parsed_block
- * @return array
- */
-function render_block_data( $parsed_block ) {
-	if ( 'core/search' !== $parsed_block['blockName'] ) {
-		return $parsed_block;
-	}
-
-	if ( is_parsed_post_type() || 'command' === get_post_type() ) {
-		$parsed_block['attrs']['placeholder'] = __( 'Search for commands...', 'wporg' );
-	}
-
-	return $parsed_block;
-}
-
-add_filter( 'render_block_data', __NAMESPACE__ . '\render_block_data', 10, 2 );
-
-/**
  * Replaces the action URL in a block content string with a given URL path.
  *
  * @param string $block_content The block content string to modify.

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
@@ -29,15 +29,23 @@
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
-<div class="wp-block-group is-style-cards-grid">
-	
-	<!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
-	<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/"><strong><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></strong><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></a></h3>
-	<!-- /wp:heading -->
+<div class="wp-block-group is-style-cards-grid"><!-- wp:wporg/link-wrapper -->
+<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
 
-	<!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
-	<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/handbook/"><strong><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></strong><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></a></h3>
-	<!-- /wp:heading -->
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></a>
+<!-- /wp:wporg/link-wrapper -->
 
-</div>
+<!-- wp:wporg/link-wrapper -->
+<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></a>
+<!-- /wp:wporg/link-wrapper --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
@@ -25,13 +25,13 @@
 <!-- wp:wporg/cli-command-table {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></h2>
+<h2 class="wp-block-heading" id="other-developer-resources"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
 <div class="wp-block-group is-style-cards-grid"><!-- wp:wporg/link-wrapper -->
 <a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></h3>
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size" id="cli-blog" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->
@@ -41,7 +41,7 @@
 
 <!-- wp:wporg/link-wrapper -->
 <a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></h3>
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size" id="cli-handbook" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Title: CLI Commands Page Static Content
+ * Slug: wporg-developer-2023/cli-commands-content
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'Below is a listing of all currently available WP-CLI commands with links to documentation on usage and subcommands.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php echo wp_kses_post(
+	sprintf(
+	/* translators: %1$s: URL of the WP-CLI handbook, %2$s: URL of the WP-CLI blog */
+		__( 'Looking to learn more about the internal API of WP-CLI or to contribute to its development? Check out the WP-CLI team&rsquo;s <a href="%1$s">handbook</a> and the <a href="%2$s">WP-CLI Blog</a>.', 'wporg' ),
+		'https://make.wordpress.org/cli/handbook/',
+		'https://make.wordpress.org/cli/'
+	)
+); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:wporg/cli-command-table {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
+<div class="wp-block-group is-style-cards-grid">
+	
+	<!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
+	<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/"><strong><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></strong><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></a></h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
+	<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/handbook/"><strong><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></strong><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></a></h3>
+	<!-- /wp:heading -->
+
+</div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
@@ -7,6 +7,10 @@
 
 ?>
 
+<!-- wp:heading {"level":1,"className":" is-toc-heading","fontSize":"heading-2"} -->
+<h1 class="wp-block-heading is-toc-heading has-heading-2-font-size" id="wp-cli-commands"><a href="#wp-cli-commands"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></a></h1>
+<!-- /wp:heading -->
+
 <!-- wp:paragraph -->
 <p><?php esc_html_e( 'Below is a listing of all currently available WP-CLI commands with links to documentation on usage and subcommands.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
@@ -27,25 +31,3 @@
 <!-- wp:heading {"className":"is-toc-heading"} -->
 <h2 class="wp-block-heading is-toc-heading" id="other-developer-resources"><a href="#other-developer-resources"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></a></h2>
 <!-- /wp:heading -->
-
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
-<div class="wp-block-group is-style-cards-grid"><!-- wp:wporg/link-wrapper -->
-<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size" id="cli-blog" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></a>
-<!-- /wp:wporg/link-wrapper -->
-
-<!-- wp:wporg/link-wrapper -->
-<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size" id="cli-handbook" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></a>
-<!-- /wp:wporg/link-wrapper --></div>
-<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
@@ -24,8 +24,8 @@
 
 <!-- wp:wporg/cli-command-table {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->
 
-<!-- wp:heading -->
-<h2 class="wp-block-heading" id="other-developer-resources"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></h2>
+<!-- wp:heading {"className":"is-toc-heading"} -->
+<h2 class="wp-block-heading is-toc-heading" id="other-developer-resources"><a href="#other-developer-resources"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></a></h2>
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -8,54 +8,51 @@
 ?>
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"className":"alignfull","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"}} -->
-<main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
-<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"><!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search resources', 'wporg' ); ?>","width":240,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /--></div>
-<!-- /wp:group -->
+<main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
 
-<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
-<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)"><!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0px"}}}} -->
-<article class="wp-block-group" style="margin-top:0px"><!-- wp:wporg/sidebar-container -->
-<!-- wp:group -->
-<div class="wp-block-group"><!-- wp:wporg/table-of-contents /--></div>
-<!-- /wp:group -->
-<!-- /wp:wporg/sidebar-container -->
+	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)">
 
-<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide"><!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
-<h1 class="wp-block-heading has-heading-2-font-size"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></h1>
-<!-- /wp:heading -->
+		<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search resources', 'wporg' ); ?>","width":240,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->
 
-<!-- wp:paragraph -->
-<p><?php esc_html_e( 'Below is a listing of all currently available WP-CLI commands with links to documentation on usage and subcommands.', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:paragraph -->
-<p><?php echo wp_kses_post(
-	sprintf(
-	/* translators: %1$s: URL of the WP-CLI handbook, %2$s: URL of the WP-CLI blog */
-		__( 'Looking to learn more about the internal API of WP-CLI or to contribute to its development? Check out the WP-CLI team&rsquo;s <a href="%1$s">handbook</a> and the <a href="%2$s">WP-CLI Blog</a>.', 'wporg' ),
-		'https://make.wordpress.org/cli/handbook/',
-		'https://make.wordpress.org/cli/'
-	)
-); ?></p>
-<!-- /wp:paragraph -->
+	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+	
+		<!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0px"}}}} -->
+		<article class="wp-block-group" style="margin-top:0px">
+		
+			<!-- wp:wporg/sidebar-container -->
 
-<!-- wp:wporg/cli-command-table {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->
+				<!-- wp:group -->
+				<div class="wp-block-group">
+					
+					<!-- wp:wporg/table-of-contents /-->
 
-<!-- wp:heading -->
-<h2 class="wp-block-heading"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></h2>
-<!-- /wp:heading -->
+				</div>
+				<!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
-<div class="wp-block-group is-style-cards-grid"><!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/"><strong><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></strong><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></a></h3>
-<!-- /wp:heading -->
+			<!-- /wp:wporg/sidebar-container -->
 
-<!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/handbook/"><strong><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></strong><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></a></h3>
-<!-- /wp:heading --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></article>
-<!-- /wp:group --></div>
-<!-- /wp:group --></main>
+		<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignwide">
+			
+			<!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
+			<h1 class="wp-block-heading has-heading-2-font-size"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->
+
+		</div>
+		<!-- /wp:group -->
+
+		</article>
+		<!-- /wp:group -->
+
+	</div>
+	<!-- /wp:group -->
+
+</main>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -24,21 +24,11 @@
 		<!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0px"}}}} -->
 		<article class="wp-block-group" style="margin-top:0px">
 		
-			<!-- wp:wporg/sidebar-container -->
-
-				<!-- wp:group -->
-				<div class="wp-block-group">
-					
-					<!-- wp:wporg/table-of-contents /-->
-
-				</div>
-				<!-- /wp:group -->
-
-			<!-- /wp:wporg/sidebar-container -->
+		<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
 		<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 		<div class="wp-block-group alignwide">
-			
+
 			<!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
 			<h1 class="wp-block-heading has-heading-2-font-size"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></h1>
 			<!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -29,11 +29,41 @@
 		<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 		<div class="wp-block-group alignwide">
 
-			<!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
-			<h1 class="wp-block-heading has-heading-2-font-size"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></h1>
-			<!-- /wp:heading -->
-
 			<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
+			<div class="wp-block-group is-style-cards-grid">
+				
+				<!-- wp:wporg/link-wrapper -->
+				<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/">
+					
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
+					<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></h3>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph {"fontSize":"small"} -->
+					<p class="has-small-font-size"><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></p>
+					<!-- /wp:paragraph -->
+
+				</a>
+				<!-- /wp:wporg/link-wrapper -->
+
+				<!-- wp:wporg/link-wrapper -->
+				<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/handbook/">
+					
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
+					<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></h3>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph {"fontSize":"small"} -->
+					<p class="has-small-font-size"><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></p>
+					<!-- /wp:paragraph -->
+					
+				</a>
+				<!-- /wp:wporg/link-wrapper -->
+			
+			</div>
+			<!-- /wp:group -->
 
 		</div>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -7,16 +7,25 @@
 
 ?>
 
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33%"} -->
-<div class="wp-block-column" style="flex-basis:33%"><!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
-<h1 class="wp-block-heading has-heading-2-font-size">WP-CLI Commands</h1>
-<!-- /wp:heading --></div>
-<!-- /wp:column -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"className":"alignfull","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"}} -->
+<main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"><!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search resources', 'wporg' ); ?>","width":240,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /--></div>
+<!-- /wp:group -->
 
-<!-- wp:column {"width":"66%"} -->
-<div class="wp-block-column" style="flex-basis:66%"><!-- wp:paragraph -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)"><!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0px"}}}} -->
+<article class="wp-block-group" style="margin-top:0px"><!-- wp:wporg/sidebar-container -->
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:wporg/table-of-contents /--></div>
+<!-- /wp:group -->
+<!-- /wp:wporg/sidebar-container -->
+
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
+<h1 class="wp-block-heading has-heading-2-font-size">WP-CLI Commands</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
 <p>Below is a listing of all currently available WP-CLI commands with links to documentation on usage and subcommands.</p>
 <!-- /wp:paragraph -->
 
@@ -24,7 +33,22 @@
 <p>Looking to learn more about the internal API of WP-CLI or to contribute to its development? Check out the WP-CLI team’s <a href="https://make.wordpress.org/cli/handbook/">handbook</a> and the <a href="https://make.wordpress.org/cli/">WP-CLI Blog</a>.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:wporg/cli-command-table /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+<!-- wp:wporg/cli-command-table {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Other Developer Resources</h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
+<div class="wp-block-group is-style-cards-grid"><!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/"><strong>CLI Blog</strong>Catch up on the latest on WP-CLI in the main updates blog.</a></h3>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/handbook/"><strong>CLI Handbook</strong>A collection of helpful guides and resources for using WP-CLI.</a></h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></article>
+<!-- /wp:group --></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -22,30 +22,37 @@
 
 <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide"><!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
-<h1 class="wp-block-heading has-heading-2-font-size">WP-CLI Commands</h1>
+<h1 class="wp-block-heading has-heading-2-font-size"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Below is a listing of all currently available WP-CLI commands with links to documentation on usage and subcommands.</p>
+<p><?php esc_html_e( 'Below is a listing of all currently available WP-CLI commands with links to documentation on usage and subcommands.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Looking to learn more about the internal API of WP-CLI or to contribute to its development? Check out the WP-CLI team’s <a href="https://make.wordpress.org/cli/handbook/">handbook</a> and the <a href="https://make.wordpress.org/cli/">WP-CLI Blog</a>.</p>
+<p><?php echo wp_kses_post(
+	sprintf(
+	/* translators: %1$s: URL of the WP-CLI handbook, %2$s: URL of the WP-CLI blog */
+		__( 'Looking to learn more about the internal API of WP-CLI or to contribute to its development? Check out the WP-CLI team&rsquo;s <a href="%1$s">handbook</a> and the <a href="%2$s">WP-CLI Blog</a>.', 'wporg' ),
+		'https://make.wordpress.org/cli/handbook/',
+		'https://make.wordpress.org/cli/'
+	)
+); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wporg/cli-command-table {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">Other Developer Resources</h2>
+<h2 class="wp-block-heading"><?php esc_html_e( 'Other Developer Resources', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
 <div class="wp-block-group is-style-cards-grid"><!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/"><strong>CLI Blog</strong>Catch up on the latest on WP-CLI in the main updates blog.</a></h3>
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/"><strong><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></strong><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></a></h3>
 <!-- /wp:heading -->
 
 <!-- wp:heading {"level":3,"fontSize":"small","fontFamily":"inter"} -->
-<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/handbook/"><strong>CLI Handbook</strong>A collection of helpful guides and resources for using WP-CLI.</a></h3>
+<h3 class="wp-block-heading has-inter-font-family has-small-font-size"><a href="https://make.wordpress.org/cli/handbook/"><strong><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></strong><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></a></h3>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></article>

--- a/source/wp-content/themes/wporg-developer-2023/patterns/single-search.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/single-search.php
@@ -7,4 +7,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search in the documentation', 'wporg' ); ?>","width":260,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1"} /-->
+<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search resources', 'wporg' ); ?>","width":260,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}}},"backgroundColor":"light-grey-2","textColor":"charcoal-1"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
@@ -1,7 +1,6 @@
 .wp-block-wporg-command-github {
-	.github-tracker {
-		margin-bottom: 40px;
-	}
+	// override standard block gap between sections in the content
+	margin-block-start: 0 !important;
 
 	img {
 		width: 23px;

--- a/source/wp-content/themes/wporg-developer-2023/src/command-title/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-title/block.php
@@ -60,11 +60,16 @@ function render( $attributes, $content, $block ) {
 	$content .= '</a>';
 	$content .= '</h1>';
 
-	// TODO: Reinstate excerpt. This is causing an infinite loop, see https://github.com/WordPress/wporg-developer/issues/277
-	// $excerpt = get_the_excerpt( $post_ID );
-	// if ( $excerpt ) {
-	// 	$content .= '<p class="excerpt">' . $excerpt . '</p>';
-	// }
+	// Remove the filter that adds the code reference block to the content.
+	remove_filter( 'the_content', 'DevHub\filter_command_content', 4 );
+
+	$excerpt = get_the_excerpt( $post_ID );
+	if ( $excerpt ) {
+		$content .= '<p class="excerpt">' . $excerpt . '</p>';
+	}
+
+	// Re-add the filter that adds this block to the content.
+	add_filter( 'the_content', 'DevHub\filter_command_content', 4 );
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(

--- a/source/wp-content/themes/wporg-developer-2023/src/command-title/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-title/style.scss
@@ -1,6 +1,7 @@
 .wp-block-wporg-command-title {
 	h1 {
-		margin-bottom: 32px;
+		margin-top: var(--wp--preset--spacing--30);
+		margin-bottom: var(--wp--preset--spacing--30);
 	}
 
 	a {

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
@@ -3,10 +3,18 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space"}}}} -->
-	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)">
+		
+		<!-- wp:pattern {"slug":"wporg-developer-2023/single-search"} /-->
 
-		<!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0px"}}}} -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+
+		<!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"0","margin":{"top":"0px"}}}} -->
 		<article class="wp-block-group" style="margin-top:0px">
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->


### PR DESCRIPTION
Closes #264 
Fixes #277 

Depends on https://github.com/WordPress/wporg-parent-2021/pull/110 which updates the card grid styles to use LinkWrapper blocks, enabling better markup for the cards which is compatible with the ToC.

Adds search, and 'Other Developer Resources' section.

Reformats content into one column and adds sidebar with ToC.

The h1 is included in the ToC, which isn't consistent with other pages like the [Code Reference](http://localhost:8888/reference/functions/absint/). @WordPress/meta-design what's correct here please?

### Screenshots

#### Commands archive

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_cli_commands_(Desktop) (3)](https://github.com/WordPress/wporg-developer/assets/1017872/63498410-87fa-45c8-b29a-ece4e5268c05) | ![localhost_8888_cli_commands_(iPad) (2)](https://github.com/WordPress/wporg-developer/assets/1017872/6d8c5672-a09f-48cc-8013-7ed6a40d9425) | ![localhost_8888_cli_commands_(Samsung Galaxy S20 Ultra) (3)](https://github.com/WordPress/wporg-developer/assets/1017872/2f7d3ae4-0511-46c4-8ffb-d7efa2582818) |

#### Single Command

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_cli_commands_admin_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/e840de9f-4cad-4048-a6cb-965ef4169f37) | ![localhost_8888_cli_commands_admin_(iPad)](https://github.com/WordPress/wporg-developer/assets/1017872/102c0990-697c-4845-8e15-93bd1bc512d1) | ![localhost_8888_cli_commands_admin_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-developer/assets/1017872/f8188d07-3a28-4739-9236-5344756cc126) |