### PR TITLE
Abstract article meta GitHub for use in different contexts

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
@@ -7,7 +7,6 @@
 
 use function DevHub\is_parsed_post_type;
 
-
 add_filter( 'render_block', __NAMESPACE__ . '\filter_article_meta_block', 10, 2 );
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
@@ -7,6 +7,9 @@
 
 use function DevHub\is_parsed_post_type;
 
+
+add_filter( 'render_block', __NAMESPACE__ . '\filter_article_meta_block', 10, 2 );
+
 /**
  * Filters the search block and conditionally inserts search filters.
  *
@@ -47,4 +50,38 @@ function get_block_content_by_home_url( $block_content, $replacement_home_url = 
 		'action="' . esc_url( $replacement_home_url ) . '"',
 		$block_content
 	);
+}
+
+/**
+ * Filters the article meta block and conditionally removes it.
+ *
+ * @param string $block_content
+ * @param array  $block
+ * @return string
+ */
+function filter_article_meta_block( $block_content, $block ) {
+	if ( 'wporg/article-meta-github' === $block['blockName'] ) {
+		$github_handbooks = array(
+			'wpcs-handbook',
+			'blocks-handbook',
+			'rest-api-handbook',
+			'cli-handbook',
+			'adv-admin-handbook',
+		);
+
+		$post_type = get_post_type();
+
+		// Not all handbooks come from GitHub.
+		if ( ! in_array( $post_type, $github_handbooks, true ) ) {
+			return '';
+		}
+
+		// The block editor handbook doesn't have a changelog.
+		// We only know it's the changelog because of the linkURL attribute.
+		if ( 'blocks-handbook' === $post_type && '[article_changelog_link]' === $block['attrs']['linkURL'] ) {
+			return '';
+		}
+	}
+
+	return $block_content;
 }

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -30,6 +30,8 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:wporg/article-meta-github {"editLinkURL":"[article_edit_link]","handbooks":["wpcs-handbook","blocks-handbook","rest-api-handbook","cli-handbook","adv-admin-handbook"]} /-->
+	<!-- wp:wporg/article-meta-github {"heading":"<?php esc_html_e( 'Edit article', 'wporg' ); ?>","linkURL":"[article_edit_link]","text":"<?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?>"} /-->
+	<!-- wp:wporg/article-meta-github {"heading":"<?php esc_html_e( 'Changelog', 'wporg' ); ?>","linkURL":"[article_changelog_link]","text":"<?php esc_html_e( 'See list of changes', 'wporg' ); ?>"} /-->
+
 </div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -30,8 +30,9 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:wporg/article-meta-github {"heading":"<?php esc_html_e( 'Edit article', 'wporg' ); ?>","linkURL":"[article_edit_link]","text":"<?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?>"} /-->
-	<!-- wp:wporg/article-meta-github {"heading":"<?php esc_html_e( 'Changelog', 'wporg' ); ?>","linkURL":"[article_changelog_link]","text":"<?php esc_html_e( 'See list of changes', 'wporg' ); ?>"} /-->
+	<!-- wp:wporg/article-meta-github {"heading":"<?php esc_html_e( 'Edit article', 'wporg' ); ?>","linkURL":"[article_edit_link]","linkText":"<?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?>"} /-->
+	
+	<!-- wp:wporg/article-meta-github {"heading":"<?php esc_html_e( 'Changelog', 'wporg' ); ?>","linkURL":"[article_changelog_link]","linkText":"<?php esc_html_e( 'See list of changes', 'wporg' ); ?>"} /-->
 
 </div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -30,6 +30,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:wporg/article-meta-github /-->
+	<!-- wp:wporg/article-meta-github {"editLinkURL":"[article_edit_link]","handbooks":["wpcs-handbook","blocks-handbook","rest-api-handbook","cli-handbook","adv-admin-handbook"]} /-->
 </div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.json
@@ -8,7 +8,16 @@
 	"icon": "smiley",
 	"description": "",
 	"usesContext": [ "postId", "postType" ],
