### PR TITLE
Add styles for comment link modal

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -218,6 +218,7 @@ function init() {
 	add_action( 'pre_get_posts', __NAMESPACE__ . '\\pre_get_posts' );
 	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\theme_scripts_styles' );
 	add_action( 'add_meta_boxes', __NAMESPACE__ . '\\rename_comments_meta_box', 10, 2 );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_admin_styles' );
 
 	add_filter( 'post_type_link', __NAMESPACE__ . '\\method_permalink', 11, 2 );
 	add_filter( 'term_link', __NAMESPACE__ . '\\taxonomy_permalink', 10, 3 );
@@ -499,6 +500,18 @@ function theme_scripts_styles() {
 			true
 		);
 	}
+}
+
+/**
+ * Enqueue the editor styles.
+ */
+function enqueue_admin_styles() {
+	wp_enqueue_style(
+		'wporg-developer-2023-editor-style',
+		get_stylesheet_directory_uri() . '/build/editor-style/style-index.css',
+		array( 'editor-buttons' ),
+		filemtime( __DIR__ . '/build/editor-style/style-index.css' )
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-comments/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comments/block.php
@@ -17,6 +17,21 @@ function init() {
 			'render_callback' => __NAMESPACE__ . '\render',
 		)
 	);
+
+	// Ensure editor and dashicons styles are enqueued.
+	// When there are multiple comment forms this is not always the case.
+	// Handles must be different from default for these assets or they won't load.
+	// Don't include the version as we want the WordPress version.
+	wp_enqueue_style( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		'editor-buttons-style',
+		includes_url() . 'css/editor.css',
+		array(),
+	);
+	wp_enqueue_style( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		'dashicons-style',
+		includes_url() . 'css/dashicons.css',
+		array(),
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/editor-style/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/editor-style/block.json
@@ -1,0 +1,3 @@
+{
+	"script": "file:./index.js"
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/editor-style/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/editor-style/index.js
@@ -1,0 +1,2 @@
+// Noop, just imports the CSS for webpack.
+import './style.scss';

--- a/source/wp-content/themes/wporg-developer-2023/src/editor-style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/editor-style/style.scss
@@ -1,0 +1,16 @@
+// User notes styles.
+#wp-link-wrap {
+	height: 220px !important;
+	margin-top: -110px !important;
+
+	#link-selector {
+		position: unset;
+		padding-left: 16px;
+
+		#search-panel,
+		#wplink-link-existing-content,
+		#link-options .link-target {
+			display: none;
+		}
+	}
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -532,6 +532,11 @@ body[class] {
 	#wp-link-close {
 		top: var(--wp--preset--spacing--20);
 		right: var(--wp--preset--spacing--20);
+
+		&:hover,
+		&:focus {
+			color: var(--wp--custom--button--hover--color--background);
+		}
 	}
 
 	#wp-link input[type="text"] {
@@ -541,6 +546,41 @@ body[class] {
 	#wp-link .submitbox {
 		padding: var(--wp--preset--spacing--30);
 		border-top: unset;
+	}
+
+	/* stylelint-disable-next-line max-line-length */
+	// All these button styles match those from wporg-parent-2021 theme. See https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/sass/blocks/_button-mixins.scss
+	#wp-link-submit,
+	#wp-link-cancel button {
+		--wp--custom--button--spacing--padding--top: var(--wp--custom--button--small--spacing--padding--top);
+		--wp--custom--button--spacing--padding--bottom: var(--wp--custom--button--small--spacing--padding--bottom);
+		--wp--custom--button--spacing--padding--left: var(--wp--custom--button--small--spacing--padding--left);
+		--wp--custom--button--spacing--padding--right: var(--wp--custom--button--small--spacing--padding--right);
+
+		min-height: unset;
+		font-size: var(--wp--custom--button--small--typography--font-size);
+		border-radius: var(--wp--custom--button--border--radius);
+		line-height: var(--wp--custom--button--typography--line-height);
+		// Standard button does not have a border, so the padding needs to include border size.
+		// This ensures the outline and filled button are the same height.
+		border-width: 0;
+		padding-top: calc(var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+		/* stylelint-disable-next-line max-line-length */
+		padding-bottom: calc(var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+		padding-left: calc(var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+		/* stylelint-disable-next-line max-line-length */
+		padding-right: calc(var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+	}
+
+	#wp-link-close,
+	#wp-link-submit,
+	#wp-link-cancel button {
+		&:focus {
+			box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
+			outline: 1.5px solid var(--wp--custom--button--outline--focus--border--color);
+			outline-offset: -1.5px;
+			border: transparent;
+		}
 	}
 
 	#wp-link-submit {
@@ -556,9 +596,15 @@ body[class] {
 	}
 
 	#wp-link-cancel button {
-		color: var(--wp--custom--button--outline--color--text);
-		border-color: var(--wp--custom--button--outline--border--color);
 		background-color: var(--wp--custom--button--outline--color--background);
+		border: var(--wp--custom--button--border--width) solid var(--wp--custom--button--outline--border--color);
+		color: var(--wp--custom--button--outline--color--text);
+
+		// Padding does not account for border width.
+		padding-top: var(--wp--custom--button--spacing--padding--top);
+		padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+		padding-left: var(--wp--custom--button--spacing--padding--left);
+		padding-right: var(--wp--custom--button--spacing--padding--right);
 
 		&:hover {
 			color: var(--wp--custom--button--outline--hover--color--text);
@@ -568,7 +614,6 @@ body[class] {
 
 		&:focus {
 			color: var(--wp--custom--button--outline--focus--color--text);
-			border-color: var(--wp--custom--button--outline--focus--border--color);
 			background-color: var(--wp--custom--button--outline--focus--color--background);
 		}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -507,3 +507,14 @@ body[class] {
 		}
 	}
 }
+
+#wp-link-wrap {
+	height: 250px !important;
+	margin-top: -125px !important;
+}
+
+#link-selector #search-panel,
+#link-selector #wplink-link-existing-content,
+#link-selector #link-options .link-target {
+	display: none;
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -549,6 +549,10 @@ body[class] {
 		&:hover {
 			background-color: var(--wp--custom--button--hover--color--background);
 		}
+
+		&:active {
+			background-color: var(--wp--custom--button--active--color--background);
+		}
 	}
 
 	#wp-link-cancel button {
@@ -560,6 +564,18 @@ body[class] {
 			color: var(--wp--custom--button--outline--hover--color--text);
 			border-color: var(--wp--custom--button--outline--hover--border--color);
 			background-color: var(--wp--custom--button--outline--hover--color--background);
+		}
+
+		&:focus {
+			color: var(--wp--custom--button--outline--focus--color--text);
+			border-color: var(--wp--custom--button--outline--focus--border--color);
+			background-color: var(--wp--custom--button--outline--focus--color--background);
+		}
+
+		&:active {
+			color: var(--wp--custom--button--outline--active--color--text);
+			border-color: var(--wp--custom--button--outline--active--border--color);
+			background-color: var(--wp--custom--button--outline--active--color--background);
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -508,13 +508,58 @@ body[class] {
 	}
 }
 
+// User notes styles.
 #wp-link-wrap {
-	height: 250px !important;
-	margin-top: -125px !important;
-}
+	height: 320px !important;
+	margin-top: -160px !important;
 
-#link-selector #search-panel,
-#link-selector #wplink-link-existing-content,
-#link-selector #link-options .link-target {
-	display: none;
+	#link-selector {
+		position: unset !important;
+		padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--30) 0 !important;
+
+		#search-panel,
+		#wplink-link-existing-content,
+		#link-options .link-target {
+			display: none;
+		}
+	}
+
+	#link-modal-title {
+		padding: var(--wp--preset--spacing--20) var(--wp--preset--spacing--30);
+		border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+	}
+
+	#wp-link-close {
+		top: var(--wp--preset--spacing--20);
+		right: var(--wp--preset--spacing--20);
+	}
+
+	#wp-link input[type="text"] {
+		border: 1px solid var(--wp--preset--color--light-grey-1);
+	}
+
+	#wp-link .submitbox {
+		padding: var(--wp--preset--spacing--30);
+		border-top: unset;
+	}
+
+	#wp-link-submit {
+		background-color: var(--wp--custom--button--color--background);
+
+		&:hover {
+			background-color: var(--wp--custom--button--hover--color--background);
+		}
+	}
+
+	#wp-link-cancel button {
+		color: var(--wp--custom--button--outline--color--text);
+		border-color: var(--wp--custom--button--outline--border--color);
+		background-color: var(--wp--custom--button--outline--color--background);
+
+		&:hover {
+			color: var(--wp--custom--button--outline--hover--color--text);
+			border-color: var(--wp--custom--button--outline--hover--border--color);
+			background-color: var(--wp--custom--button--outline--hover--color--background);
+		}
+	}
 }


