### PR TITLE
Use &nbsp; to not allow orphaned brackets.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -734,7 +734,7 @@ namespace DevHub {
 				$signature .= ', ';
 				$signature .= implode( ', ', $hook_args );
 			}
-			$signature .= ' )';
+			$signature .= '&nbsp;)';
 			return $signature;
 		}
 


### PR DESCRIPTION
Fixes: #380 

This uses `&nbsp` to avoid a single ")" on a new line.

