### PR TITLE
Add back <p> tags via wpautop

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1880,6 +1880,9 @@ namespace DevHub {
 		// Restore original global post.
 		$post = $orig;
 
+		// Automatic paragraph and line break formatting in content.
+		add_filter( 'the_content', 'wpautop' );
+
 		// Restore filter.
 		add_filter( 'the_content', array( 'DevHub_Formatting', 'fix_unintended_markdown' ), 1 );
 


### PR DESCRIPTION
Fixes #396 

This PR uses `add_filter( 'the_content', 'wpautop' );` to add back the missing `<p>` for the Explanation content.

## Screenshot

| Before | After |
|-|-|
| ![image](https://github.com/WordPress/wporg-developer/assets/18050944/a6dfc412-7c6b-4a9e-9309-32bbaa61e917) | ![image](https://github.com/WordPress/wporg-developer/assets/18050944/20bfc0ab-ea22-4e7d-83a4-29d7e77c740b) |
| ![image](https://github.com/WordPress/wporg-developer/assets/18050944/cfd2f4fb-59d1-4b12-9e68-2f3e607436f5) | ![image](https://github.com/WordPress/wporg-developer/assets/18050944/b91ccba5-2f4a-4120-a1c3-a0056a5cd786) |
