### PR TITLE
Use IBM Plex Sans for headings

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -187,8 +187,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"charcoal-2","textColor":"white","className":"wporg-front-page-footer","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wporg-front-page-footer has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="border-bottom-color:var(--wp--preset--color--white-opacity-15);border-bottom-style:solid;border-bottom-width:1px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20"}}},"className":"is-style-default"} -->
 <div class="wp-block-columns alignwide is-style-default"><!-- wp:column {"verticalAlignment":"top","width":"50%","className":"is-left-column","layout":{"inherit":false}} -->
-<div class="wp-block-column is-vertically-aligned-top is-left-column" style="flex-basis:50%"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"1.3"}},"fontSize":"large","fontFamily":"eb-garamond"} -->
-<h2 class="wp-block-heading has-eb-garamond-font-family has-large-font-size" style="font-style:normal;font-weight:400;line-height:1.3"><?php esc_html_e( 'More resources', 'wporg' ); ?></h2>
+<div class="wp-block-column is-vertically-aligned-top is-left-column" style="flex-basis:50%"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"1.3"}},"fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+<h2 class="wp-block-heading has-ibm-plex-sans-font-family has-large-font-size" style="font-style:normal;font-weight:400;line-height:1.3"><?php esc_html_e( 'More resources', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
@@ -215,8 +215,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"50%","layout":{"inherit":false}} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"1.3"}},"fontSize":"large","fontFamily":"eb-garamond"} -->
-<h2 class="wp-block-heading has-eb-garamond-font-family has-large-font-size" style="font-style:normal;font-weight:400;line-height:1.3"><?php esc_html_e( 'Related', 'wporg' ); ?></h2>
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"1.3"}},"fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+<h2 class="wp-block-heading has-ibm-plex-sans-font-family has-large-font-size" style="font-style:normal;font-weight:400;line-height:1.3"><?php esc_html_e( 'Related', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-content.php
@@ -10,8 +10,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"var:preset|spacing|50"}},"className":"entry-content"} -->
 <div class="wp-block-group alignfull entry-content" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1.7"}},"className":"is-style-short-text","fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading is-style-short-text has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:700;line-height:1.7"><?php esc_html_e( 'Documentation', 'wporg' ); ?></h2>
+<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1.7"}},"className":"is-style-short-text","fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+<h2 class="wp-block-heading is-style-short-text has-ibm-plex-sans-font-family has-large-font-size" style="font-style:normal;font-weight:600;line-height:1.7"><?php esc_html_e( 'Documentation', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"32.3%"},"fontSize":"small"} -->
@@ -80,8 +80,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1.7"}},"className":"is-style-short-text","fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading is-style-short-text has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:700;line-height:1.7"><?php esc_html_e( 'API Reference', 'wporg' ); ?></h2>
+<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1.7"}},"className":"is-style-short-text","fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+<h2 class="wp-block-heading is-style-short-text has-ibm-plex-sans-font-family has-large-font-size" style="font-style:normal;font-weight:600;line-height:1.7"><?php esc_html_e( 'API Reference', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"className":"is-style-cards-grid","layout":{"type":"grid","minimumColumnWidth":"49%"},"fontSize":"small"} -->
@@ -130,8 +130,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-white-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1.7"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="margin-bottom:var(--wp--preset--spacing--10);font-style:normal;font-weight:700;line-height:1.7"><?php esc_html_e( 'Developer Blog', 'wporg' ); ?></h2>
+<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1.7"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+<h2 class="wp-block-heading has-ibm-plex-sans-font-family has-large-font-size" style="margin-bottom:var(--wp--preset--spacing--10);font-style:normal;font-weight:600;line-height:1.7"><?php esc_html_e( 'Developer Blog', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20","top":"var:preset|spacing|10"}}},"textColor":"charcoal-4","fontSize":"small"} -->
@@ -151,8 +151,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","lineHeight":"1.7"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"fontSize":"large","fontFamily":"inter"} -->
-<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="margin-bottom:var(--wp--preset--spacing--10);font-style:normal;font-weight:700;line-height:1.7"><?php esc_html_e( 'Get Involved', 'wporg' ); ?></h2>
+<div class="wp-block-group alignwide"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1.7"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}},"fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+<h2 class="wp-block-heading has-ibm-plex-sans-font-family has-large-font-size" style="margin-bottom:var(--wp--preset--spacing--10);font-style:normal;font-weight:600;line-height:1.7"><?php esc_html_e( 'Get Involved', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20","top":"var:preset|spacing|10"}}},"textColor":"charcoal-4","fontSize":"small"} -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
@@ -23,8 +23,8 @@
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"bottom"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
 	
-		<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"50px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"eb-garamond"} -->
-		<h1 class="wp-block-heading has-eb-garamond-font-family" style="font-size:50px;font-style:normal;font-weight:400"><?php esc_html_e( 'Developer Resources', 'wporg' ); ?></h1>
+		<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"50px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"ibm-plex-sans"} -->
+		<h1 class="wp-block-heading has-ibm-plex-sans-font-family" style="font-size:50px;font-style:normal;font-weight:400"><?php esc_html_e( 'Developer Resources', 'wporg' ); ?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"2.3"}},"textColor":"white"} -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/reference-content.php
@@ -29,8 +29,8 @@
 			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 			<div class="wp-block-group">
 				
