### PR TITLE
Fix searchbox autocomplete missing

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/autocomplete.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/autocomplete.php
@@ -68,8 +68,9 @@ class DevHub_Search_Form_Autocomplete {
 			'autocomplete',
 			'autocomplete',
 			array(
-				'ajaxurl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'autocomplete_nonce' ),
+				'ajaxurl'   => admin_url( 'admin-ajax.php' ),
+				'nonce'     => wp_create_nonce( 'autocomplete_nonce' ),
+				'post_type' => get_post_type(),
 			)
 		);
 
@@ -91,7 +92,6 @@ class DevHub_Search_Form_Autocomplete {
 		$parser_post_types = DevHub\get_parsed_post_types();
 		$defaults          = array(
 			's'         => '',
-			'post_type' => $parser_post_types,
 			'posts'     => array(),
 		);
 
@@ -108,13 +108,9 @@ class DevHub_Search_Form_Autocomplete {
 			wp_send_json_error( $defaults );
 		}
 
-		foreach ( $form_data['post_type'] as $key => $post_type ) {
-			if ( ! in_array( $post_type, $parser_post_types ) ) {
-				unset( $form_data['post_type'][ $key ] );
-			}
-		}
-
-		$post_types = ! empty( $form_data['post_type'] ) ? $form_data['post_type'] : $parser_post_types;
+		$post_types = isset( $_POST['post_type'] ) && 'command' === $_POST['post_type'] ?
+			array( 'command' ) :
+			$parser_post_types;
 
 		$args = array(
 			'posts_per_page'       => -1,

--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1765,8 +1765,7 @@ namespace DevHub {
 		$post_types = get_parsed_post_types();
 		$taxonomies = array( 'wp-parser-since', 'wp-parser-package', 'wp-parser-source-file' );
 
-		return ! ( is_search() || is_404() ) &&
-			( is_singular( $post_types ) || is_post_type_archive( $post_types ) || is_tax( $taxonomies ) || is_page( 'reference' ) || is_front_page() );
+		return ! ( is_search() || is_404() ) && ( is_singular( $post_types ) || is_post_type_archive( $post_types ) || is_tax( $taxonomies ) || is_page( 'reference' ) );
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1765,7 +1765,8 @@ namespace DevHub {
 		$post_types = get_parsed_post_types();
 		$taxonomies = array( 'wp-parser-since', 'wp-parser-package', 'wp-parser-source-file' );
 
-		return ! ( is_search() || is_404() ) && ( is_singular( $post_types ) || is_post_type_archive( $post_types ) || is_tax( $taxonomies ) || is_page( 'reference' ) );
+		return ! ( is_search() || is_404() ) &&
+			( is_singular( $post_types ) || is_post_type_archive( $post_types ) || is_tax( $taxonomies ) || is_page( 'reference' ) || is_front_page() );
 	}
 
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/js/autocomplete.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/autocomplete.js
@@ -11,7 +11,7 @@
 		return;
 	}
 
-	var form = $( '.awesomeplete-form-wrap > form' );
+	var form = $( 'main form.wp-block-search' );
 	if ( ! form.length ) {
 		return;
 	}

--- a/source/wp-content/themes/wporg-developer-2023/js/autocomplete.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/autocomplete.js
@@ -96,6 +96,7 @@
 			action: "autocomplete",
 			data: form.serialize(),
 			nonce: autocomplete.nonce,
+			post_type: autocomplete.post_type
 		};
 
 		$.post( autocomplete.ajaxurl, data )

--- a/source/wp-content/themes/wporg-developer-2023/stylesheets/awesomplete.css
+++ b/source/wp-content/themes/wporg-developer-2023/stylesheets/awesomplete.css
@@ -8,6 +8,11 @@
 div.awesomplete {
 	display: inline-block;
 	position: relative;
+	flex: 1;
+}
+
+div.awesomplete > .wp-block-search__input {
+	width: 100%;
 }
 
 div.awesomplete > ul {


### PR DESCRIPTION
Fixes #321


| **Page** |
|-|
| Reference |
| <img width="1032" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/f664a345-2787-4443-b129-9db92daa579e"> |
| CLI-Commands |
| <img width="1412" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/b5d3ed29-223e-4b61-b2ec-2c3ce9f96646"> |
| Single Page |
| <img width="962" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/efdd9809-dda4-4247-adf4-76c68c8a3044"> |
| Search |
| <img width="780" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/1c84580f-ec9d-414c-8f15-bb345b5ca2e4"> |


| **Taxonomy** |
|-|
| **Since** |
| <img width="1673" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/56b08780-e570-437f-b487-3e2b2caa8522"> |

| **Remain no autocomplete on the handbook** |
|-|
| <img width="1028" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/dd4c336e-d442-4db8-b913-497bc3615285"> |

## TODO
**missing search bar** -> ✅ (See https://github.com/WordPress/wporg-developer/pull/359)
- [archive](http://localhost:8888/reference/functions/) 
- [tax: file](http://localhost:8888/reference/files/wp-activate.php/)
- [tax: package](http://localhost:8888/reference/package/atomlib/)

**missing breadcrumbs** -> summarized [here](https://github.com/WordPress/wporg-developer/pull/336#issuecomment-1804227066)
- http://localhost:8888/cli/commands/

**fix search bar style** -> Found ticket: https://github.com/WordPress/wporg-developer/pull/340
@adamwoodnz I guess the fix doesn't include the search bars outside handbooks? (margin -> see https://github.com/WordPress/wporg-developer/pull/359, quirky right padding -> img below, etc)
<img width="377" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/9e78bacd-faf2-44ae-b04c-866cb267642b">

