### PR TITLE
Add scripts and style to handle toggles in handbook pages

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -487,6 +487,16 @@ function theme_scripts_styles() {
 		// All headings.
 		global_fonts_preload( 'IBM Plex Sans, IBM Plex Sans SemiBold, Inter', $subsets );
 	}
+
+	if ( wporg_is_handbook() ) {
+		wp_enqueue_script(
+			'wporg-developer-code-tabs',
+			get_stylesheet_directory_uri() . '/js/code-tabs.js',
+			array(),
+			filemtime( __DIR__ . '/js/code-tabs.js' ),
+			true
+		);
+	}
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/js/code-tabs.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/code-tabs.js
@@ -1,30 +1,48 @@
 const init = () => {
-	const tabs = document.querySelectorAll( '.code-tabs' );
+	const tabLists = document.querySelectorAll( '.code-tabs' );
 
-	if ( ! tabs.length ) {
+	if ( ! tabLists.length ) {
 		return;
 	}
 
-	tabs.forEach( ( tab ) => {
-		const buttons = tab.querySelectorAll( 'button' );
+	tabLists.forEach( ( tabList ) => {
+		const buttons = tabList.querySelectorAll( '.code-tab' );
+		const panels = tabList.querySelectorAll( '.code-tab-block' );
 
 		buttons.forEach( ( button ) => {
-			button.classList.add( 'wp-block-button__link' );
+			const isActive = button.classList.contains( 'is-active' );
+			const buttonId = window.crypto?.randomUUID?.();
+			const panelId = window.crypto?.randomUUID?.();
+			const tabName = button.getAttribute( 'data-language' );
+			const relatedPanel = Array.from( panels ).find( ( panel ) => panel.classList.contains( tabName ) );
 
-			if ( button.classList.contains( 'is-active' ) ) {
-				button.setAttribute( 'aria-pressed', 'true' );
+			button.classList.add( 'wp-block-button__link' );
+			button.setAttribute( 'role', 'tab' );
+			button.setAttribute( 'aria-selected', isActive );
+			button.setAttribute( 'tabindex', isActive ? '0' : '-1' );
+			button.setAttribute( 'id', buttonId );
+
+			if ( buttonId && panelId && relatedPanel ) {
+				button.setAttribute( 'aria-controls', panelId );
+				relatedPanel.setAttribute( 'aria-labelledby', buttonId );
+				relatedPanel.setAttribute( 'id', panelId );
 			}
 		} );
 
-		// Block button styles require a parent with `class*="wp-block"`.
-		tab.classList.add( 'wp-block', 'is-small', 'is-style-toggle' );
+		panels.forEach( ( panel ) => {
+			panel.setAttribute( 'role', 'tabpanel' );
+		} );
 
-		tab.addEventListener( 'click', ( event ) => {
+		tabList.setAttribute( 'role', 'tablist' );
+		// Block button styles require a parent with `class*="wp-block"`.
+		tabList.classList.add( 'wp-block', 'is-small', 'is-style-toggle' );
+
+		tabList.addEventListener( 'click', ( event ) => {
 			event.preventDefault();
 
-			if ( event.target.classList.contains( 'wp-block-button__link' ) ) {
+			if ( Array.from( buttons ).includes( event.target ) ) {
 				const targetButton = event.target;
-				const tabName = targetButton.getAttribute( 'data-language' );
+				const id = targetButton.getAttribute( 'aria-controls' );
 
 				if ( targetButton.classList.contains( 'is-active' ) ) {
 					return;
@@ -33,16 +51,18 @@ const init = () => {
 				// Update button states.
 				buttons.forEach( ( button ) => {
 					button.classList.remove( 'is-active' );
-					button.setAttribute( 'aria-pressed', 'false' );
+					button.setAttribute( 'aria-selected', 'false' );
+					button.setAttribute( 'tabindex', '-1' );
 				} );
 				targetButton.classList.add( 'is-active' );
-				targetButton.setAttribute( 'aria-pressed', 'true' );
+				targetButton.setAttribute( 'aria-selected', 'true' );
+				targetButton.setAttribute( 'tabindex', '0' );
 
 				// Update tab states.
-				tab.querySelectorAll( '.code-tab-block' ).forEach( ( block ) => {
-					block.classList.remove( 'is-active' );
+				panels.forEach( ( panel ) => {
+					panel.classList.remove( 'is-active' );
 				} );
-				tab.querySelector( `.code-tab-block[class*="${ tabName }"]` ).classList.add( 'is-active' );
+				document.getElementById( id )?.classList.add( 'is-active' );
 			}
 		} );
 	} );

--- a/source/wp-content/themes/wporg-developer-2023/js/code-tabs.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/code-tabs.js
@@ -1,0 +1,51 @@
+const init = () => {
+	const tabs = document.querySelectorAll( '.code-tabs' );
+
+	if ( ! tabs.length ) {
+		return;
+	}
+
+	tabs.forEach( ( tab ) => {
+		const buttons = tab.querySelectorAll( 'button' );
+
+		buttons.forEach( ( button ) => {
+			button.classList.add( 'wp-block-button__link' );
+
+			if ( button.classList.contains( 'is-active' ) ) {
+				button.setAttribute( 'aria-pressed', 'true' );
+			}
+		} );
+
+		// Block button styles require a parent with `class*="wp-block"`.
+		tab.classList.add( 'wp-block', 'is-small', 'is-style-toggle' );
+
+		tab.addEventListener( 'click', ( event ) => {
+			event.preventDefault();
+
+			if ( event.target.classList.contains( 'wp-block-button__link' ) ) {
+				const targetButton = event.target;
+				const tabName = targetButton.getAttribute( 'data-language' );
+
+				if ( targetButton.classList.contains( 'is-active' ) ) {
+					return;
+				}
+
+				// Update button states.
+				buttons.forEach( ( button ) => {
+					button.classList.remove( 'is-active' );
+					button.setAttribute( 'aria-pressed', 'false' );
+				} );
+				targetButton.classList.add( 'is-active' );
+				targetButton.setAttribute( 'aria-pressed', 'true' );
+
+				// Update tab states.
+				tab.querySelectorAll( '.code-tab-block' ).forEach( ( block ) => {
+					block.classList.remove( 'is-active' );
+				} );
+				tab.querySelector( `.code-tab-block[class*="${ tabName }"]` ).classList.add( 'is-active' );
+			}
+		} );
+	} );
+};
+
+window.addEventListener( 'load', init );

--- a/source/wp-content/themes/wporg-developer-2023/js/code-tabs.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/code-tabs.js
@@ -9,6 +9,14 @@ const init = () => {
 		const buttons = tabList.querySelectorAll( '.code-tab' );
 		const panels = tabList.querySelectorAll( '.code-tab-block' );
 
+		if ( ! buttons.length || ! panels.length || buttons.length !== panels.length ) {
+			return;
+		}
+
+		tabList.setAttribute( 'role', 'tablist' );
+		// Block button styles require a parent with `class*="wp-block"`.
+		tabList.classList.add( 'wp-block', 'is-small', 'is-style-toggle' );
+
 		buttons.forEach( ( button ) => {
 			const isActive = button.classList.contains( 'is-active' );
 			const buttonId = window.crypto?.randomUUID?.();
@@ -33,36 +41,61 @@ const init = () => {
 			panel.setAttribute( 'role', 'tabpanel' );
 		} );
 
-		tabList.setAttribute( 'role', 'tablist' );
-		// Block button styles require a parent with `class*="wp-block"`.
-		tabList.classList.add( 'wp-block', 'is-small', 'is-style-toggle' );
+		const maybeActivateTab = ( currentButton ) => {
+			if ( currentButton.classList.contains( 'is-active' ) ) {
+				return;
+			}
+
+			const panelId = currentButton.getAttribute( 'aria-controls' );
+
+			// Update button states.
+			buttons.forEach( ( button ) => {
+				button.classList.remove( 'is-active' );
+				button.setAttribute( 'aria-selected', 'false' );
+				button.setAttribute( 'tabindex', '-1' );
+			} );
+			currentButton.classList.add( 'is-active' );
+			currentButton.setAttribute( 'aria-selected', 'true' );
+			currentButton.setAttribute( 'tabindex', '0' );
+
+			// Update panel states.
+			panels.forEach( ( panel ) => {
+				panel.classList.remove( 'is-active' );
+			} );
+			document.getElementById( panelId )?.classList.add( 'is-active' );
+		};
 
 		tabList.addEventListener( 'click', ( event ) => {
+			if ( ! Array.from( buttons ).includes( event.target ) ) {
+				return;
+			}
+
 			event.preventDefault();
+			maybeActivateTab( event.target );
+		} );
 
-			if ( Array.from( buttons ).includes( event.target ) ) {
-				const targetButton = event.target;
-				const id = targetButton.getAttribute( 'aria-controls' );
+		tabList.addEventListener( 'keydown', ( event ) => {
+			if ( ! Array.from( buttons ).includes( event.target ) ) {
+				return;
+			}
 
-				if ( targetButton.classList.contains( 'is-active' ) ) {
-					return;
+			if ( event.code === 'Enter' || event.code === 'Space' ) {
+				event.preventDefault();
+				maybeActivateTab( event.target );
+			} else if ( event.code === 'ArrowLeft' || event.code === 'ArrowRight' ) {
+				event.preventDefault();
+
+				// Cycle focus within the tab list.
+				const currentIndex = Array.from( buttons ).indexOf( event.target );
+				const isMovingRight = event.code === 'ArrowRight';
+				const nextIndex = isMovingRight ? currentIndex + 1 : currentIndex - 1;
+				const nextButton = buttons[ nextIndex ];
+
+				if ( nextButton ) {
+					nextButton.focus();
+				} else {
+					buttons[ isMovingRight ? 0 : buttons.length - 1 ].focus();
 				}
-
-				// Update button states.
-				buttons.forEach( ( button ) => {
-					button.classList.remove( 'is-active' );
-					button.setAttribute( 'aria-selected', 'false' );
-					button.setAttribute( 'tabindex', '-1' );
-				} );
-				targetButton.classList.add( 'is-active' );
-				targetButton.setAttribute( 'aria-selected', 'true' );
-				targetButton.setAttribute( 'tabindex', '0' );
-
-				// Update tab states.
-				panels.forEach( ( panel ) => {
-					panel.classList.remove( 'is-active' );
-				} );
-				document.getElementById( id )?.classList.add( 'is-active' );
 			}
 		} );
 	} );

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -474,3 +474,15 @@ body[class] {
 		padding-left: var(--wp--preset--spacing--10);
 	}
 }
+
+.code-tabs {
+	> button {
+		margin-right: var(--wp--preset--spacing--10);
+	}
+
+	.code-tab-block {
+		&:not(.is-active) {
+			display: none;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #352 

Add a script to manage the tab state of `code-tab` sections of the block editor handbook, but the script enqueuing is only limited to handbook pages, so other handbooks could replicate this behaviour.

Styles are mostly handled by adding block button classes from the parent theme.

Accessibility behaviour based on https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/

**Requires a change to the [parent button styles](https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button.scss#L31) to expand the toggle styles to cover `aria-selected` as well as `aria-pressed`.** I'll make that change when I ship.

### Screenshots

| Tab 1 active | Tab 2 active |
|-|-|
| ![Screenshot 2023-11-20 at 3 52 00 PM](https://github.com/WordPress/wporg-developer/assets/1017872/7a1ed035-0136-42fa-b2b3-aa2647e5094a) | ![Screenshot 2023-11-20 at 3 52 12 PM](https://github.com/WordPress/wporg-developer/assets/1017872/3b006074-d2bd-4ccc-b3ac-c10c3ae0ff3e) |

### Testing

1. Check the Input/Output toggles on http://localhost:8888/block-editor/how-to-guides/themes/theme-json/
2. Check the JSX/Plain toggles on http://localhost:8888/block-editor/how-to-guides/block-tutorial/writing-your-first-block-type/ (although [these will be removed before launch](https://github.com/WordPress/wporg-developer/issues/352#issuecomment-1809164955))