### PR TITLE
Update local navs to use chevron icon

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
@@ -2,6 +2,6 @@
 
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-	<!-- wp:navigation {"hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
+	<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
 		
 <!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
@@ -13,7 +13,7 @@
 <div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>
 <!-- /wp:html -->
 
-<!-- wp:navigation {"hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
+<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
 <!-- /wp:wporg/local-navigation-bar --></div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Closes #302 
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/480

Updates the local nav menus to use the 3 bar menu icon, which can be replaced with a chevron icon by the filter in mu-plugins.

### Screenshots

| State | Before | After |
|-|-|-|
| Closed | ![localhost_8888_(Samsung Galaxy S20 Ultra) (22)](https://github.com/WordPress/wporg-developer/assets/1017872/dd55cf39-7119-45d9-b154-ae0cab9a8ef2) | ![localhost_8888_(Samsung Galaxy S20 Ultra) (20)](https://github.com/WordPress/wporg-developer/assets/1017872/4769ad7b-eb49-497e-abdf-381043180f8d) |
| Open | ![localhost_8888_(Samsung Galaxy S20 Ultra) (23)](https://github.com/WordPress/wporg-developer/assets/1017872/da9c5436-6a13-4685-aa61-e1250721d0fc) | ![localhost_8888_(Samsung Galaxy S20 Ultra) (21)](https://github.com/WordPress/wporg-developer/assets/1017872/486f8127-9bd0-46a2-90cd-1ed0b3867ebf) |