### PR TITLE
Fix the paged home page handler 404 response

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/redirects.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/redirects.php
@@ -135,7 +135,17 @@ class DevHub_Redirects {
 	public static function paginated_home_page_404() {
 		// Paginated front page.
 		if ( is_front_page() && is_paged() ) {
-			include( get_template_directory() . '/404.php' );
+			// Add the usual 404 page body class so that styles are applied.
+			add_filter(
+				'body_class',
+				function( $classes ) {
+					$classes[] = 'error404';
+
+					return $classes;
+				}
+			);
+
+			include( get_404_template() );
 			exit;
 		}
 	}


### PR DESCRIPTION
Fixes #458 by updating the classic theme 404 template include with a block theme compatible one.

### Testing

1. Load http://localhost:8888/page/4/
2. Observe that the 404 page loads and is styled correctly, compared to a typical 404 like http://localhost:8888/blah