### PR TITLE
Fix broken code block sticky header

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
@@ -209,8 +209,6 @@ pre.line-numbers > code {
 
 /* Copy button */
 .wp-code-block-button-container {
-	position: sticky;
-	top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height, 0px));
 	z-index: 1;
 	display: flex;
 	justify-content: right;

--- a/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
@@ -264,13 +264,13 @@ pre.line-numbers > code {
 	&::after {
 		content: "";
 
-		/* Since the margin-bottom of the pre defined in _global.scss is 1.6em,
-		 * -1.63em is set here to make the shape of the rounded corners at the bottom of
-		 * the code block complete when the sticky wp-code-block-button-container is scolled there.
+		/* Since the margin-bottom of the pre defined in _global.scss is 1em,
+		 * -1.1em is set here to make the shape of the rounded corners at the bottom of
+		 * the code block complete when the sticky wp-code-block-button-container is scrolled there.
 		 *
 		 * See https://github.com/WordPress/wporg-developer/pull/148#issuecomment-1289595980
 		 */
-		margin-bottom: -1.63em;
+		margin-bottom: -1.1em;
 	}
 }
 

--- a/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
@@ -210,7 +210,7 @@ pre.line-numbers > code {
 /* Copy button */
 .wp-code-block-button-container {
 	position: sticky;
-	top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height));
+	top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height, 0px));
 	z-index: 1;
 	display: flex;
 	justify-content: right;

--- a/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
+++ b/source/wp-content/themes/wporg-developer-2023/scss/prism.scss
@@ -210,7 +210,7 @@ pre.line-numbers > code {
 /* Copy button */
 .wp-code-block-button-container {
 	position: sticky;
-	top: calc(var(--wp-global-header-height) + var(--wp-admin--admin-bar--height));
+	top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height));
 	z-index: 1;
 	display: flex;
 	justify-content: right;

--- a/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
@@ -198,7 +198,7 @@ pre.line-numbers > code {
 /* Copy button */
 .wp-code-block-button-container {
   position: sticky;
-  top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height));
+  top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height, 0px));
   z-index: 1;
   display: flex;
   justify-content: right;

--- a/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
@@ -197,8 +197,6 @@ pre.line-numbers > code {
 
 /* Copy button */
 .wp-code-block-button-container {
-  position: sticky;
-  top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height, 0px));
   z-index: 1;
   display: flex;
   justify-content: right;

--- a/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
@@ -198,7 +198,7 @@ pre.line-numbers > code {
 /* Copy button */
 .wp-code-block-button-container {
   position: sticky;
-  top: calc(var(--wp-global-header-height) + var(--wp-admin--admin-bar--height));
+  top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp-admin--admin-bar--height));
   z-index: 1;
   display: flex;
   justify-content: right;

--- a/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
+++ b/source/wp-content/themes/wporg-developer-2023/stylesheets/prism.css
@@ -255,5 +255,5 @@ pre.line-numbers > code {
 
 .wporg-developer-code-block::after {
   content: "";
-  margin-bottom: -1.63em;
+  margin-bottom: -1.1em;
 }

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -151,6 +151,11 @@
 						"top": "150px"
 					}
 				}
+			},
+			"local-navigation-bar": {
+				"spacing": {
+					"height": "60px"
+				}
 			}
 		},
 		"typography": {

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -151,11 +151,6 @@
 						"top": "150px"
 					}
 				}
-			},
-			"local-navigation-bar": {
-				"spacing": {
-					"height": "60px"
-				}
 			}
 		},
 		"typography": {


### PR DESCRIPTION
Fixes #373

This PR gives local-navigation-bar a 60px height so that the sticky header can set its `top` accurately.
Also make the shape of the code block rounded corners on the bottom complete
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/519.

## Screencast

https://github.com/WordPress/wporg-developer/assets/18050944/83469890-4f98-44fd-ada7-5092d2dce1e0

