### PR TITLE
Add breadcrumbs to cli/commands.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -228,7 +228,6 @@ function init() {
 
 	// Modify default breadcrumbs.
 	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_items_for_hooks', 10, 2 );
-	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_items_remove_reference', 11, 2 );
 	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_items_for_handbook_root', 10, 2 );
 	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_for_note_edit', 10, 2 );
 	add_filter( 'breadcrumb_trail_items', __NAMESPACE__ . '\\breadcrumb_trail_for_since_view', 10, 2 );
@@ -281,29 +280,6 @@ function breadcrumb_trail_items_for_hooks( $items, $args ) {
 	unset( $items[4] );
 
 	return $items;
-}
-
-/**
- * Remove the 'Reference' part of the breadcrumb trail.
- *
- * @param  array $items The breadcrumb trail items.
- * @param  array $args  Original args.
- * @return array
- */
-function breadcrumb_trail_items_remove_reference( $items, $args ) {
-	if ( ! is_parsed_post_type() ) {
-		return $items;
-	}
-
-	return array_filter(
-		$items,
-		function( $item ) {
-			// Remove the 'reference' parent based on the presence of its URL.
-			// We can't use the label because of internationalization.
-			$result = (bool) preg_match( '!href="[^"]+/reference/"!', $item );
-			return ( false === $result );
-		}
-	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/parts/header-no-breadcrumbs.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/header-no-breadcrumbs.html
@@ -1,3 +1,0 @@
-<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
-
-<!-- wp:template-part {"slug":"local-nav","className":"has-display-contents"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/parts/header.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/header.html
@@ -1,6 +1,13 @@
 <!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
-<!-- wp:template-part {"slug":"local-nav","className":"has-display-contents"} /-->
+<!-- wp:wporg/local-navigation-bar {"className":"has-display-contents","backgroundColor":"charcoal-2","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
+
+	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
+
+	<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
+		
+<!-- /wp:wporg/local-navigation-bar -->
+
 
 <!-- wp:group {"className":"wporg-breadcrumbs","align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wporg-breadcrumbs wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">

--- a/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/local-nav.html
@@ -1,7 +1,0 @@
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
-
-	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
-
-	<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"developer"} /-->
-		
-<!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -403,10 +403,6 @@ body[class] {
 	}
 }
 
-.post-type-archive-command .wp-block-wporg-sidebar-container {
-	--wp--custom--wporg-sidebar-container--spacing--margin--top: 110px;
-}
-
 .single-command {
 	h3 {
 		margin-bottom: var(--wp--preset--spacing--20);

--- a/source/wp-content/themes/wporg-developer-2023/templates/archive-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/archive-command.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/taxonomy-wp-parser-since.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/taxonomy-wp-parser-since.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 


### PR DESCRIPTION
This PR adds the breadcrumbs to `cli/commands`. 

I realized after logging an issue that the [designs](https://www.figma.com/file/2WxlJFzMJvqPfZL1EkAOVp/Developer-Resources?type=design&node-id=3745-10313&mode=design) don't have the breadcrumb. However, I don't understand why this page would not have it when the block-editor handbook _landing page_ and other landing pages have it. 
It's also linked in deeper nested pages as the parent and last [production](https://developer.wordpress.org/cli/commands/) currently has the breadcrumb there.

## Screenshot
![localhost_8888_cli_commands_ (1)](https://github.com/WordPress/wporg-developer/assets/1657336/2ab7ccef-80b8-4e70-a911-342db6a1bfdb)

## Nested Page
![localhost_8888_cli_commands_admin_](https://github.com/WordPress/wporg-developer/assets/1657336/4aa3eab4-74d4-4449-8b0a-bdf1b8333716)
