### PR TITLE
Add the ability to pass an id to the `code-table`.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-related/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-related/block.php
@@ -117,7 +117,7 @@ function get_uses_table( $uses ) {
 	$headings     = array( __( 'Uses', 'wporg' ), __( 'Description', 'wporg' ) );
 
 	return sprintf(
-		'<!-- wp:wporg/code-table {"itemsToShow":%s,"headings":%s,"rows":%s,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
+		'<!-- wp:wporg/code-table {"id":"uses","itemsToShow":%s,"headings":%s,"rows":%s,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
 		esc_attr( $uses_to_show ),
 		wp_json_encode( $headings ),
 		wp_json_encode( get_row_data( $uses ) )
@@ -130,7 +130,7 @@ function get_uses_table( $uses ) {
 function get_used_by_table( $used_by ) {
 	$headings = array( __( 'Used by', 'wporg' ), __( 'Description', 'wporg' ) );
 	return sprintf(
-		'<!-- wp:wporg/code-table {"itemsToShow":5,"headings":%s,"rows":%s,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
+		'<!-- wp:wporg/code-table {"id":"used-by","itemsToShow":5,"headings":%s,"rows":%s,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
 		wp_json_encode( $headings ),
 		wp_json_encode( get_row_data( $used_by ) )
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-table/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-table/block.json
@@ -16,6 +16,9 @@
 			"type": "array",
 			"default": []
 		},
+		"id": {
+			"type": "string"
+		},
 		"rows": {
 			"type": "array",
 			"default": []

--- a/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
@@ -26,13 +26,7 @@ function init() {
  */
 function render( $attributes ) {
 	$table  = '<!-- wp:table {"className":"' . $attributes['className'] . '"} --><figure class="wp-block-table ' . $attributes['className'] . '">';
-
-	if ( isset( $attributes['id'] ) ) {
-		$table .= '<table id="' . esc_html( $attributes['id'] ) . '">';
-	} else {
-		$table .= '<table>';
-	}
-
+	$table .= '<table>';
 	$table .= '<thead>';
 	$table .= '<tr>';
 	foreach ( $attributes['headings'] as $heading ) {
@@ -55,6 +49,10 @@ function render( $attributes ) {
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();
+	if ( isset( $attributes['id'] ) ) {
+		$wrapper_attributes .= ' id="' . esc_attr( $attributes['id'] ) . '"';
+	}
+
 	return sprintf(
 		'<section %1$s>%2$s</section>',
 		$wrapper_attributes,

--- a/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
@@ -26,7 +26,13 @@ function init() {
  */
 function render( $attributes ) {
 	$table  = '<!-- wp:table {"className":"' . $attributes['className'] . '"} --><figure class="wp-block-table ' . $attributes['className'] . '">';
-	$table .= '<table>';
+
+	if ( isset( $attributes['id'] ) ) {
+		$table .= '<table id="' . esc_html( $attributes['id'] ) . '">';
+	} else {
+		$table .= '<table>';
+	}
+
 	$table .= '<thead>';
 	$table .= '<tr>';
 	foreach ( $attributes['headings'] as $heading ) {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-table/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-table/style.scss
@@ -1,4 +1,9 @@
 .wp-block-wporg-code-table {
+	&#uses,
+	&#used-by {
+		scroll-margin-top: var(--wp-local-header-offset, 0);
+	}
+
 	.wp-block-table {
 		thead {
 			border-bottom: none;


### PR DESCRIPTION
Fixes #324.

This PR adds the ability to pass an id for the table which can be used for `#{id}` links which is used by the "Uses" and "Used by" tables.
