### PR TITLE
For tables in the content, extend the table full width.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -42,6 +42,10 @@ body[class] {
 		padding-right: 3px;
 		max-width: 100%;
 	}
+
+	table {
+		width: 100%;
+	}
 }
 
 .wporg-filtered-search-form {


### PR DESCRIPTION
Fixes: #383

This PR adds a `100%` width to tables in the `entry-content` to make sure tables expand the full width. I think this is safe because the pre-existing theme had the same style (although not scoped to the entry content):

<img width="548" alt="Screenshot 2023-11-20 at 4 01 25 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/057271c4-562d-4c1f-a064-bbaa03c7125c">


# Screenshot

| Before | After |
|--------|--------|
| <img width="855" alt="Screenshot 2023-11-20 at 3 58 21 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/5bfce206-d2f9-421e-b1b6-7feb1bdb8c9b"> | <img width="847" alt="Screenshot 2023-11-20 at 3 58 32 PM" src="https://github.com/WordPress/wporg-developer/assets/1657336/990e7fd5-a671-4cc2-a768-d0aad3e74b4a"> | 



