### PR TITLE
Remove title edit links from handbooks

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -198,9 +198,14 @@ add_filter( 'wporg_table_of_contents_post_content', __NAMESPACE__ . '\filter_cod
 add_filter( 'the_content', __NAMESPACE__ . '\filter_command_content', 4 );
 add_filter( 'wporg_table_of_contents_post_content', __NAMESPACE__ . '\filter_command_content' );
 
-
 // Remove table of contents.
 add_filter( 'wporg_handbook_toc_should_add_toc', '__return_false' );
+
+// Remove GitHub edit links from handbooks
+global $devhub_handbook_editors;
+foreach ($devhub_handbook_editors as $editor) {
+	remove_filter( 'the_title', array( $editor, 'filter_the_title_edit_link' ), 10);
+}
 
 /**
  * Set up the theme.

--- a/source/wp-content/themes/wporg-developer-2023/inc/import-docs.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-docs.php
@@ -102,6 +102,7 @@ class DevHub_Docs_Importer extends Importer {
 		add_action( "devhub_{$this->post_type}_import_all_markdown", array( $this, 'import_all_markdown' ) );
 
 		$editor = new Editor( $this );
+		$GLOBALS[ "devhub_handbook_editors" ][ $this->post_type ] = $editor;
 		$editor->init();
 	}
 


### PR DESCRIPTION
Removes the GitHub edit links from the titles on handbook pages. Achieved by making the `WordPressdotorg\Markdown\Editor` instances available globally so that the filter can be removed.

### Screenshots

| Before | After |
|-|-|
| ![developer wordpress org_redesign-test_block-editor_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/a8d86bb4-40ad-4a91-b416-fecbcaf20657) | ![developer wordpress org_redesign-test_block-editor_(Desktop) (1)](https://github.com/WordPress/wporg-developer/assets/1017872/920fb2f4-2963-46dc-b552-7dd558138e58) |

### Testing

Easiest in a sandbox. The edit links don't show for me locally.

Open each of the GitHub handbooks and check that the edit links don't appear: [Best Practices](https://developer.wordpress.org/redesign-test/coding-standards/), [Block Editor Handbook](https://developer.wordpress.org/redesign-test/block-editor/), [Rest API](https://developer.wordpress.org/redesign-test/rest-api/), [Adv Admin](https://developer.wordpress.org/redesign-test/advanced-administration/)