### PR TITLE
Add blockquote styles

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -28,6 +28,13 @@ pre {
 		}
 	}
 
+	blockquote {
+		border-left: 2px solid var(--wp--preset--color--charcoal-1);
+		margin-left: 0;
+		margin-right: 0;
+		padding-left: var(--wp--preset--spacing--20);
+	}
+
 	pre:not(.wp-block-code) {
 		padding: 20px;
 		background-color: #f7f7f7;


### PR DESCRIPTION
Fixes #390 

Adds `blockquote` styling. 

| Before | After |
|-|-|
|<img width="350" alt="image" src="https://github.com/WordPress/wporg-developer/assets/4832319/0cd9e335-e15f-47f2-a83e-0abf0ca045f3">|<img width="350" alt="image" src="https://github.com/WordPress/wporg-developer/assets/4832319/224755f4-fda7-4972-9afd-927adb6865af">|