### PR TITLE
Improve UX of Related section

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-table/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-table/style.scss
@@ -30,7 +30,7 @@
 
 		td a {
 			text-decoration: underline;
-			word-break: break-all;
+			word-break: break-word;
 		}
 
 		tr td:first-child {
@@ -42,6 +42,7 @@
 
 		code {
 			color: var(--wp--preset--color--charcoal-4);
+			font-size: var(--wp--preset--font-size--small);
 			word-break: break-all;
 		}
 


### PR DESCRIPTION
Fixes #371

As suggested [here](https://github.com/WordPress/wporg-developer/issues/371#issuecomment-1812000401), set the file path font size as `14px` and the link as `word-break: break-word`.

## Screenshot

![image](https://github.com/WordPress/wporg-developer/assets/18050944/c622275e-18b8-468f-9c0e-08d484663057)
