### PR TITLE
Fix first/last updates font size to match adjacent links.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta-github.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta-github.php
@@ -15,7 +15,7 @@
 		<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'First published', 'wporg' ); ?></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:post-date {"fontSize":"small"} /-->
+		<!-- wp:post-date /-->
 	</div>
 	<!-- /wp:group -->
 
@@ -25,7 +25,7 @@
 		<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Last updated', 'wporg' ); ?></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:post-date {"displayType":"modified","fontSize":"small"} /-->
+		<!-- wp:post-date {"displayType":"modified"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta-github.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta-github.php
@@ -15,7 +15,7 @@
 		<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'First published', 'wporg' ); ?></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:post-date {"fontSize":"normal"} /-->
+		<!-- wp:post-date {"fontSize":"small"} /-->
 	</div>
 	<!-- /wp:group -->
 
@@ -25,7 +25,7 @@
 		<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Last updated', 'wporg' ); ?></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
+		<!-- wp:post-date {"displayType":"modified","fontSize":"small"} /-->
 	</div>
 	<!-- /wp:group -->
 


### PR DESCRIPTION
Fixes #382.

The "Improve" links are inheriting a style of `14px` from the [parent theme](https://github.com/WordPress/wporg-parent-2021/blob/aa715a7bc1d9b5a63edd636e550f7791772568fb/source/wp-content/themes/wporg-parent-2021/sass/page/_single.scss#L3C1-L3C1). In this case, the smaller text seems to work better as it's secondary information. As a result, I've change the first/last to be the same size of `14px`. 

Noting we can't set the `fontSize` to `small` because it will change the line-height. So we remove it allow the parent styles to style these controls.

| Before  | After |
|--------|--------|
| <img width="710" alt="Screenshot 2023-11-20 at 3 38 21 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/94a2491d-558e-4ad6-b69e-74f0a8a5be1c"> | <img width="656" alt="Screenshot 2023-11-20 at 3 48 25 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/39eb566f-75bb-4a65-9944-663487f1b7e4"> |


