### PR TITLE
Increase banner font-size on Front Page

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/front-page-header.php
@@ -40,8 +40,8 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}},"backgroundColor":"lemon-3","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-lemon-3-background-color has-background" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)">
 
-	<!-- wp:paragraph {"align":"center","fontSize":"extra-small"} -->
-	<p class="has-text-align-center has-extra-small-font-size"><?php echo wp_kses_post(
+	<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+	<p class="has-text-align-center has-small-font-size"><?php echo wp_kses_post(
 		sprintf(
 		/* translators: %1$s: version link, %2$s: version number */
 			__( 'See <a href="%1$s">what has changed</a> in the WordPress %2$s API.', 'wporg' ),


### PR DESCRIPTION
Given the font-size, I have found the "See what has changed in the WordPress 6.4 API." banner on the Front Page very hard to read. 

This PR bumps up the size to `small` instead of `extra-small`.

|Before|After|
|-|-|
|<img width="777" alt="image" src="https://github.com/WordPress/wporg-developer/assets/4832319/10ad9226-dd0e-4a34-9658-b36ab241ce22">|<img width="777" alt="image" src="https://github.com/WordPress/wporg-developer/assets/4832319/9067f9d3-d0d8-4079-9754-c2eb69441d65">|
