### PR TITLE
Collapse Chapter List by default on mobile

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
@@ -57,17 +57,22 @@ function render( $attributes, $content, $block ) {
 
 	$content = wp_list_pages( $args );
 
-	$title = do_blocks(
+	$header = '<div class="wporg-chapter-list__header">';
+	$header .= do_blocks(
 		'<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small","fontFamily":"inter"} -->
-		<h2 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:400">' . __( 'Chapters', 'wporg' ) . '</h2>
+		<h2 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:400">' . esc_html__( 'Chapters', 'wporg' ) . '</h2>
 		<!-- /wp:heading -->'
 	);
+	$header .= '<button type="button" class="wporg-chapter-list__toggle" aria-expanded="false">';
+	$header .= '<span class="screen-reader-text">' . esc_html__( 'Chapter list', 'wporg' ) . '</span>';
+	$header .= '</button>';
+	$header .= '</div>';
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
-		'<nav %1$s>%2$s<ul>%3$s</ul></nav>',
+		'<nav %1$s>%2$s<ul class="wporg-chapter-list__list">%3$s</ul></nav>',
 		$wrapper_attributes,
-		$title,
+		$header,
 		$content
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -3,6 +3,35 @@
 	--local--icon-size: calc(var(--local--line-height) * 1em);
 	line-height: var(--local--line-height);
 
+	@media (max-width: 767px) {
+		border: 1px solid var(--wp--preset--color--light-grey-1);
+		padding: 15px var(--wp--preset--spacing--20);
+
+		.wporg-chapter-list__list {
+			display: none;
+		}
+	}
+
+	@media (min-width: 768px) {
+		.wporg-chapter-list__toggle {
+			display: none;
+		}
+	}
+
+	.wporg-chapter-list__header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		.wp-block-heading {
+			margin-bottom: 0;
+		}
+	}
+
+	.wporg-chapter-list__list {
+		margin-top: var(--wp--preset--spacing--20);
+	}
+
 	ul {
 		margin-top: 0;
 		margin-bottom: 0;
@@ -58,12 +87,13 @@
 		}
 	}
 
-	.wporg-chapter-list--button-group {
+	.wporg-chapter-list__button-group {
 		display: flex;
 		align-items: flex-start;
 	}
 
-	.wporg-chapter-list--button-group > button {
+	.wporg-chapter-list__toggle,
+	.wporg-chapter-list__button-group > button {
 		font-size: inherit;
 		background-color: transparent;
 		border: none;
@@ -89,6 +119,12 @@
 
 		&:focus-visible {
 			outline: 1px dashed var(--wp--preset--color--blueberry-1);
+		}
+	}
+
+	.wporg-chapter-list__toggle {
+		&[aria-expanded="true"]::before {
+			background-color: var(--wp--preset--color--charcoal-1);
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/view.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/view.js
@@ -4,9 +4,24 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 const init = () => {
-	const container = document.querySelector( '.wp-block-wporg-chapter-list > ul' );
+	const container = document.querySelector( '.wp-block-wporg-chapter-list' );
+	const toggleButton = container?.querySelector( '.wporg-chapter-list__toggle' );
+	const list = container?.querySelector( '.wporg-chapter-list__list' );
+
+	if ( toggleButton && list ) {
+		toggleButton.addEventListener( 'click', function () {
+			if ( toggleButton.getAttribute( 'aria-expanded' ) === 'true' ) {
+				toggleButton.setAttribute( 'aria-expanded', false );
+				list.removeAttribute( 'style' );
+			} else {
+				toggleButton.setAttribute( 'aria-expanded', true );
+				list.setAttribute( 'style', 'display:block;' );
+			}
+		} );
+	}
+
 	if ( container ) {
-		container.parentNode.classList.toggle( 'has-js-control' );
+		container.classList.toggle( 'has-js-control' );
 
 		const parents = container.querySelectorAll( '.page_item_has_children' );
 		parents.forEach( ( item ) => {
@@ -43,7 +58,7 @@ const init = () => {
 			};
 
 			const buttonGroup = document.createElement( 'span' );
-			buttonGroup.className = 'wporg-chapter-list--button-group';
+			buttonGroup.className = 'wporg-chapter-list__button-group';
 			buttonGroup.append( button, link );
 
 			item.insertBefore( buttonGroup, submenu );

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
@@ -5,14 +5,14 @@
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
 
-	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
-	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--40)">
+	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"40px"},"blockGap":"var:preset|spacing|50"}}}}} -->
+	<div class="wp-block-group alignwide has-three-columns" style="margin-top:40px">
 
-		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
 
 		<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 		<article class="wp-block-group" style="margin-top:0px">
-			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
@@ -8,7 +8,7 @@
 	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
 	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--40)">
 
-		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"80px"}}}} /-->
+		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
 
 		<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 		<article class="wp-block-group" style="margin-top:0px">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -5,14 +5,14 @@
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
 
-	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
-	<div class="wp-block-group alignwide has-three-columns" style="margin-top:var(--wp--preset--spacing--40)">
+	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"40px"},"blockGap":"var:preset|spacing|50"}}}}} -->
+	<div class="wp-block-group alignwide has-three-columns" style="margin-top:40px">
 
-		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"80px"}}}} /-->
+		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
 
 		<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 		<article class="wp-block-group" style="margin-top:0px">
-			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 


### PR DESCRIPTION
Closes #316 

Makes the Chapter List collapsable on mobile only, and collapsed by default on page load.

The markup and JS largely follows the tech design of the [ToC component](https://github.com/WordPress/wporg-mu-plugins/tree/trunk/mu-plugins/blocks/table-of-contents), which will be updated to match this style in https://github.com/WordPress/wporg-mu-plugins/issues/491

Styling matches the new [design](https://www.figma.com/file/2WxlJFzMJvqPfZL1EkAOVp/Developer-Resources?node-id=3745%3A10313&mode=dev).

Further updates to the surrounding layout will be made in #343.

### Screenshots

| Mobile expanded | Mobile collapsed |
|-|-|
| ![localhost_8888_coding-standards_inline-documentation-standards_javascript_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-developer/assets/1017872/5304c7d5-a818-42f7-9b65-c6b60396e346) | ![localhost_8888_coding-standards_inline-documentation-standards_javascript_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-developer/assets/1017872/91d983a9-be6e-4ba7-9c10-da59dc990fdf) |

| Desktop | Tablet landscape| Tablet portrait |
|-|-|-|
| ![localhost_8888_coding-standards_inline-documentation-standards_javascript_(Desktop) (1)](https://github.com/WordPress/wporg-developer/assets/1017872/356c4c1d-0312-4270-8d83-5c9ce1b6ea18) | ![localhost_8888_coding-standards_inline-documentation-standards_javascript_(iPad) (2)](https://github.com/WordPress/wporg-developer/assets/1017872/15ba1022-40c3-40dc-a091-021da564773b) | ![localhost_8888_coding-standards_inline-documentation-standards_javascript_(iPad) (1)](https://github.com/WordPress/wporg-developer/assets/1017872/ad37fc95-bf49-40e7-bde6-9bcd84564b61) |

### Testing

Check state on page load on different device sizes.

Check expand and collapse functionality on mobile.
