### PR TITLE
Update chapter list

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/images/chevron-small.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/chevron-small.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M15.9899 10.8888L12.0018 14.3071L8.01367 10.8888L8.98986 9.74988L12.0018 12.3315L15.0137 9.74988L15.9899 10.8888Z" fill="#1E1E1E"/>
+</svg>

--- a/source/wp-content/themes/wporg-developer-2023/images/chevron.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/chevron.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M5.99512 13.4451L11.9996 7.98642L18.0041 13.4451L16.9951 14.555L11.9996 10.0136L7.00413 14.555L5.99512 13.4451Z" fill="#1E1E1E"/>
+<svg width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M.956 6.445 6.961.986l6.004 5.459-1.009 1.11-4.995-4.541-4.996 4.54L.956 6.446Z" fill="#000"/>
 </svg>

--- a/source/wp-content/themes/wporg-developer-2023/images/chevron.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/chevron.svg
@@ -1,3 +1,3 @@
-<svg width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M.956 6.445 6.961.986l6.004 5.459-1.009 1.11-4.995-4.541-4.996 4.54L.956 6.446Z" fill="#000"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5.99512 13.4451L11.9996 7.98642L18.0041 13.4451L16.9951 14.555L11.9996 10.0136L7.00413 14.555L5.99512 13.4451Z" fill="#1E1E1E"/>
 </svg>

