### PR TITLE
Fix accessibility issues with page layouts

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/parts/search-wide.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/search-wide.html
@@ -1,0 +1,7 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+
+</div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/parts/search.html
+++ b/source/wp-content/themes/wporg-developer-2023/parts/search.html
@@ -1,0 +1,7 @@
+<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+
+</div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -10,57 +10,55 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"className":"alignfull","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"}} -->
 <main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
 	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
 	
-		<!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"0px"}}}} -->
-		<article class="wp-block-group" style="margin-top:0px">
+		<!-- wp:group {"tagName":"article"} -->
+		<article class="wp-block-group">
 		
-		<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
+			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
-		<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-		<div class="wp-block-group alignwide">
+			<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group alignwide">
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->
+				<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->
 
-			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
-			<div class="wp-block-group is-style-cards-grid">
+				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"}} -->
+				<div class="wp-block-group is-style-cards-grid">
+					
+					<!-- wp:wporg/link-wrapper -->
+					<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/">
+						
+						<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
+						<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></h3>
+						<!-- /wp:heading -->
+
+						<!-- wp:paragraph {"fontSize":"small"} -->
+						<p class="has-small-font-size"><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></p>
+						<!-- /wp:paragraph -->
+
+					</a>
+					<!-- /wp:wporg/link-wrapper -->
+
+					<!-- wp:wporg/link-wrapper -->
+					<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/handbook/">
+						
+						<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
+						<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></h3>
+						<!-- /wp:heading -->
+
+						<!-- wp:paragraph {"fontSize":"small"} -->
+						<p class="has-small-font-size"><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></p>
+						<!-- /wp:paragraph -->
+						
+					</a>
+					<!-- /wp:wporg/link-wrapper -->
 				
-				<!-- wp:wporg/link-wrapper -->
-				<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/">
-					
-					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
-					<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Blog', 'wporg' ); ?></h3>
-					<!-- /wp:heading -->
+				</div>
+				<!-- /wp:group -->
 
-					<!-- wp:paragraph {"fontSize":"small"} -->
-					<p class="has-small-font-size"><?php esc_html_e( 'Catch up on the latest on WP-CLI in the main updates blog.', 'wporg' ); ?></p>
-					<!-- /wp:paragraph -->
-
-				</a>
-				<!-- /wp:wporg/link-wrapper -->
-
-				<!-- wp:wporg/link-wrapper -->
-				<a class="wp-block-wporg-link-wrapper" href="https://make.wordpress.org/cli/handbook/">
-					
-					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small","fontFamily":"inter"} -->
-					<h3 class="wp-block-heading has-inter-font-family has-small-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'CLI Handbook', 'wporg' ); ?></h3>
-					<!-- /wp:heading -->
-
-					<!-- wp:paragraph {"fontSize":"small"} -->
-					<p class="has-small-font-size"><?php esc_html_e( 'A collection of helpful guides and resources for using WP-CLI.', 'wporg' ); ?></p>
-					<!-- /wp:paragraph -->
-					
-				</a>
-				<!-- /wp:wporg/link-wrapper -->
-			
 			</div>
 			<!-- /wp:group -->
-
-		</div>
-		<!-- /wp:group -->
 
 		</article>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
@@ -10,10 +10,8 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|60"}}},"className":"alignfull","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"}} -->
 <main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|40"}}}} -->
-	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40)">
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--20)">
 		
 		<!-- wp:column {"style":{"spacing":{"blockGap":"0"}}} -->
 		<div class="wp-block-column">

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
@@ -70,7 +70,7 @@ function render( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
-		'<nav %1$s>%2$s<ul class="wporg-chapter-list__list">%3$s</ul></nav>',
+		'<aside %1$s><nav>%2$s<ul class="wporg-chapter-list__list">%3$s</ul></nav></aside>',
 		$wrapper_attributes,
 		$header,
 		$content

--- a/source/wp-content/themes/wporg-developer-2023/src/command-title/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-title/style.scss
@@ -1,6 +1,6 @@
 .wp-block-wporg-command-title {
 	h1 {
-		margin-top: var(--wp--preset--spacing--30);
+		margin-top: 0;
 		margin-bottom: var(--wp--preset--spacing--30);
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -67,12 +67,25 @@ body[class] {
 	--local--sidebar--width: 232px;
 	--local--column-gap: 40px;
 
+	> * {
+		width: 100%;
+	}
+
+	main {
+		order: 1;
+	}
+
 	@media (min-width: 768px) {
-		display: grid;
-		/* stylelint-disable-next-line max-line-length */
-		grid-template-columns: var(--local--sidebar--width) calc(100% - var(--local--sidebar--width) - var(--local--column-gap));
-		grid-template-rows: auto auto;
+		flex-direction: row !important;
 		column-gap: var(--local--column-gap);
+
+		aside {
+			width: var(--local--sidebar--width);
+		}
+
+		main {
+			width: calc(100% - var(--local--sidebar--width) - var(--local--column-gap));
+		}
 
 		.wp-block-wporg-sidebar-container {
 			--local--block-end-sidebar--width: var(--local--sidebar--width);

--- a/source/wp-content/themes/wporg-developer-2023/templates/archive-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/archive-command.html
@@ -1,5 +1,13 @@
 <!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
 
+<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+
+</div>
+<!-- /wp:group -->
+
 <!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands"} /-->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/archive-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/archive-command.html
@@ -1,12 +1,6 @@
 <!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
 
-<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 
 <!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/archive.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/archive.html
@@ -1,15 +1,15 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space);">
+<!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:query {"queryId":0,"query":{"inherit":true,"perPage":10},"align":"wide"} -->
 	<div class="wp-block-query alignwide">
 
-	<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|40"}}},"align":"wide"} -->
-	<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--40);margin-top:var(--wp--preset--spacing--40)">
+	<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|20"}}},"align":"wide"} -->
+	<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--40);margin-top:var(--wp--preset--spacing--20)">
 		<!-- wp:query-title {"type":"archive"} /-->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
@@ -1,12 +1,6 @@
 <!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
 
-<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 
 <!-- wp:pattern {"slug":"wporg-developer-2023/reference-content"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/page-reference.html
@@ -1,5 +1,13 @@
 <!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
 
+<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+
+</div>
+<!-- /wp:group -->
+
 <!-- wp:pattern {"slug":"wporg-developer-2023/reference-content"} /-->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
@@ -1,9 +1,15 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
 	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
@@ -1,12 +1,6 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
@@ -1,12 +1,6 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:template-part {"slug":"search-wide","className":"has-display-contents"} /-->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
@@ -1,34 +1,46 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
-<main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
 
-	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"40px"},"blockGap":"var:preset|spacing|50"}}}}} -->
-	<div class="wp-block-group alignwide has-three-columns" style="margin-top:40px">
+</div>
+<!-- /wp:group -->
 
