### PR TITLE
Remove extra space above ToC when scrolled down the page

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -67,46 +67,38 @@
 
 
 .has-three-columns {
-	--local--sidebar--width: 232px;
-	--local--column-gap: 40px;
-
 	> * {
 		width: 100%;
 	}
 
 	main {
 		order: 1;
+		position: relative;
 	}
 
 	@media (min-width: 768px) {
 		flex-direction: row !important;
-		column-gap: var(--local--column-gap);
+		column-gap: var(--wp--custom--wporg-sidebar-container--spacing--gap);
 
 		aside {
-			width: var(--local--sidebar--width);
+			width: var(--wp--custom--wporg-sidebar-container--width);
 		}
 
 		main {
-			width: calc(100% - var(--local--sidebar--width) - var(--local--column-gap));
-		}
-
-		.wp-block-wporg-sidebar-container {
-			--local--block-end-sidebar--width: var(--local--sidebar--width);
+			/* stylelint-disable-next-line max-line-length */
+			width: calc(100% - var(--wp--custom--wporg-sidebar-container--width) - var(--wp--custom--wporg-sidebar-container--spacing--gap));
 		}
 	}
 
 	@media (min-width: 1200px) {
-		width: calc(100% - var(--local--sidebar--width) - var(--local--column-gap));
+		/* stylelint-disable-next-line max-line-length */
+		width: calc(100% - var(--wp--custom--wporg-sidebar-container--width) - var(--wp--custom--wporg-sidebar-container--spacing--gap));
 
 		article {
 			width: 100%;
 			max-width: 960px;
 			margin-left: auto;
 			margin-right: auto;
-		}
-
-		.wp-block-wporg-sidebar-container {
-			right: var(--wp--preset--spacing--edge-space);
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -144,13 +144,6 @@
 				"lineHeight": "var(--wp--custom--body--typography--line-height)",
 				"paddingVertical": "calc(( var(--wp--custom--select--height) - (var(--wp--custom--select--font-size) * var(--wp--custom--select--line-height))) / 2)",
 				"borderRadius": "var(--wp--custom--button--border--radius)"
-			},
-			"wporg-sidebar-container": {
-				"spacing": {
-					"margin": {
-						"top": "150px"
-					}
-				}
 			}
 		},
 		"typography": {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/issues/524
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/525

The ToC now scrolls up with the page until it reaches 60px below the fixed local nav (gap is proportional to the local nav height), where it becomes fixed. When scrolling to the bottom it will become unfixed when it reaches 80px above the footer (matches edge space).

The changes include fixing the logic for the bottom positioning, which likely broke when we recently made changes to the global header positioning.

### Before


### After