### PR TITLE
Replace `jetpack_require_lib` with a direct file include

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/cli.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/cli.php
@@ -207,12 +207,14 @@ class DevHub_CLI {
 		if ( is_wp_error( $markdown_source ) ) {
 			return $markdown_source;
 		}
-		
-		if ( ! class_exists( 'WPCom_GHF_Markdown_Parser' ) && defined( 'JETPACK__PLUGIN_DIR' ) ) {
-			include JETPACK__PLUGIN_DIR . '/_inc/lib/markdown.php';
-		}
+
+		// Load Jetpack Markdown if it's not already loaded, for transforming markdown to HTML.
 		if ( ! class_exists( 'WPCom_GHF_Markdown_Parser' ) ) {
-			return new WP_Error( 'missing-jetpack-markdown', 'Jetpack Markdown is missing on system.' );
+			if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {
+				require_once JETPACK__PLUGIN_DIR . '/_inc/lib/markdown.php';
+			} else {
+				return new WP_Error( 'missing-jetpack-markdown', 'Jetpack Markdown is missing on system.' );
+			}
 		}
 
 		// Transform GitHub repo HTML pages into their raw equivalents
@@ -244,7 +246,6 @@ class DevHub_CLI {
 		}
 
 		// Transform to HTML and save the post
-		require_once JETPACK__PLUGIN_DIR . '_inc/lib/markdown.php';
 		$parser = new \WPCom_GHF_Markdown_Parser;
 		$html = $parser->transform( $markdown );
 		$post_data = array(

--- a/source/wp-content/themes/wporg-developer-2023/inc/cli.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/cli.php
@@ -207,8 +207,12 @@ class DevHub_CLI {
 		if ( is_wp_error( $markdown_source ) ) {
 			return $markdown_source;
 		}
-		if ( ! function_exists( 'jetpack_require_lib' ) ) {
-			return new WP_Error( 'missing-jetpack-require-lib', 'jetpack_require_lib() is missing on system.' );
+		
+		if ( ! class_exists( 'WPCom_GHF_Markdown_Parser' ) && defined( 'JETPACK__PLUGIN_DIR' ) ) {
+			include JETPACK__PLUGIN_DIR . '/_inc/lib/markdown.php';
+		}
+		if ( ! class_exists( 'WPCom_GHF_Markdown_Parser' ) ) {
+			return new WP_Error( 'missing-jetpack-markdown', 'Jetpack Markdown is missing on system.' );
 		}
 
 		// Transform GitHub repo HTML pages into their raw equivalents
@@ -240,7 +244,7 @@ class DevHub_CLI {
 		}
 
 		// Transform to HTML and save the post
-		jetpack_require_lib( 'markdown' );
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/markdown.php';
 		$parser = new \WPCom_GHF_Markdown_Parser;
 		$html = $parser->transform( $markdown );
 		$post_data = array(


### PR DESCRIPTION
I noticed locally that the docs weren't being imported properly, and I was seeing warnings about `jetpack_require_lib() is missing on system.`, however looking at the source this is actually an error, and [`jetpack_require_lib` has been deprecated and removed](https://github.com/Automattic/jetpack/pull/28866).

This PR implements the [suggested replacement](https://github.com/Automattic/jetpack/pull/28866#issuecomment-1548467922) following what has been done in [`wporg-markdown`](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/plugins/wporg-markdown/inc/class-importer.php#L423).

Also similar to https://github.com/WordPress/wordcamp.org/commit/ca0b71b4a53b1ac44dca4c49c8fa9f5d0cfb63cf

### Testing

Run `yarn setup:wp` and check for warnings about `jetpack_require_lib`
Ensure the CLI import completes successfully with something like:
```
Success: Successfully updated 414 of 418 CLI command pages.
Executed the cron event 'devhub_cli_markdown_import' in 180.088s.
```