-		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	
+	<!-- wp:group {"align":"full","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-group alignfull has-three-columns" style="margin-top:var(--wp--preset--spacing--20)">
+		
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
-		<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
-		<article class="wp-block-group" style="margin-top:0px">
-			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
+			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
+			<article class="wp-block-group" style="margin-top:0px">
+				<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
+				<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
-			<!-- wp:post-content /-->
+				<!-- wp:post-content /-->
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta-github"} /-->
+				<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta-github"} /-->
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/handbook-pagination"} /-->
+				<!-- wp:pattern {"slug":"wporg-developer-2023/handbook-pagination"} /-->
 
-		</article>
+			</article>
+			<!-- /wp:group -->
+
+		</main>
 		<!-- /wp:group -->
+
+		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"20px"}}}} /-->
 
 	</div>
 	<!-- /wp:group -->
 
-</main>
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -1,12 +1,6 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:template-part {"slug":"search-wide","className":"has-display-contents"} /-->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -1,33 +1,46 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
-<main class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
 
-	<!-- wp:group {"className":"has-three-columns","align":"wide","style":{"spacing":{"margin":{"top":"40px"},"blockGap":"var:preset|spacing|50"}}}}} -->
-	<div class="wp-block-group alignwide has-three-columns" style="margin-top:40px">
+</div>
+<!-- /wp:group -->
 
-		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	
+	<!-- wp:group {"align":"full","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-group alignfull has-three-columns" style="margin-top:var(--wp--preset--spacing--20)">
+		
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
-		<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
-		<article class="wp-block-group" style="margin-top:0px">
-			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
+			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
+			<article class="wp-block-group" style="margin-top:0px">
+				<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
+				<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
-			<!-- wp:post-content /-->
+				<!-- wp:post-content /-->
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
+				<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
 
-			<!-- wp:pattern {"slug":"wporg-developer-2023/handbook-pagination"} /-->
-		</article>
+				<!-- wp:pattern {"slug":"wporg-developer-2023/handbook-pagination"} /-->
+
+			</article>
+			<!-- /wp:group -->
+
+		</main>
 		<!-- /wp:group -->
+
+		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"20px"}}}} /-->
 
 	</div>
 	<!-- /wp:group -->
 
-</main>
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -1,12 +1,6 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -1,13 +1,18 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
+<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+
+</div>
+<!-- /wp:group -->
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
-
-	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
-	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--40)">
+	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
 
 		<!-- wp:group {"tagName":"article"} -->
 		<article class="wp-block-group">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -17,7 +17,7 @@
 		<!-- wp:group {"tagName":"article"} -->
 		<article class="wp-block-group">
 			
-			<!-- wp:wporg/code-reference-title {"level":1} /-->
+			<!-- wp:wporg/code-reference-title {"level":1,"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/taxonomy-wp-parser-since.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/taxonomy-wp-parser-since.html
@@ -1,14 +1,14 @@
 <!-- wp:template-part {"slug":"header-no-breadcrumbs","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+<!-- wp:template-part {"slug":"search","className":"has-display-contents"} /-->
 
-	<!-- wp:pattern {"slug":"wporg-developer-2023/search-field"} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:query {"queryId":0,"query":{"inherit":true,"perPage":10},"align":"wide"} -->
 	<div class="wp-block-query alignwide">
 
-	<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|40"}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"heading-1","fontFamily":"ibm-plex-sans"} /-->
+	<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|20"}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"heading-1","fontFamily":"ibm-plex-sans"} /-->
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/release-post-type-filters"} /-->
 


### PR DESCRIPTION
See #368 

Several issues with the handbook layouts are fixed, and some of these fixes have also been applied to other layouts (remove search field from main landmark):

- [x] The handbook chapters heading 2 is the first heading on the page. This design needs to be reworked, no questions asked.
- [x] The skip to main content link does not land you in the main content, it lands you in all the items before the main heading 1.
- [x] The main landmark should not wrap navigational elements such as the Chapters heading 2 or the search form above it.

**The visual layout should not change.**

### Testing

Use dev tools to test and check the following:

1. Almost all the templates have updated layouts, with the Search field moving out of `main`. The skip to content link should take you directly to the main content, with no search or chapters in main before the h1.
2. On handbook pages the chapter list aside has been moved after main, so check the headings hierarchy and accessibility tree