### PR TITLE
Update header behaviour

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/parts/header-no-breadcrumbs.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/header-no-breadcrumbs.html
@@ -1,9 +1,3 @@
-<!-- wp:wporg/global-header /-->
+<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-charcoal-2-background-color has-background">
-
-	<!-- wp:template-part {"slug":"local-nav","className":"has-display-contents"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:template-part {"slug":"local-nav","className":"has-display-contents"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/parts/header.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/header.html
@@ -1,17 +1,11 @@
-<!-- wp:wporg/global-header /-->
+<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-charcoal-2-background-color has-background">
+<!-- wp:template-part {"slug":"local-nav","className":"has-display-contents"} /-->
 
-	<!-- wp:template-part {"slug":"local-nav","className":"has-display-contents"} /-->
-
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
-		
-		<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
-
-	</div>
-	<!-- /wp:group -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+	
+	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
 
 </div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
@@ -1,4 +1,4 @@
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
@@ -1,4 +1,4 @@
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
@@ -8,34 +8,48 @@
 ?>
 
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
-<!-- wp:html -->
-<div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>
-<!-- /wp:html -->
 
-<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
+	<!-- wp:html -->
+	<div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>
+	<!-- /wp:html -->
+
+	<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
+
 <!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"charcoal-2","className":"has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"bottom"}} -->
-<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"50px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"eb-garamond"} -->
-<h1 class="wp-block-heading has-eb-garamond-font-family" style="font-size:50px;font-style:normal;font-weight:400"><?php esc_html_e( 'Developer Resources', 'wporg' ); ?></h1>
-<!-- /wp:heading -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"2.3"}},"textColor":"white"} -->
-<p class="has-white-color has-text-color" style="line-height:2.3"><?php esc_html_e( '/The freedom to build', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"bottom"}} -->
+	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+	
+		<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"50px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"eb-garamond"} -->
+		<h1 class="wp-block-heading has-eb-garamond-font-family" style="font-size:50px;font-style:normal;font-weight:400"><?php esc_html_e( 'Developer Resources', 'wporg' ); ?></h1>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"2.3"}},"textColor":"white"} -->
+		<p class="has-white-color has-text-color" style="line-height:2.3"><?php esc_html_e( '/The freedom to build', 'wporg' ); ?></p>
+		<!-- /wp:paragraph -->
+	
+	</div>
+	<!-- /wp:group -->
+
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}},"backgroundColor":"lemon-3","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-lemon-3-background-color has-background" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"><!-- wp:paragraph {"align":"center","fontSize":"extra-small"} -->
-<p class="has-text-align-center has-extra-small-font-size"><?php echo wp_kses_post(
-	sprintf(
-	/* translators: %1$s: version link, %2$s: version number */
-		__( 'See <a href="%1$s">what has changed</a> in the WordPress %2$s API.', 'wporg' ),
-		'[wordpress_version_link]',
-		'[wordpress_version]'
-	)
-); ?></p>
-<!-- /wp:paragraph --></div>
+<div class="wp-block-group alignfull has-lemon-3-background-color has-background" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)">
+
+	<!-- wp:paragraph {"align":"center","fontSize":"extra-small"} -->
+	<p class="has-text-align-center has-extra-small-font-size"><?php echo wp_kses_post(
+		sprintf(
+		/* translators: %1$s: version link, %2$s: version number */
+			__( 'See <a href="%1$s">what has changed</a> in the WordPress %2$s API.', 'wporg' ),
+			'[wordpress_version_link]',
+			'[wordpress_version]'
+		)
+	); ?></p>
+	<!-- /wp:paragraph -->
+
+</div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
@@ -7,7 +7,7 @@
 
 ?>
 
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 
 	<!-- wp:html -->
 	<div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
@@ -7,15 +7,13 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-charcoal-2-background-color has-background"><!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 <!-- wp:html -->
 <div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>
 <!-- /wp:html -->
 
 <!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
-<!-- /wp:wporg/local-navigation-bar --></div>
-<!-- /wp:group -->
+<!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"charcoal-2","className":"has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"bottom"}} -->

--- a/source/wp-content/themes/wporg-developer-2023/templates/front-page.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/front-page.html
@@ -1,4 +1,4 @@
-<!-- wp:wporg/global-header /-->
+<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
 <!-- wp:pattern {"slug":"wporg-developer-2023/front-page-header"} /-->
 


### PR DESCRIPTION
Fixes #298 
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/466

Very similar to [changes required for Documentation](https://github.com/WordPress/wporg-documentation-2022/pull/71) after the global header becomes non-sticky:

> Other changes I made:
> 
> * Removing the padding on `local-navigation-bar`, this is set correctly by default now
> * Move the border from `local-navigation-bar` to the global header, this looks better when the page scrolls
> * Since the `local-navigation-bar` was moved out of the group, I moved the `style` attribute to `local-navigation-bar` directly

With these changes **only the local nav is sticky** (global header, breadcrumbs and search are not).

### Screenshots

| Page | Top | Scrolled |
|-|-|-|
| Home | ![localhost_8888_(Desktop) (10)](https://github.com/WordPress/wporg-developer/assets/1017872/b24a63f0-1d38-453a-b3e0-6530ba15dd6e) | ![localhost_8888_(Desktop) (11)](https://github.com/WordPress/wporg-developer/assets/1017872/d34f9c91-f92b-4c52-b89a-2ed53509d5a4) |
| With breadcrumbs | ![localhost_8888_coding-standards_wordpress-coding-standards_css_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/8caf9b37-d86b-4dd1-b9d3-591f6d8b9900) | ![localhost_8888_coding-standards_wordpress-coding-standards_css_(Desktop) (1)](https://github.com/WordPress/wporg-developer/assets/1017872/521dd81c-0f59-4420-9eca-c9e0f07a39c2) |
| Without breadcrumbs | ![localhost_8888_cli_commands_(Desktop) (4)](https://github.com/WordPress/wporg-developer/assets/1017872/536baca4-f960-4961-9fa1-acd07ef31394) | ![localhost_8888_cli_commands_(Desktop) (5)](https://github.com/WordPress/wporg-developer/assets/1017872/efbb3432-13b3-4ba1-a49f-13a4f68bec96) |

### Testing 

1. Ensure your mu-plugins is on https://github.com/WordPress/wporg-mu-plugins/pull/466
2. Navigate to the pages in the screenshots above at desktop size, and check the header behaviour.
3. Resize for tablet and mobile; no headers should be sticky below 890px (tablet landscape will still have sticky local nav).