### PR TITLE
Fix WP-CLI Commands layouts accessibility

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -654,7 +654,7 @@ function filter_command_content( $content ) {
 
 	// Feed the static content from the CLI archive template to generate the ToC
 	// Note: ids must be added to the cli-commands-content pattern manually
-	if ( is_archive() && '/cli/commands/' === $_SERVER['REQUEST_URI'] ) {
+	if ( is_archive() && isset( $_SERVER['REQUEST_URI'] ) && '/cli/commands/' === $_SERVER['REQUEST_URI'] ) {
 		// Stop infinite loop
 		remove_filter( 'the_content', 'DevHub\filter_command_content', 4 );
 

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -658,8 +658,8 @@ function filter_command_content( $content ) {
 		// Stop infinite loop
 		remove_filter( 'the_content', 'DevHub\filter_command_content', 4 );
 
-		$content = do_blocks('<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->');
-		
+		$content = do_blocks( '<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-title"} /--><!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->' );
+
 		add_filter( 'the_content', 'DevHub\filter_command_content', 4 );
 
 		return $content;

--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -671,7 +671,6 @@ function filter_command_content( $content ) {
 
 	return do_blocks(
 		'
-		<!-- wp:wporg/command-title /-->
 		<!-- wp:wporg/command-github /-->
 		<!-- wp:wporg/command-content /-->
 		<!-- wp:wporg/command-subcommand /-->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
@@ -7,10 +7,6 @@
 
 ?>
 
-<!-- wp:heading {"level":1,"className":" is-toc-heading","fontSize":"heading-2"} -->
-<h1 class="wp-block-heading is-toc-heading has-heading-2-font-size" id="wp-cli-commands"><a href="#wp-cli-commands"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></a></h1>
-<!-- /wp:heading -->
-
 <!-- wp:paragraph -->
 <p><?php esc_html_e( 'Below is a listing of all currently available WP-CLI commands with links to documentation on usage and subcommands.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-content.php
@@ -12,14 +12,16 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php echo wp_kses_post(
-	sprintf(
-	/* translators: %1$s: URL of the WP-CLI handbook, %2$s: URL of the WP-CLI blog */
-		__( 'Looking to learn more about the internal API of WP-CLI or to contribute to its development? Check out the WP-CLI team&rsquo;s <a href="%1$s">handbook</a> and the <a href="%2$s">WP-CLI Blog</a>.', 'wporg' ),
-		'https://make.wordpress.org/cli/handbook/',
-		'https://make.wordpress.org/cli/'
-	)
-); ?></p>
+<p>
+	<?php echo wp_kses_post(
+		sprintf(
+		/* translators: %1$s: URL of the WP-CLI handbook, %2$s: URL of the WP-CLI blog */
+			__( 'Looking to learn more about the internal API of WP-CLI or to contribute to its development? Check out the WP-CLI team&rsquo;s <a href="%1$s">handbook</a> and the <a href="%2$s">WP-CLI Blog</a>.', 'wporg' ),
+			'https://make.wordpress.org/cli/handbook/',
+			'https://make.wordpress.org/cli/'
+		)
+	); ?>
+</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wporg/cli-command-table {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /-->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-title.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands-title.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Title: CLI Commands Page Title
+ * Slug: wporg-developer-2023/cli-commands-title
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:heading {"level":1,"className":"is-toc-heading","fontSize":"heading-2","style":{"spacing":{"margin":{"bottom":"40px"}}}} -->
+<h1 class="wp-block-heading is-toc-heading has-heading-2-font-size" style="margin-bottom:40px" id="wp-cli-commands"><a href="#wp-cli-commands"><?php esc_html_e( 'WP-CLI Commands', 'wporg' ); ?></a></h1>
+<!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -15,11 +15,13 @@
 	
 		<!-- wp:group {"tagName":"article"} -->
 		<article class="wp-block-group">
-		
-			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
 			<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 			<div class="wp-block-group alignwide">
+
+				<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-title"} /-->
+
+				<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
 				<!-- wp:pattern {"slug":"wporg-developer-2023/cli-commands-content"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/src/command-github/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-github/block.php
@@ -44,7 +44,7 @@ function render( $attributes, $content, $block ) {
 		$content .= sprintf(
 			'
 			<a href="%s">
-				<img src="https://make.wordpress.org/cli/wp-content/plugins/wporg-cli/assets/images/github-mark.svg" class="icon-github" />
+				<img src="https://make.wordpress.org/cli/wp-content/plugins/wporg-cli/assets/images/github-mark.svg" class="icon-github" alt="GitHub" />
 			</a>
 			',
 			esc_url( $repo_url )
@@ -54,10 +54,10 @@ function render( $attributes, $content, $block ) {
 	$content .= sprintf(
 		'
 		<div class="btn-group">
-			<a href="%1$s" class="button">
+			<a href="%1$s" class="button wporg-command-github-open">
 				%2$s <span class="green">%3$s</span>
 			</a>
-			<a href="%4$s"class="button">
+			<a href="%4$s" class="button wporg-command-github-closed">
 				%5$s <span class="red">%6$s</span>
 			</a>
 		',
@@ -71,7 +71,7 @@ function render( $attributes, $content, $block ) {
 
 	if ( $repo_url ) {
 		$content .= sprintf(
-			'<a href="%1$s" class="button">%2$s</a>',
+			'<a href="%1$s" class="button wporg-command-github-new">%2$s</a>',
 			esc_url( rtrim( $repo_url, '/' ) . '/issues/new' ),
 			__( 'Create New Issue', 'wporg' ),
 		);

--- a/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
@@ -29,6 +29,7 @@
 			font-size: var(--wp--preset--font-size--extra-small);
 			box-shadow: 0 1px 0 #ccc;
 			line-height: 1;
+			margin-top: var(--wp--preset--spacing--10);
 
 			&:hover {
 				border-color: #ccc #bbb #aaa #bbb;
@@ -43,12 +44,17 @@
 				color: var(--wp--preset--color--syntax-red);
 			}
 
-			&:first-child {
-				margin-right: -6px;
-			}
+			@media screen and (min-width: 380px) {
+				&.wporg-command-github-open {
+					margin-right: -6px;
+					border-top-right-radius: 0;
+					border-bottom-right-radius: 0;
+				}
 
-			&:last-child {
-				margin-left: 5px;
+				&.wporg-command-github-closed {
+					border-top-left-radius: 0;
+					border-bottom-left-radius: 0;
+				}
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
@@ -11,6 +11,8 @@
 		<!-- wp:group {"tagName":"article","style":{"spacing":{"blockGap":"0","margin":{"top":"0px"}}}} -->
 		<article class="wp-block-group" style="margin-top:0px">
 
+			<!-- wp:wporg/command-title {"style":{"spacing":{"margin":{"bottom":"40px"}}}} /-->
+
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 			
 			<!-- wp:pattern {"slug":"wporg-developer-2023/single-content"} /-->


### PR DESCRIPTION
Fixes #394 

On both landing and single pages the ToC has been moved after the h1.

I've also included minor style updates to the GitHub buttons to match the [design](https://www.figma.com/file/2WxlJFzMJvqPfZL1EkAOVp/Developer-Resources?node-id=2934%3A7281&mode=dev).

### Screenshots

#### Landing

| Desktop | Tablet | Mobile |
|-|-|-|
| ![Screenshot 2023-11-22 at 4 37 37 PM](https://github.com/WordPress/wporg-developer/assets/1017872/a5f42f5f-493b-46b0-9541-d4565ed64fa2) | ![localhost_8888_cli_commands_(iPad) (3)](https://github.com/WordPress/wporg-developer/assets/1017872/5c3ad39a-5972-4152-8f8d-9b7de2c2db92) | ![localhost_8888_cli_commands_(Samsung Galaxy S20 Ultra) (4)](https://github.com/WordPress/wporg-developer/assets/1017872/f39082b9-72fb-48bb-88c5-29ad51b30315) |

#### Single

| Desktop | Tablet | Mobile |
|-|-|-|
| ![Screenshot 2023-11-22 at 5 39 51 PM](https://github.com/WordPress/wporg-developer/assets/1017872/affc0043-0d7c-4719-b10e-2a3b44b9b06d) | ![localhost_8888_cli_commands_admin_(iPad) (2)](https://github.com/WordPress/wporg-developer/assets/1017872/07bfa99d-b6f3-4dd7-b925-ab24ec5f674d) | ![localhost_8888_cli_commands_admin_(Samsung Galaxy S20 Ultra) (4)](https://github.com/WordPress/wporg-developer/assets/1017872/5aa476c7-2f6a-4ccb-967f-4e9974a48624) |

### Testing

Check the heading hierarchy either by running an a11y checker, a headings map tool or inspecting the DOM
