### PR TITLE
Update inline code padding and use border-radius variable

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -182,10 +182,7 @@ pre {
 
 // Style code tags but not ones inside of the code block.
 .wporg-has-embedded-code *:not(.wp-block-code):not(.wp-code-block-button-container) > code {
-	padding: 4px 6px;
-	background-color: var(--wp--preset--color--light-grey-2);
 	font-size: var(--wp--preset--font-size--small);
-	border-radius: var(--wp--custom--button--border--radius);
 }
 
 .wporg-dot-link-list {

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -32,7 +32,7 @@ pre {
 		padding: 20px;
 		background-color: #f7f7f7;
 		border: 1px solid var(--wp--preset--color--light-grey-1);
-		border-radius: var(--wp--custom--button--border--radius);
+		border-radius: var(--wp--custom--code--border--radius);
 		overflow: scroll;
 	}
 
@@ -40,7 +40,7 @@ pre {
 		display: inline-block;
 		line-height: var(--wp--custom--body--extra-small--typography--line-height);
 		background: var(--wp--preset--color--light-grey-2);
-		border-radius: var(--wp--custom--button--border--radius);
+		border-radius: var(--wp--custom--code--border--radius);
 		padding-inline-start: 0.25em;
 		padding-inline-end: 0.25em;
 		max-width: 100%;
@@ -432,7 +432,7 @@ pre {
 
 .wporg-developer-code-block {
 	$half_padding: calc(var(--wp--preset--spacing--10) / 2);
-	$border_radius: var(--wp--custom--button--border--radius);
+	$border_radius: var(--wp--custom--code--border--radius);
 
 	.wp-code-block-button-container {
 		background-color: var(--wp--preset--color--light-grey-2);

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -32,7 +32,7 @@ pre {
 		padding: 20px;
 		background-color: #f7f7f7;
 		border: 1px solid var(--wp--preset--color--light-grey-1);
-		border-radius: 2px;
+		border-radius: var(--wp--custom--button--border--radius);
 		overflow: scroll;
 	}
 
@@ -40,9 +40,9 @@ pre {
 		display: inline-block;
 		line-height: var(--wp--custom--body--extra-small--typography--line-height);
 		background: var(--wp--preset--color--light-grey-2);
-		border-radius: 2px;
-		padding-inline-start: 3px;
-		padding-inline-end: 3px;
+		border-radius: var(--wp--custom--button--border--radius);
+		padding-inline-start: 0.25em;
+		padding-inline-end: 0.25em;
 		max-width: 100%;
 	}
 
@@ -185,7 +185,7 @@ pre {
 	padding: 4px 6px;
 	background-color: var(--wp--preset--color--light-grey-2);
 	font-size: var(--wp--preset--font-size--small);
-	border-radius: 2px;
+	border-radius: var(--wp--custom--button--border--radius);
 }
 
 .wporg-dot-link-list {
@@ -435,7 +435,7 @@ pre {
 
 .wporg-developer-code-block {
 	$half_padding: calc(var(--wp--preset--spacing--10) / 2);
-	$border_radius: 2px;
+	$border_radius: var(--wp--custom--button--border--radius);
 
 	.wp-code-block-button-container {
 		background-color: var(--wp--preset--color--light-grey-2);
@@ -633,7 +633,7 @@ pre {
 	color: var(--wp--custom--wporg-callout--color--text);
 	background-color: var(--wp--custom--wporg-callout--color--background);
 	border-width: 0;
-	border-radius: 2px;
+	border-radius: var(--wp--custom--button--border--radius);
 	font-size: var(--wp--preset--font-size--small);
 
 	&::before {


### PR DESCRIPTION
This is a minor tweak to inline code styles. Previously, the padding was hardcoded and did not adjust based on the size of the font. There are a few instances where inline code is used in headings. 

This PR updates the left and right padding to `0.25em`. This translates to a padding increase of `1px` to `4px` for article copy. 

While adjusting the padding, I also updated all instances of `border-radius: 2px` to use the custom variable. 