### PR TITLE
Add back missing search bar on archive pages

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/templates/archive.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/archive.html
@@ -3,6 +3,8 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-top:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space);">
 
+	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+
 	<!-- wp:query {"queryId":0,"query":{"inherit":true,"perPage":10},"align":"wide"} -->
 	<div class="wp-block-query alignwide">
 


### PR DESCRIPTION
Fixes #358 

| **Archive** |
|-|
| <img width="554" alt="Screenshot 2023-11-10 at 2 51 08 AM" src="https://github.com/WordPress/wporg-developer/assets/18050944/a5a30bd1-acac-4af2-bf18-b3c5afa6b4c2"> | 

| **Files** |
|-|
| <img width="723" alt="Screenshot 2023-11-10 at 2 50 45 AM" src="https://github.com/WordPress/wporg-developer/assets/18050944/01333684-7a10-49e3-bacf-0c97db774fff"> |

| **Packages** |
|-|
| <img width="665" alt="Screenshot 2023-11-10 at 2 50 49 AM" src="https://github.com/WordPress/wporg-developer/assets/18050944/c7c94927-ace8-4c81-8c0e-e1c44f2f9cf7"> |