### PR TITLE
Fix the last updated date is not displaying

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
@@ -54,6 +54,9 @@ add_shortcode(
 	}
 );
 
+/**
+ * Only display the 'Last updated' if the modified date is later than the publishing date.
+ */
 add_shortcode(
 	'last_updated',
 	function() {

--- a/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
@@ -53,3 +53,14 @@ add_shortcode(
 		return '#';
 	}
 );
+
+add_shortcode(
+	'last_updated',
+	function() {
+		global $post;
+		if ( get_the_modified_date( 'Ymdhi', $post->ID ) > get_the_date( 'Ymdhi', $post->ID ) ) {
+			return '<p style="font-style:normal;font-weight:700">' . esc_html__( 'Last updated', 'wporg' ) . '</p>';
+		}
+		return '';
+	}
+);

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -25,6 +25,7 @@
 		<!-- wp:shortcode -->
 		[last_updated]
 		<!-- /wp:shortcode -->
+
 		<!-- wp:post-date {"displayType":"modified"} /-->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -22,10 +22,9 @@
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
-		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-		<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'Last updated', 'wporg' ); ?></p>
-		<!-- /wp:paragraph -->
-
+		<!-- wp:shortcode -->
+		[last_updated]
+		<!-- /wp:shortcode -->
 		<!-- wp:post-date {"displayType":"modified"} /-->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
Fixes #398

Since direct use of PHP conditions in the pattern isn't possible, I've implemented a shortcode solution. Now, the "Last updated" text only appears when the modified date is later than the publish date.

## Test Steps
1. Find a page that has no "Last updated" shows up.
2. Update the page.
3. "Last updated" should be there.
