### PR TITLE
Fix Code Reference: Missing parsed code styles  

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -11,6 +11,7 @@
 		.type {
 			font-family: var(--wp--preset--font-family--monospace);
 			font-size: var(--wp--preset--font-size--small);
+			color: var(--wp--preset--color--syntax-red);
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -11,7 +11,6 @@
 		.type {
 			font-family: var(--wp--preset--font-family--monospace);
 			font-size: var(--wp--preset--font-size--small);
-			color: var(--wp--preset--color--syntax-red);
 		}
 	}
 
@@ -74,5 +73,9 @@
 		cursor: pointer;
 		list-style: none;
 		text-decoration: underline;
+	}
+	
+	.type {
+		color: var(--wp--preset--color--syntax-red);
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -60,6 +60,12 @@
 		margin-left: 5px;
 	}
 
+	.type {
+		color: var(--wp--preset--color--syntax-red);
+		font-family: var(--wp--preset--font-family--monospace);
+		font-size: var(--wp--preset--font-size--small);
+	}
+
 	// Visible when parameters are imported from reference.
 	summary {
 		margin-top: var(--wp--preset--spacing--10);
@@ -67,11 +73,5 @@
 		cursor: pointer;
 		list-style: none;
 		text-decoration: underline;
-	}
-	
-	.type {
-		color: var(--wp--preset--color--syntax-red);
-		font-family: var(--wp--preset--font-family--monospace);
-		font-size: var(--wp--preset--font-size--small);
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -7,11 +7,6 @@
 		display: flex;
 		align-items: center;
 		gap: var(--wp--preset--spacing--10);
-
-		.type {
-			font-family: var(--wp--preset--font-family--monospace);
-			font-size: var(--wp--preset--font-size--small);
-		}
 	}
 
 	dt > code,
@@ -57,7 +52,6 @@
 	.param-hash .type {
 		padding: 4px 6px;
 		background-color: var(--wp--preset--color--light-grey-2);
-		font-size: var(--wp--preset--font-size--small);
 		border-radius: 2px;
 	}
 
@@ -77,5 +71,7 @@
 	
 	.type {
 		color: var(--wp--preset--color--syntax-red);
+		font-family: var(--wp--preset--font-family--monospace);
+		font-size: var(--wp--preset--font-size--small);
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
@@ -1,10 +1,5 @@
 .wp-block-wporg-code-reference-return-value {
-	.return-type {
-		font-family: var(--wp--preset--font-family--monospace);
-		font-size: var(--wp--preset--font-size--small);
-		color: var(--wp--preset--color--syntax-red);
-	}
-
+	.return-type,
 	.type {
 		font-family: var(--wp--preset--font-family--monospace);
 		font-size: var(--wp--preset--font-size--small);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
@@ -4,4 +4,10 @@
 		font-size: var(--wp--preset--font-size--small);
 		color: var(--wp--preset--color--syntax-red);
 	}
+
+	.type {
+		font-family: var(--wp--preset--font-family--monospace);
+		font-size: var(--wp--preset--font-size--small);
+		color: var(--wp--preset--color--syntax-red);
+	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-return-value/style.scss
@@ -2,5 +2,6 @@
 	.return-type {
 		font-family: var(--wp--preset--font-family--monospace);
 		font-size: var(--wp--preset--font-size--small);
+		color: var(--wp--preset--color--syntax-red);
 	}
 }


### PR DESCRIPTION
Fixes #322

Apply `syntax-red` to the parameter type.

## Screenshot

![image](https://github.com/WordPress/wporg-developer/assets/18050944/4c878bba-290e-4e53-abdf-6c310cedf75a)