--- a/source/wp-content/themes/wporg-developer-2023/images/dot.svg
+++ b/source/wp-content/themes/wporg-developer-2023/images/dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4" viewBox="0 0 4 4" fill="none">
+  <circle cx="2" cy="2" r="1.5" fill="#656A71"/>
+</svg>

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
@@ -58,8 +58,8 @@ function render( $attributes, $content, $block ) {
 	$content = wp_list_pages( $args );
 
 	$title = do_blocks(
-		'<!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|20"}}},"fontFamily":"inter"} -->
-			<h2 class="wp-block-heading has-inter-font-family" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--20)">' . __( 'Chapters', 'wporg' ) . '</h2>
+		'<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small","fontFamily":"inter"} -->
+		<h2 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:400">' . __( 'Chapters', 'wporg' ) . '</h2>
 		<!-- /wp:heading -->'
 	);
 

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -50,7 +50,7 @@
 
 	&.has-js-control ul ul {
 		display: none;
-		padding-left: 18px;
+		padding-left: 14px;
 
 		.page_item_has_children {
 			padding-left: 0;
@@ -71,8 +71,6 @@
 	}
 
 	.wporg-chapter-list--button-group > button {
-		// Add space between button & link.
-		margin-inline-end: 0.25em;
 		font-size: inherit;
 		background-color: transparent;
 		border: none;

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -1,6 +1,6 @@
 .wp-block-wporg-chapter-list {
 	--local--line-height: var(--wp--custom--body--small--typography--line-height);
-	--local--button-size: calc(var(--local--line-height) * 1em);
+	--local--icon-size: calc(var(--local--line-height) * 1em);
 	line-height: var(--local--line-height);
 
 	ul {
@@ -10,13 +10,25 @@
 	}
 
 	ul ul {
-		padding-left: var(--wp--preset--spacing--30);
-		list-style-type: disc;
-	}
+		padding-left: 0;
 
-	// Remove list item style from items with children, as they have the caret.
-	.page_item_has_children {
-		display: block;
+		li {
+			padding-left: var(--local--icon-size);
+			position: relative;
+
+			&::before {
+				content: "";
+				display: inline-block;
+				position: absolute;
+				left: 0;
+				width: var(--local--icon-size);
+				height: var(--local--icon-size);
+				mask-image: url(../../images/dot.svg);
+				mask-repeat: no-repeat;
+				mask-position: center;
+				background-color: var(--wp--preset--color--charcoal-4);
+			}
+		}
 	}
 
 	li {
@@ -38,6 +50,15 @@
 
 	&.has-js-control ul ul {
 		display: none;
+		padding-left: 18px;
+
+		.page_item_has_children {
+			padding-left: 0;
+
+			&::before {
+				display: none;
+			}
+		}
 
 		&.is-open {
 			display: revert;
@@ -49,21 +70,10 @@
 		align-items: flex-start;
 	}
 
-	&:not(.has-js-control) li::before,
-	&.has-js-control li:not(.page_item_has_children)::before,
 	.wporg-chapter-list--button-group > button {
 		// Add space between button & link.
 		margin-inline-end: 0.25em;
 		font-size: inherit;
-		height: var(--local--button-size);
-		width: var(--local--button-size);
-	}
-
-	&:not(.has-js-control) li::before {
-		height: 0.8em;
-	}
-
-	.wporg-chapter-list--button-group > button {
 		background-color: transparent;
 		border: none;
 		padding: 0;
@@ -72,12 +82,12 @@
 		&::before {
 			content: "";
 			display: inline-block;
-			height: var(--local--button-size);
-			width: var(--local--button-size);
-			mask-image: url(../../images/chevron.svg);
+			height: var(--local--icon-size);
+			width: var(--local--icon-size);
+			mask-image: url(../../images/chevron-small.svg);
 			mask-repeat: no-repeat;
 			mask-position: center;
-			transform: rotate(180deg);
+			transform: rotate(-90deg);
 			background-color: var(--wp--preset--color--charcoal-4);
 		}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -10,13 +10,18 @@
 	}
 
 	ul ul {
-		margin-left: calc(var(--local--button-size) / 2);
-		padding-left: calc(var(--wp--preset--spacing--20) / 4);
-		border-left: 1px solid var(--wp--preset--color--light-grey-1);
+		padding-left: var(--wp--preset--spacing--30);
+		list-style-type: disc;
+	}
+
+	// Remove list item style from items with children, as they have the caret.
+	.page_item_has_children {
+		display: block;
 	}
 
 	li {
 		margin-block: calc(var(--wp--preset--spacing--20) / 4);
+		color: var(--wp--preset--color--charcoal-4);
 	}
 
 	> ul {
@@ -27,6 +32,10 @@
 		}
 	}
 
+	a {
+		text-decoration: none;
+	}
+
 	&.has-js-control ul ul {
 		display: none;
 
@@ -35,8 +44,6 @@
 		}
 	}
 
-	// Style the dash & chevron, most of the styles can be shared.
-	&.has-js-control li:not(.page_item_has_children),
 	.wporg-chapter-list--button-group {
 		display: flex;
 		align-items: flex-start;
@@ -56,17 +63,6 @@
 		height: 0.8em;
 	}
 
-	&:not(.has-js-control) li::before,
-	&.has-js-control li:not(.page_item_has_children)::before,
-	.wporg-chapter-list--button-group > button::before {
-		content: "";
-		display: inline-block;
-		mask-image: url(../../images/line.svg);
-		mask-repeat: no-repeat;
-		mask-position: center;
-		background-color: var(--wp--preset--color--light-grey-1);
-	}
-
 	.wporg-chapter-list--button-group > button {
 		background-color: transparent;
 		border: none;
@@ -74,12 +70,15 @@
 		cursor: pointer;
 
 		&::before {
+			content: "";
+			display: inline-block;
 			height: var(--local--button-size);
 			width: var(--local--button-size);
 			mask-image: url(../../images/chevron.svg);
-			mask-size: 0.8em 0.4em;
+			mask-repeat: no-repeat;
+			mask-position: center;
 			transform: rotate(180deg);
-			background-color: var(--wp--preset--color--blueberry-1);
+			background-color: var(--wp--preset--color--charcoal-4);
 		}
 
 		&[aria-expanded="true"]::before {
@@ -92,10 +91,18 @@
 	}
 
 	// Descendent is `span` if there are children, or `a` if not.
-	.current_page_ancestor > span,
-	.current_page_ancestor > a,
-	.current_page_item > span,
+	.current_page_item,
+	.current_page_item > span a,
 	.current_page_item > a {
-		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-1);
+	}
+
+	.current_page_item > span a,
+	.current_page_item > a {
+		font-weight: 700;
+	}
+
+	.current_page_item > span button::before {
+		background-color: var(--wp--preset--color--charcoal-1);
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -51,30 +51,34 @@ body[class] {
 	}
 }
 
-@media (min-width: 1320px) {
-	.has-three-columns {
+
+.has-three-columns {
+	--local--sidebar--width: 232px;
+	--local--column-gap: 40px;
+
+	@media (min-width: 768px) {
 		--wp--style--global--wide-size: 1760px;
 
-		--local--block-start-sidebar--width: 300px;
-
 		display: grid;
-		grid-template-columns: var(--local--block-start-sidebar--width) 1fr;
+		grid-template-columns: var(--local--sidebar--width) 1fr;
 		grid-template-rows: auto auto;
-		column-gap: 40px;
+		column-gap: var(--local--column-gap);
 
 		.wp-block-wporg-sidebar-container {
-			--local--block-end-sidebar--width: 300px;
-		}
-
-		article {
-			--wp--style--global--content-size: 1080px;
-
-			width: clamp(30rem, -52.5rem + 100vw, 67.5rem);
+			--local--block-end-sidebar--width: var(--local--sidebar--width);
 		}
 
 		.has-three-columns__pagination {
 			grid-row-start: 2;
 			grid-column-start: 2;
+		}
+	}
+
+	@media (min-width: 1200px) {
+		article {
+			// Width must be caluclated to fit absolute positioned ToC.
+			// Scales between 496px at 1200px wide and 1216px at 1920px wide, based on sidebar and gap dimensions above.
+			width: clamp(31rem, -44rem + 100vw, 76rem);
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -60,7 +60,8 @@ body[class] {
 		--wp--style--global--wide-size: 1760px;
 
 		display: grid;
-		grid-template-columns: var(--local--sidebar--width) 1fr;
+		/* stylelint-disable-next-line max-line-length */
+		grid-template-columns: var(--local--sidebar--width) calc(100% - var(--local--sidebar--width) - var(--local--column-gap));
 		grid-template-rows: auto auto;
 		column-gap: var(--local--column-gap);
 
@@ -76,7 +77,7 @@ body[class] {
 
 	@media (min-width: 1200px) {
 		article {
-			// Width must be caluclated to fit absolute positioned ToC.
+			// Width must be calculated to fit absolute positioned ToC.
 			// Scales between 496px at 1200px wide and 1216px at 1920px wide, based on sidebar and gap dimensions above.
 			width: clamp(31rem, -44rem + 100vw, 76rem);
 		}

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
@@ -5,7 +5,7 @@
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
 
-	<!-- wp:group {"className":"has-three-columns","layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
 	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--40)">
 
 		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"80px"}}}} /-->
@@ -16,7 +16,7 @@
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
-			<!-- wp:post-content {"layout":{"inherit":true}} /-->
+			<!-- wp:post-content /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta-github"} /-->
 		</article>

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -5,7 +5,7 @@
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
 
-	<!-- wp:group {"className":"has-three-columns","layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
 	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--40)">
 
 		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"80px"}}}} /-->
@@ -16,7 +16,7 @@
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
-			<!-- wp:post-content {"layout":{"inherit":true}} /-->
+			<!-- wp:post-content /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
 		</article>

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -202,7 +202,7 @@
 					},
 					"link": {
 						"color": {
-							"text": "var(--wp--preset--color--blueberry-1)"
+							"text": "var(--wp--preset--color--charcoal-4)"
 						}
 					}
 				}


### PR DESCRIPTION
Closes #265, #310, #313

Updates styling of chapter list:
- Font weights, colors, list item styles

Note: Does not include #306 

Note also that the root handbook page is always shown in the current prod chapter list, so 'Best Practices' being shown on the WPCS page in the screenshots below is consistent with the other handbooks.

### Screenshots

#### Coding standards
![localhost_8888_coding-standards_wordpress-coding-standards_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/bcc9ba02-9830-4be8-bb68-7724767c2852)

#### Block Editor

![localhost_8888_block-editor_reference-guides_theme-json-reference_theme-json-living_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/fa98cd0a-79df-4d1a-b507-58fcc5166e8f)

#### Advanced admin

![localhost_8888_advanced-administration_security_backup_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/78d67509-91b8-4d4d-a5fc-837be3bb5370)