-				<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"large","fontFamily":"inter"} -->
-				<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'API reference', 'wporg' ); ?></h2>
+				<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+				<h2 class="wp-block-heading has-ibm-plex-sans-font-family has-large-font-size" style="font-style:normal;font-weight:600"><?php esc_html_e( 'API reference', 'wporg' ); ?></h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/reference-new-updated/block.php
@@ -72,8 +72,8 @@ function render( $attributes, $content, $block ) {
 		'<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group">
 
-			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"large","fontFamily":"inter"} -->
-			<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:700">%s</h2>
+			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"large","fontFamily":"ibm-plex-sans"} -->
+			<h2 class="wp-block-heading has-ibm-plex-sans-font-family has-large-font-size" style="font-style:normal;font-weight:600">%s</h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->

--- a/source/wp-content/themes/wporg-developer-2023/templates/taxonomy-wp-parser-since.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/taxonomy-wp-parser-since.html
@@ -8,7 +8,7 @@
 	<!-- wp:query {"queryId":0,"query":{"inherit":true,"perPage":10},"align":"wide"} -->
 	<div class="wp-block-query alignwide">
 
-	<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|40"}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"heading-1","fontFamily":"eb-garamond"} /-->
+	<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40","top":"var:preset|spacing|40"}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"heading-1","fontFamily":"ibm-plex-sans"} /-->
 
 	<!-- wp:pattern {"slug":"wporg-developer-2023/release-post-type-filters"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -45,8 +45,8 @@
 		"custom": {
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--monospace)",
-					"fontWeight": 500,
+					"fontFamily": "var(--wp--preset--font-family--ibm-plex-sans)",
+					"fontWeight": 600,
 					"lineHeight": 1.2
 				},
 				"level-1": {


### PR DESCRIPTION
Closes #374 
Depends on https://github.com/WordPress/wporg-mu-plugins/issues/506
Depend on https://github.com/WordPress/wporg-parent-2021/pull/116

Use IBM Plex Sans for:
- [x] Anything currently using EB Garamond (eg. home page h1 and h2s)
- [x] All non code titles (eg. exclude code reference titles)

### Screenshots

| Home | New and Updated | Code | Handbook |
|-|-|-|-|
| ![localhost_8888_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/1b3c5c07-6b67-42a7-8d91-971b65ded958) | ![localhost_8888_reference_since_6 3 0_(Desktop) (2)](https://github.com/WordPress/wporg-developer/assets/1017872/a2e917de-c1a3-46a5-be2c-8b3b18d658bb) | ![localhost_8888_reference_functions__prime_site_caches_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/53033cc4-cb21-4f64-85d6-af69ca59ac39) | ![localhost_8888_block-editor_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/84bf3bf9-da5b-4102-af11-064d8c7f4fb3) |