### PR DESCRIPTION
Fixes #392 

Fixes an issue where the modal for adding a link in a user note or feedback didn't appear when there is already a note added to the code reference item being viewed.

I discovered that the JS correctly activates the modal but the editor and dashicons styles are missing so the modal is shown at the bottom of the page, rather than over the top:

<img src="https://github.com/WordPress/wporg-developer/assets/1017872/2b587fb0-59cc-4f44-a676-61108c7fa68e" width="400">

The dashicons in the admin bar are also broken, only on this page:

![Screenshot 2023-11-29 at 11 50 28 AM](https://github.com/WordPress/wporg-developer/assets/1017872/642d7974-a394-47bb-a4a8-847c22c114cc)

I haven't been able to work out why the styles aren't enqueued correctly, (they should be added [here](https://github.com/WordPress/wordpress-develop/blob/a21f5a3cc054137f3ace4760db43845158fb3cc2/src/wp-includes/class-wp-editor.php#L209)), so this PR ensures they are loaded if the `code-comments` block is loaded. It isn't an issue if there aren't any notes submitted yet and only the `code-comment-form` block is loaded, so we don't need to do anything in that block.

I've also added styles to bring the modal more inline with the parent theme, using colors and spacing.

### Screenshots

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_reference_functions_is_admin_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/34f7b3f6-446c-4ef3-a3b7-bba7ed52d1bb) | ![localhost_8888_reference_functions_is_admin_(iPad)](https://github.com/WordPress/wporg-developer/assets/1017872/6c45e878-6c0f-4d94-a632-3bd5d13960c7) | ![localhost_8888_reference_functions_is_admin_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-developer/assets/1017872/045afb98-47a8-4e42-9703-60ee2793c339) |

### Testing

1. Add a user note on a code reference single page with no existing notes. Include a link to ensure it works.
2. Once the page reloads check in the devtools network tab that both editor.css and dashicons.css are loaded. The dashicons in the admin bar should be ok.
3. Add feedback on the first note, and include a link.
4. Add a new note and include a link.