### PR TITLE
Fix missing Methods section for Class

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -155,6 +155,7 @@ require_once __DIR__ . '/src/cli-command-table/block.php';
 require_once __DIR__ . '/src/code-changelog/block.php';
 require_once __DIR__ . '/src/code-deprecated/block.php';
 require_once __DIR__ . '/src/code-description/block.php';
+require_once __DIR__ . '/src/code-methods/block.php';
 require_once __DIR__ . '/src/code-explanation/block.php';
 require_once __DIR__ . '/src/code-hooks/block.php';
 require_once __DIR__ . '/src/code-parameters/block.php';
@@ -569,7 +570,9 @@ function add_handbook_templates( $templates ) {
 /**
  * Filters content for the code reference blocks so Table of Contents can be added.
  *
- * Note: This filter is added and removed in src/code-description/block.php to prevent infinite loops.
+ * Note: This filter is added and removed in the files below to prevent infinite loops.
+ * - src/code-description/block.php
+ * - src/code-methods/block.php
  * Any update to the function name should be reflected there.
  *
  * @param string $content
@@ -584,6 +587,7 @@ function filter_code_content( $content ) {
 		'
 		<!-- wp:wporg/code-reference-summary /-->
 		<!-- wp:wporg/code-reference-description /-->
+		<!-- wp:wporg/code-reference-methods /-->
 		<!-- wp:wporg/code-reference-parameters /-->
 		<!-- wp:wporg/code-reference-return-value /-->
 		<!-- wp:wporg/code-reference-explanation /-->

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/code-reference-methods",
+	"version": "0.1.0",
+	"title": "Code Reference: Methods",
+	"category": "widgets",
+	"icon": "smiley",
+	"description": "Show class methods.",
+	"usesContext": [ "postId" ],
+	"supports": {
+		"html": false,
+		"spacing": {
+			"margin": [
+				"top",
+				"bottom"
+			],
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"textdomain": "wporg",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
@@ -1,0 +1,114 @@
+<?php
+namespace WordPressdotorg\Theme\Developer_2023\Dynamic_Code_Methods;
+
+use function DevHub\is_deprecated;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/code-methods',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$content = get_methods_content( $block->context['postId'] );
+
+	if ( empty( $content ) ) {
+		return '';
+	}
+
+	$title_block = sprintf(
+		'<!-- wp:heading {"fontSize":"heading-5"} --><h2 class="wp-block-heading has-heading-5-font-size">%s</h2><!-- /wp:heading -->',
+		__( 'Methods', 'wporg' )
+	);
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<section %s>%s %s</section>',
+		$wrapper_attributes,
+		$title_block,
+		$content
+	);
+}
+
+/**
+ * Return code methods html.
+ *
+ * @return string
+ */
+function get_methods_content( $post_id ) {
+	$output = '';
+
+	if ( 'wp-parser-class' === get_post_type() ) {
+		$class_methods = get_children(
+			array(
+				'post_parent' => get_the_ID(),
+				'post_status' => 'publish',
+			)
+		);
+
+		if ( $class_methods ) {
+			usort( $class_methods, 'DevHub\compare_objects_by_name' );
+			$output .= '<ul>';
+			foreach ( $class_methods as $method ) {
+				$methods_list = '<li>';
+
+				$permalink = get_permalink( $method->ID );
+				$methods_list .= "<a href='$permalink'>";
+
+				$title = get_the_title( $method );
+				$last_colon = strrpos( $title, ':' );
+				$pos = ( false !== $last_colon ) ? $last_colon + 1 : 0;
+				$methods_list .= substr( $title, $pos );
+
+				$methods_list .= '</a>';
+
+				// Remove the filter that adds the code reference block to the content to avoid a possible infinite loop.
+				remove_filter( 'the_content', 'DevHub\filter_code_content', 4 );
+
+				$excerpt = apply_filters( 'get_the_excerpt', $method->post_excerpt, $method );
+				if ( $excerpt ) {
+					$methods_list .= ' &mdash; ' . sanitize_text_field( $excerpt );
+				}
+
+				// Re-add the filter that adds this block to the content.
+				add_filter( 'the_content', 'DevHub\filter_code_content', 4 );
+
+				if ( is_deprecated( $method->ID ) ) {
+					$methods_list .= ' &mdash; <span class="deprecated-method">' . __( 'deprecated', 'wporg' ) . '</span>';
+				}
+
+				$methods_list .= '</li>';
+
+				$output .= $methods_list;
+			}
+			$output .= '</ul>';
+		}
+	}
+
+	return $output;
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../shared/dynamic-edit';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/index.js
@@ -8,7 +8,6 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import Edit from '../shared/dynamic-edit';
 import metadata from './block.json';
-import './style.scss';
 
 registerBlockType( metadata.name, {
 	/**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/style.scss
@@ -1,1 +1,0 @@
-/* css styles */

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/style.scss
@@ -1,0 +1,1 @@
+/* css styles */


### PR DESCRIPTION
Fixes #325.

This PR adds a custom block to render the missing Methods section on Class pages.

### Screenshot
<img width="1333" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/6fceed4f-270e-4195-9fc2-bd5d69996732">

### Note I
For the missing "flushing-rewrite-on-activation" section mentioned [here](https://github.com/WordPress/wporg-developer/issues/300#issuecomment-1780375363), since there are some sort of broken linkings between the Explanation and the Function on staging env, the whole [More Information](https://developer.wordpress.org/redesign-test/reference/functions/register_post_type/#more-information) is not rendered. I've fixed the page by manually adding an explanation to the function `register_post_type` on the staging env, with same the content as the previous one.

| **The synced explanation doesn't link correctly to the corresponding function** (post name: (no title)) | **Manually added one** (post name: Explanation: register_post_type) |
|-|-|
| <img width="838" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/edcb29e0-eefd-4106-ad8d-90c4327a10d1"> | <img width="766" alt="image" src="https://github.com/WordPress/wporg-developer/assets/18050944/56f9c08f-2c27-469f-b21d-a5b19971af90"> |

And because we're not going to touch any data on the current developer site and we're going to apply the 2023 theme to the current site, we don't need to do anything on this issue, once the new theme is applied, `More Information` will be there. 

Put simply: The logic is there, it's just the data linking is broken on staging and local env.

### Note II
There are also some kinds of data linking problems between the Class and Methods, but only on local env.
Locally, [this](https://github.com/WordPress/wporg-developer/compare/fix/missing-Methods-section-for-Class?expand=1#diff-ae29e15b24374e527ce977eb53b1fad259230fb058568e95575ac4e968c3ebb3R67) would return an empty array, making Methods section not rendered.
If you want to test this PR, you can either test directly on the staging env while sandboxed, 
or you can run the following code once on your local env, it will designate every method of [(WP_Hook)](http://localhost:8888/reference/classes/wp_hook/#description) as a child of WP_Hook.
```
$class_post = get_posts(array(
    'post_type'   => 'wp-parser-class',
    'title'       => 'WP_Hook',
    'numberposts' => 1
));

if ( count($class_post) ) {
    $class_post_id = $class_post[0]->ID;

    $method_posts = get_posts(array(
        'post_type'   => 'wp-parser-method',
        'numberposts' => -1,
        's'           => 'WP_Hook::',
    ));

    foreach ( $method_posts as $method_post ) {
        wp_update_post(array(
            'ID'          => $method_post->ID,
            'post_parent' => $class_post_id,
        ));
    }
}
```
I've been trying to locate where method posts are designated as child posts of a class post with keywords like 'parent_post' on either the old codebase or the current one, but there's no luck finding it. If anyone gets any idea about this, please let me know, thanks.