### PR TITLE
Remove extra p and a tags from the explanation content

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/explanations.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/explanations.php
@@ -106,6 +106,7 @@ class WPORG_Explanations {
 			'supports'          => array( 'editor', 'revisions' ),
 			'rewrite'           => false,
 			'query_var'         => false,
+			'show_in_rest'      => true,
 		) );
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1848,9 +1848,6 @@ namespace DevHub {
 	function get_explanation_content( $_post ) {
 		global $post;
 
-		// Temporarily remove filter.
-		remove_filter( 'the_content', array( 'DevHub_Formatting', 'fix_unintended_markdown' ), 1 );
-
 		// Store original global post.
 		$orig = $post;
 
@@ -1874,17 +1871,14 @@ namespace DevHub {
 			$content = get_explanation_field( 'post_content', $_post );
 		}
 
-		// Pass the content through expected content filters.
-		$content = apply_filters( 'the_content', apply_filters( 'get_the_content', $content ) );
+		// Sanitize message content.
+		$content = wp_kses_post( $content );
+
+		// Remove the {@see} tag, leaving only the function name, so that there'd be no extra a tags being rendered.
+		$content = preg_replace( '/\{@see (.*?)\}/', '$1', $content );
 
 		// Restore original global post.
 		$post = $orig;
-
-		// Automatic paragraph and line break formatting in content.
-		add_filter( 'the_content', 'wpautop' );
-
-		// Restore filter.
-		add_filter( 'the_content', array( 'DevHub_Formatting', 'fix_unintended_markdown' ), 1 );
 
 		return $content;
 	}


### PR DESCRIPTION
Fixes #413 

Initially, I tried using regex to parse content, only processing `<p>` tags. Despite this, although many `<p>` tags were eliminated, there were still `<p></p>` tags generated above and below `<h2>`, `<h3>` tags. I think this is because of an attempt to render `<heading>` that's from classic editor in the block theme. Although I could also use another regex to process these `<heading>` tags, I think that would complicate the code. 

So, I started looking for a Gutenberg API that could directly convert content into blocks, but the `$parsed_blocks = parse_blocks($content);` + `$block_content = serialize_blocks($parsed_blocks);` approach didn't work.

Therefore, in the end, I thought about directly converting the classic editor into a GB editor and then using the 'convert to blocks' feature for the conversion.

![image](https://github.com/WordPress/wporg-developer/assets/18050944/dbfdc2ac-51d5-4d75-833a-f9aa63003bf7)

This indeed successfully removed all the redundant `<p>` tags

--

Next, I addressed the issue of redundant `<a>` tags. The reason for these extra `<a>` tags primarily come from adding `$content = apply_filters( 'the_content', apply_filters( 'get_the_content', $content ) );`, and also from using the `@see` tag from phpDocumentor in the editor. 

So I removed the filter as well as got rid of the `{@see}` and left the original function name, the content can then be parsed normally without generating extra <a> tags.

## Screencast

In axeDevTools, all related issues have been resolved.

![Screenshot 2023-12-13 at 21 30 05](https://github.com/WordPress/wporg-developer/assets/18050944/2a00a8c8-3170-4b14-9f3e-6148c4f5157c)

Then, in Lighthouse, the score seems to have improved, but this is on a local basis. I notice there is still an excessive DOM size.

![image](https://github.com/WordPress/wporg-developer/assets/18050944/cd364498-b51a-4160-8dd4-35bbbcad3d44)
![image](https://github.com/WordPress/wporg-developer/assets/18050944/f6a7eba1-91a3-495d-9830-d69910b9c014)

## Note

1. This method requires going into posts and clicking the Convert to Blocks button to switch the content. I am not aware of any function that can achieve this. I've browsed around but didn't find anything. Perhaps it's possible to refer to the Gutenberg source code [here](https://github.com/WordPress/gutenberg/blob/a51534b6b374879e602c41ee171563452ac9115f/packages/block-library/src/freeform/convert-to-blocks-button.js#L22) for this, but it might be faster to convert manually than to understand this code.

2. Then, in transitioning from the classic editor to the GB editor, the only difference I see is the disappearance of the 'Associated with' at the top of the edit screen. I feel this is okay as the 'Preview in new tab' feature of the Block Editor still allows viewing the complete page. Additionally, the code can be adjusted later to add it back.

![image](https://github.com/WordPress/wporg-developer/assets/18050944/461557d1-1adf-41d5-b91e-1d7083b84860)