-	"attributes": {},
+	"attributes": {
+		"handbooks": {
+			"type": "array",
+			"default": []
+		},
+		"editLinkURL": {
+			"type": "string",
+			"default": ""
+		}
+	},
 	"supports": {
 		"inserter": false
 	},

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.json
@@ -9,15 +9,15 @@
 	"description": "",
 	"usesContext": [ "postId", "postType" ],
 	"attributes": {
-		"linkUrl": {
-			"type": "string",
-			"default": ""
-		},
 		"heading": {
 			"type": "string",
 			"default": ""
 		},
-		"text": {
+		"linkText": {
+			"type": "string",
+			"default": ""
+		},
+		"linkUrl": {
 			"type": "string",
 			"default": ""
 		}

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.json
@@ -9,11 +9,15 @@
 	"description": "",
 	"usesContext": [ "postId", "postType" ],
 	"attributes": {
-		"handbooks": {
-			"type": "array",
-			"default": []
+		"linkUrl": {
+			"type": "string",
+			"default": ""
 		},
-		"editLinkURL": {
+		"heading": {
+			"type": "string",
+			"default": ""
+		},
+		"text": {
 			"type": "string",
 			"default": ""
 		}

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
@@ -29,21 +29,13 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes, $content, $block ) {
-	$github_handbooks = array(
-		'wpcs-handbook',
-		'blocks-handbook',
-		'rest-api-handbook',
-		'cli-handbook',
-		'adv-admin-handbook',
-	);
-
 	$post_type = $block->context['postType'];
 	$post_id = $block->context['postId'];
 
 	if (
 		! isset( $post_id )
 		|| ! isset( $post_type )
-		|| ! in_array( $post_type, $github_handbooks, true )
+		|| ! in_array( $post_type, $attributes['handbooks'], true )
 	) {
 		return '';
 	}
@@ -60,13 +52,14 @@ function render( $attributes, $content, $block ) {
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"className":"external-link"} -->
-				<p class="external-link"><a href="[article_edit_link]">%2$s</a></p>
+				<p class="external-link"><a href="%2$s">%3$s</a></p>
 				<!-- /wp:paragraph -->
 
 			</div>
 			<!-- /wp:group -->'
 		),
 		esc_html__( 'Edit article', 'wporg' ),
+		esc_url( $attributes['editLinkURL'] ),
 		sprintf(
 			/* translators: %s: article title */
 			__( 'Improve it on GitHub<span class="screen-reader-text">: %s</span>', 'wporg' ),

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
@@ -35,14 +35,13 @@ function render( $attributes, $content, $block ) {
 	if (
 		! isset( $post_id )
 		|| ! isset( $post_type )
-		|| ! in_array( $post_type, $attributes['handbooks'], true )
 	) {
 		return '';
 	}
 
 	$title = get_the_title( $post_id );
 
-	$content = sprintf(
+	return sprintf(
 		do_blocks(
 			'<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group">
@@ -58,40 +57,13 @@ function render( $attributes, $content, $block ) {
 			</div>
 			<!-- /wp:group -->'
 		),
-		esc_html__( 'Edit article', 'wporg' ),
-		esc_url( $attributes['editLinkURL'] ),
+		esc_html__( $attributes['heading'], 'wporg' ),
+		esc_url( $attributes['linkURL'] ),
 		sprintf(
 			/* translators: %s: article title */
-			__( 'Improve it on GitHub<span class="screen-reader-text">: %s</span>', 'wporg' ),
+			__( '%1$s<span class="screen-reader-text">: %2$s"</span>', 'wporg' ),
+			esc_html( $attributes['text'] ),
 			esc_html( $title )
 		)
 	);
-
-	if ( 'blocks-handbook' !== $post_type ) {
-		$content .= sprintf(
-			do_blocks(
-				'<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group">
-
-					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-					<p style="font-style:normal;font-weight:700">%1$s</p>
-					<!-- /wp:paragraph -->
-
-					<!-- wp:paragraph {"className":"external-link"} -->
-					<p class="external-link"><a href="[article_changelog_link]">%2$s</a></p>
-					<!-- /wp:paragraph -->
-					
-				</div>
-				<!-- /wp:group -->'
-			),
-			esc_html__( 'Changelog', 'wporg' ),
-			sprintf(
-				/* translators: %s: article title */
-				__( 'See list of changes<span class="screen-reader-text">: %s</span>', 'wporg' ),
-				esc_html( $title )
-			)
-		);
-	}
-
-	return $content;
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
@@ -33,8 +33,7 @@ function render( $attributes, $content, $block ) {
 	$post_id = $block->context['postId'];
 
 	if (
-		! isset( $post_id )
-		|| ! isset( $post_type )
+		! isset( $post_id ) || ! isset( $post_type )
 	) {
 		return '';
 	}
@@ -57,12 +56,12 @@ function render( $attributes, $content, $block ) {
 			</div>
 			<!-- /wp:group -->'
 		),
-		esc_html__( $attributes['heading'], 'wporg' ),
+		esc_html( $attributes['heading'] ),
 		esc_url( $attributes['linkURL'] ),
 		sprintf(
-			/* translators: %s: article title */
+			/* translators: %1$s: call to action, %2$s: article title */
 			__( '%1$s<span class="screen-reader-text">: %2$s"</span>', 'wporg' ),
-			esc_html( $attributes['text'] ),
+			esc_html( $attributes['linkText'] ),
 			esc_html( $title )
 		)
 	);


### PR DESCRIPTION
I added this abstraction so we can use this component in other themes (documentation/data-liberation). 

Ideally, once this merges, we could then move it to the [wporg-mu-plugin](https://github.com/wordpress/wporg-mu-plugins) repository. I didn't want to make those changes in one large PR.

## Changes
- Pass in the `heading`, `text` and `linkURL`.
- Remove logic related to conditional displaying of the block.
- Add block hooks to handle the conditional rendering.

## Considerations
In order to check if the block is being used for the changelog, which doesn't exist on the block-editor handbook, I had to use the url in the check:

https://github.com/WordPress/wporg-developer/pull/454/files#diff-d2b871ec9cde93c4a3003771e7339d18ebe322f91a523dd3c9405aa95b61b5f3R81

I don't think that is ideal since that could change in the future. I thought about adding an ID attribute but that could get out of sync as well. I'm figuring that it should be good enough.

What do ya'll think?







