### PR TITLE
Fix RTL layout

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/embed.php
+++ b/source/wp-content/themes/wporg-developer-2023/embed.php
@@ -125,7 +125,7 @@ $parameter_display_max = 4; // We truncate the display of params
 		}
 
 		.wp-embed-parameters code {
-			margin-right: 8px;
+			margin-inline-end: 8px;
 		}
 
 		.wp-embed-hook {

--- a/source/wp-content/themes/wporg-developer-2023/patterns/search-field.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/search-field.php
@@ -7,7 +7,7 @@
 
 ?>
 
-<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
 <div id="wporg-search" class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)">
 
 	<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_attr_e( 'Search resources', 'wporg' ); ?>","width":232,"widthUnit":"px","buttonText":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true} /-->

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -50,18 +50,13 @@
 			content: "";
 			display: inline-block;
 			position: absolute;
-			left: 0;
+			inset-inline-start: 0;
 			width: var(--local--icon-size);
 			height: var(--local--icon-size);
 			mask-image: url(../../images/dot.svg);
 			mask-repeat: no-repeat;
 			mask-position: center;
 			background-color: var(--wp--preset--color--charcoal-4);
-
-			[dir="rtl"] & {
-				left: unset;
-				right: 0;
-			}
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -37,13 +37,13 @@
 		margin-top: 0;
 		margin-bottom: 0;
 		list-style-type: none;
