### PR TITLE
Fix copy & expand button padding.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/function-reference.js
@@ -35,7 +35,7 @@ jQuery( function ( $ ) {
 		$element.wrap( '<div class="wporg-developer-code-block"></div>' );
 
 		const $copyButtonContainer = $( '<div class="wp-block-button is-style-outline is-small"></div>' );
-		const $copyButton = $( '<a href="#" class="wp-block-button__link wp-element-button"></a>' );
+		const $copyButton = $( '<a href="#" class="wp-block-button__link wp-element-button has-background"></a>' );
 		$copyButtonContainer.append( $copyButton );
 
 		$copyButton.text( wporgFunctionReferenceI18n.copy );
@@ -76,7 +76,7 @@ jQuery( function ( $ ) {
 
 			const $expandButtonContainer = $( '<div class="wp-block-button is-style-outline is-small"></div>' );
 			const $expandButton = $(
-				'<a href="#" class="wp-block-button__link wp-element-button" aria-controls="wporg-source-code"></a>'
+				'<a href="#" class="wp-block-button__link wp-element-button has-background" aria-controls="wporg-source-code"></a>'
 			);
 			$expandButton.on( 'click', function ( event ) {
 				event.preventDefault();

--- a/source/wp-content/themes/wporg-developer-2023/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/function-reference.js
@@ -34,7 +34,7 @@ jQuery( function ( $ ) {
 
 		$element.wrap( '<div class="wporg-developer-code-block"></div>' );
 
-		const $copyButtonContainer = $( '<div class="wp-block-button is-style-outline"></div>' );
+		const $copyButtonContainer = $( '<div class="wp-block-button is-style-outline is-small"></div>' );
 		const $copyButton = $( '<a href="#" class="wp-block-button__link wp-element-button"></a>' );
 		$copyButtonContainer.append( $copyButton );
 
@@ -74,7 +74,7 @@ jQuery( function ( $ ) {
 		if ( originalHeight > MIN_HEIGHT ) {
 			$element.data( 'height', originalHeight );
 
-			const $expandButtonContainer = $( '<div class="wp-block-button is-style-outline"></div>' );
+			const $expandButtonContainer = $( '<div class="wp-block-button is-style-outline is-small"></div>' );
 			const $expandButton = $(
 				'<a href="#" class="wp-block-button__link wp-element-button" aria-controls="wporg-source-code"></a>'
 			);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/style.scss
@@ -13,17 +13,7 @@ $border_radius: 2px;
 		gap: var(--wp--preset--spacing--10);
 
 		.wp-block-button a {
-			padding: var(--wp--preset--spacing--10);
-			background-color: var(--wp--preset--color--white) !important;
-			border-color: var(--wp--preset--color--blueberry-1) !important;
-			color: var(--wp--preset--color--blueberry-1) !important;
-			font-weight: 400;
-			font-size: 13px;
-
-			&:focus {
-				border-width: unset;
-				padding: var(--wp--preset--spacing--10);
-			}
+			background-color: var(--wp--preset--color--white);
 		}
 
 		> span:last-child {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/style.scss
@@ -19,6 +19,11 @@ $border_radius: 2px;
 			color: var(--wp--preset--color--blueberry-1) !important;
 			font-weight: 400;
 			font-size: 13px;
+
+			&:focus {
+				border-width: unset;
+				padding: var(--wp--preset--spacing--10);
+			}
 		}
 
 		> span:last-child {


### PR DESCRIPTION
Fixes #326. 

This uses classes introduced in https://github.com/WordPress/wporg-parent-2021/pull/112 to fix the buttons growing too much on `:focus`.



**Default**
<img width="235" alt="Screenshot 2023-11-06 at 2 20 58 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/123095f2-3fd6-4443-b4af-a42084639325">


**Focal States**
After the user clicks, the button text updates.
| First | Second |
|--------|--------|
| <img width="231" alt="Screenshot 2023-11-06 at 2 17 15 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/1a47e574-449f-4899-be17-3802ff74736d"> | <img width="230" alt="Screenshot 2023-11-06 at 2 17 18 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/56eee6a8-32dc-4010-a2da-5690ed95ac3c"> |
|  <img width="212" alt="Screenshot 2023-11-06 at 2 17 06 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/a5137f4f-7333-4037-bac5-462466fb0f48"> | <img width="273" alt="Screenshot 2023-11-06 at 2 17 10 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/5611000c-b783-40ae-a724-bd14577b6f01"> |