-		padding-left: 0;
+		padding-inline-start: 0;
 	}
 
 	li {
 		margin-block: calc(var(--wp--preset--spacing--20) / 4);
 		color: var(--wp--preset--color--charcoal-4);
-		padding-left: var(--local--icon-size);
+		padding-inline-start: var(--local--icon-size);
 		position: relative;
 
 		&::before {
@@ -57,12 +57,17 @@
 			mask-repeat: no-repeat;
 			mask-position: center;
 			background-color: var(--wp--preset--color--charcoal-4);
+
+			[dir="rtl"] & {
+				left: unset;
+				right: 0;
+			}
 		}
 	}
 
 	.children {
 		// Shift the children to the left by half the icon size, allowing for the dot width of 4px.
-		margin-left: calc((var(--local--icon-size) - 4px) * -0.5);
+		margin-inline-start: calc((var(--local--icon-size) - 4px) * -0.5);
 	}
 
 	a {
@@ -72,7 +77,7 @@
 
 	&.has-js-control {
 		.page_item_has_children {
-			padding-left: 0;
+			padding-inline-start: 0;
 
 			&::before {
 				display: none;
@@ -81,7 +86,7 @@
 
 		.children {
 			display: none;
-			padding-left: var(--local--icon-size);
+			padding-inline-start: var(--local--icon-size);
 
 			&.is-open {
 				display: revert;

--- a/source/wp-content/themes/wporg-developer-2023/src/code-comments/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comments/style.scss
@@ -27,8 +27,8 @@ a):not(.wporg-developer-code-block a) {
 				padding-bottom: var(--wp--preset--spacing--20);
 
 				> *:not(.comment-meta) {
-					padding-left: var(--wp--preset--spacing--20);
-					padding-right: var(--wp--preset--spacing--20);
+					padding-inline-start: var(--wp--preset--spacing--20);
+					padding-inline-end: var(--wp--preset--spacing--20);
 				}
 			}
 		}
@@ -45,7 +45,7 @@ a):not(.wporg-developer-code-block a) {
 	}
 
 	.comment-date {
-		margin-left: var(--wp--preset--spacing--10);
+		margin-inline-start: var(--wp--preset--spacing--10);
 		color: var(--wp--preset--color--charcoal-4);
 		text-decoration: none;
 	}
@@ -162,7 +162,7 @@ a):not(.wporg-developer-code-block a) {
 
 .wp-block-wporg-code-reference-comments-rules {
 	margin: var(--wp--style--block-gap) 0;
-	padding-left: var(--wp--preset--spacing--20);
+	padding-inline-start: var(--wp--preset--spacing--20);
 	list-style: disc;
 	font-size: var(--wp--preset--font-size--extra-small);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-comments/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comments/style.scss
@@ -46,6 +46,7 @@ a):not(.wporg-developer-code-block a) {
 
 	.comment-date {
 		margin-inline-start: var(--wp--preset--spacing--10);
+		margin-inline-end: calc(var(--wp--preset--spacing--10) / 2);
 		color: var(--wp--preset--color--charcoal-4);
 		text-decoration: none;
 	}
@@ -57,6 +58,10 @@ a):not(.wporg-developer-code-block a) {
 		border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
 		align-items: center;
 		justify-content: space-between;
+	}
+
+	.comment-author.vcard {
+		display: flex;
 	}
 
 	// If the first element is a code block, add space

--- a/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-parameters/style.scss
@@ -30,7 +30,7 @@
 
 	// Nested parameter list.
 	.param-hash {
-		padding-left: var(--wp--preset--spacing--10);
+		padding-inline-start: var(--wp--preset--spacing--10);
 		margin-top: var(--wp--preset--spacing--10);
 		border-left: 1px solid var(--wp--preset--color--light-grey-1);
 		list-style: none;
@@ -57,7 +57,7 @@
 
 	.default > code,
 	.param-hash .type {
-		margin-left: 5px;
+		margin-inline-start: 5px;
 	}
 
 	.type {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-short-title/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-short-title/style.scss
@@ -27,7 +27,7 @@
 	font-family: var(--wp--preset--font-family--monospace);
 	background: var(--wp--preset--color--light-grey-2);
 	border-radius: 2px;
-	margin-right: 8px;
+	margin-inline-end: 8px;
 	padding: 2px 8px;
 	font-weight: 500;
 	word-break: keep-all;

--- a/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
@@ -6,7 +6,7 @@
 		width: 23px;
 		position: relative;
 		top: 7px;
-		margin-right: 10px;
+		margin-inline-end: 10px;
 	}
 
 	.btn-group {
@@ -46,14 +46,14 @@
 
 			@media screen and (min-width: 380px) {
 				&.wporg-command-github-open {
-					margin-right: -6px;
-					border-top-right-radius: 0;
-					border-bottom-right-radius: 0;
+					margin-inline-end: -6px;
+					border-start-end-radius: 0;
+					border-end-end-radius: 0;
 				}
 
 				&.wporg-command-github-closed {
-					border-top-left-radius: 0;
-					border-bottom-left-radius: 0;
+					border-start-start-radius: 0;
+					border-end-start-radius: 0;
 				}
 			}
 		}

--- a/source/wp-content/themes/wporg-developer-2023/src/editor-style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/editor-style/style.scss
@@ -5,7 +5,7 @@
 
 	#link-selector {
 		position: unset;
-		padding-left: 16px;
+		padding-inline-start: 16px;
 
 		#search-panel,
 		#wplink-link-existing-content,

--- a/source/wp-content/themes/wporg-developer-2023/src/search-filters/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/search-filters/style.scss
@@ -15,7 +15,7 @@
 		padding: 0;
 		position: absolute;
 		top: 0;
-		left: 0;
+		inset-inline-start: 0;
 		width: 1px;
 		word-wrap: normal !important;
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -116,6 +116,11 @@ pre {
 
 		.wp-block-wporg-sidebar-container {
 			right: var(--wp--preset--spacing--edge-space);
+
+			[dir="rtl"] & {
+				left: var(--wp--preset--spacing--edge-space);
+				right: unset;
+			}
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -41,8 +41,8 @@ pre {
 		line-height: var(--wp--custom--body--extra-small--typography--line-height);
 		background: var(--wp--preset--color--light-grey-2);
 		border-radius: 2px;
-		padding-left: 3px;
-		padding-right: 3px;
+		padding-inline-start: 3px;
+		padding-inline-end: 3px;
 		max-width: 100%;
 	}
 
@@ -115,12 +115,7 @@ pre {
 		}
 
 		.wp-block-wporg-sidebar-container {
-			right: var(--wp--preset--spacing--edge-space);
-
-			[dir="rtl"] & {
-				left: var(--wp--preset--spacing--edge-space);
-				right: unset;
-			}
+			inset-inline-end: var(--wp--preset--spacing--edge-space);
 		}
 	}
 }
@@ -212,13 +207,13 @@ pre {
 	a {
 		position: relative;
 		text-decoration: underline;
-		margin-right: var(--wp--preset--spacing--10);
-		padding-right: var(--wp--preset--spacing--10);
+		margin-inline-end: var(--wp--preset--spacing--10);
+		padding-inline-end: var(--wp--preset--spacing--10);
 
 		&::after {
 			content: "\b7";
 			position: absolute;
-			right: -3px;
+			inset-block-end: -3px;
 		}
 
 		&:last-child::after {
@@ -260,7 +255,7 @@ pre {
 		list-style: none;
 		z-index: 1;
 		top: 0;
-		right: 0;
+		inset-inline-end: 0;
 
 		li {
 			min-width: 50px;
@@ -363,9 +358,9 @@ pre {
 		background-position: right var(--wp--custom--select--icon-position) center;
 		background-color: transparent;
 		padding-top: var(--wp--custom--select--padding-vertical);
-		padding-right: calc(var(--wp--custom--select--icon-position) + var(--wp--custom--select--icon-size));
+		padding-inline-end: calc(var(--wp--custom--select--icon-position) + var(--wp--custom--select--icon-size));
 		padding-bottom: var(--wp--custom--select--padding-vertical);
-		padding-left: var(--wp--custom--select--padding-left);
+		padding-inline-start: var(--wp--custom--select--padding-left);
 		font-size: var(--wp--custom--select--font-size);
 		line-height: var(--wp--custom--select--line-height);
 		border-radius: var(--wp--custom--select--border-radius);
@@ -497,13 +492,13 @@ pre {
 
 	.line-numbers-rows > span::before {
 		text-align: left;
-		padding-left: var(--wp--preset--spacing--10);
+		padding-inline-start: var(--wp--preset--spacing--10);
 	}
 }
 
 .code-tabs {
 	> button {
-		margin-right: var(--wp--preset--spacing--10);
+		margin-inline-end: var(--wp--preset--spacing--10);
 	}
 
 	.code-tab-block {
@@ -536,7 +531,7 @@ pre {
 
 	#wp-link-close {
 		top: var(--wp--preset--spacing--20);
-		right: var(--wp--preset--spacing--20);
+		inset-inline-end: var(--wp--preset--spacing--20);
 
 		&:hover,
 		&:focus {
@@ -572,9 +567,10 @@ pre {
 		padding-top: calc(var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
 		/* stylelint-disable-next-line max-line-length */
 		padding-bottom: calc(var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
-		padding-left: calc(var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
 		/* stylelint-disable-next-line max-line-length */
-		padding-right: calc(var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+		padding-inline-start: calc(var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+		/* stylelint-disable-next-line max-line-length */
+		padding-inline-end: calc(var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
 	}
 
 	#wp-link-close,
@@ -608,8 +604,8 @@ pre {
 		// Padding does not account for border width.
 		padding-top: var(--wp--custom--button--spacing--padding--top);
 		padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-		padding-left: var(--wp--custom--button--spacing--padding--left);
-		padding-right: var(--wp--custom--button--spacing--padding--right);
+		padding-inline-start: var(--wp--custom--button--spacing--padding--left);
+		padding-inline-end: var(--wp--custom--button--spacing--padding--right);
 
 		&:hover {
 			color: var(--wp--custom--button--outline--hover--color--text);

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -170,13 +170,14 @@ pre {
 }
 
 .home {
-	.search-wrap div.awesomplete > ul {
-		top: 46px;
-	}
-
 	.entry-content {
 		--wp--preset--spacing--60: clamp(40px, 5.55556vw, 80px);
 	}
+}
+
+.wp-block-search div.awesomplete > ul {
+	left: unset;
+	inset-inline-start: 0;
 }
 
 // Style code tags but not ones inside of the code block.

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -67,6 +67,11 @@ pre {
 			left: var(--wp--preset--spacing--60);
 		}
 	}
+
+	.is-content-justification-left > * {
+		margin-left: unset !important;
+		margin-right: 0 !important;
+	}
 }
 
 

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -55,25 +55,11 @@ pre {
 	display: block;
 }
 
-[dir="rtl"] {
-	.is-sticky .wp-block-navigation.is-style-dropdown-on-mobile {
-		.wp-block-navigation__responsive-container-open {
-			right: unset;
-			left: 0;
-		}
-
-		.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-close {
-			right: unset;
-			left: var(--wp--preset--spacing--60);
-		}
-	}
-
-	.is-content-justification-left > * {
-		margin-left: unset !important;
-		margin-right: 0 !important;
-	}
+.is-content-justification-left > .wp-block-group {
+	margin-left: unset !important;
+	margin-right: unset !important;
+	margin-inline-start: 0;
 }
-
 
 .has-three-columns {
 	--local--sidebar--width: 232px;

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -470,6 +470,7 @@ pre {
 
 	.wp-block-code {
 		border-radius: 0 0 $border_radius $border_radius;
+		direction: ltr;
 
 		code {
 			font-family: var(--wp--preset--font-family--monospace);

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -55,7 +55,7 @@ pre {
 	display: block;
 }
 
-.is-content-justification-left > .wp-block-group {
+.is-content-justification-left > [class*="wp-block-"] {
 	margin-left: unset !important;
 	margin-right: unset !important;
 	margin-inline-start: 0;


### PR DESCRIPTION
Fixes #272 

The mu-plugins blocks (ToC, sidebar container, global header, local navigation, etc) all ship with a `style-rtl.css` stylesheet so they already work, apart from one issue with the Global Header hamburger menu, seen in the screnshots below. This needs to be fixed separately.

This PR replaces all `*left` and `*right` CSS properties with their locigal peoperty equivalents, so that the margin padding or positioning is flipped by the browser when the direction changes. This negates the need for any `dir="rtl"` styles 🎉 

### Selected screenshots

#### Home

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_(Desktop) (15)](https://github.com/WordPress/wporg-developer/assets/1017872/25506fa1-fae1-4b56-90b5-60aec28f5718) | ![localhost_8888_(iPad) (3)](https://github.com/WordPress/wporg-developer/assets/1017872/dd15e7ba-5e87-46b9-a3dd-e6645d3dd4e3) | ![localhost_8888_(Samsung Galaxy S20 Ultra) (14)](https://github.com/WordPress/wporg-developer/assets/1017872/5dbdc1a8-2dca-4600-b681-9471dbbe9bc0) |

#### Single

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_reference_classes_wp_query_(Desktop)](https://github.com/WordPress/wporg-developer/assets/1017872/9607f7db-d281-41fd-8eeb-0fd2741f08b5) | ![localhost_8888_reference_classes_wp_query_(iPad)](https://github.com/WordPress/wporg-developer/assets/1017872/939fc76f-b4e0-45cd-a087-0aaa45459b67) | ![localhost_8888_reference_classes_wp_query_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-developer/assets/1017872/c0cfb26e-cc56-4a61-b41c-6f39719b4ecf) |

#### Handbook

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_block-editor_(Desktop) (1)](https://github.com/WordPress/wporg-developer/assets/1017872/dde81e95-b3a1-4586-a699-764ea79f70e0) | ![localhost_8888_block-editor_(iPad)](https://github.com/WordPress/wporg-developer/assets/1017872/c863f172-2ece-4dba-af9b-71ed9644fd5e) | ![localhost_8888_block-editor_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-developer/assets/1017872/f42fea40-33ae-48fc-a483-5f8a21cad0db) |

### Testing

1. Regression test the whole site in regular LTR mode.
2. In the General settings of the WP Admin, change the Site Language to a RTL language, eg. Arabic.
3. Reload the frontend and test the whole site. Everything should flip and margins, padding and positioning should work i reverse.