### PR TITLE
Remove GitHub handbook last updated date 

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -150,6 +150,7 @@ require __DIR__ . '/inc/shortcode-dashicons.php';
 require __DIR__ . '/inc/block-hooks.php';
 
 // Block files
+require_once __DIR__ . '/src/article-meta-date/block.php';
 require_once __DIR__ . '/src/article-meta-github/block.php';
 require_once __DIR__ . '/src/chapter-list/block.php';
 require_once __DIR__ . '/src/cli-command-table/block.php';

--- a/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/block-hooks.php
@@ -52,32 +52,37 @@ function get_block_content_by_home_url( $block_content, $replacement_home_url = 
 }
 
 /**
- * Filters the article meta block and conditionally removes it.
+ * Filters an article meta block and conditionally removes it.
  *
  * @param string $block_content
  * @param array  $block
  * @return string
  */
-function filter_article_meta_block( $block_content, $block ) {
-	if ( 'wporg/article-meta-github' === $block['blockName'] ) {
-		$github_handbooks = array(
-			'wpcs-handbook',
-			'blocks-handbook',
-			'rest-api-handbook',
-			'cli-handbook',
-			'adv-admin-handbook',
-		);
+function filter_article_meta_block( $block_content, $block ) {	
+	// Not all handbooks come from GitHub.
+	$local_handbooks = array( 'plugin-handbook', 'theme-handbook' );
 
+	if ( 'wporg/article-meta-github' === $block['blockName'] ) {
 		$post_type = get_post_type();
 
-		// Not all handbooks come from GitHub.
-		if ( ! in_array( $post_type, $github_handbooks, true ) ) {
+		if ( in_array( $post_type, $local_handbooks ) ) {
 			return '';
 		}
 
 		// The block editor handbook doesn't have a changelog.
 		// We only know it's the changelog because of the linkURL attribute.
 		if ( 'blocks-handbook' === $post_type && '[article_changelog_link]' === $block['attrs']['linkURL'] ) {
+			return '';
+		}
+	}
+
+	if ( 'wporg/article-meta-date' === $block['blockName'] ) {
+		$post_type = get_post_type();
+
+		// Last modified date for handbooks from GitHub is the last import date, rather than the edited date.
+		// Don't display until we have the edited date from GitHub.
+		// See https://github.com/WordPress/wporg-developer/issues/456
+		if ( wporg_is_handbook_post_type() && ! in_array( $post_type, $local_handbooks ) && '[last_updated]' === $block['attrs']['heading'] ) {
 			return '';
 		}
 	}

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -10,25 +10,9 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|20"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","verticalAlignment":"top"},"className":"entry-meta"} -->
 <div class="wp-block-group entry-meta" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group">
-		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-		<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'First published', 'wporg' ); ?></p>
-		<!-- /wp:paragraph -->
+	<!-- wp:wporg/article-meta-date {"heading":"<?php esc_html_e( 'First published', 'wporg' ); ?>"} /-->
 
-		<!-- wp:post-date /-->
-	</div>
-	<!-- /wp:group -->
-
-	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group">
-		<!-- wp:shortcode -->
-		[last_updated]
-		<!-- /wp:shortcode -->
-
-		<!-- wp:post-date {"displayType":"modified"} /-->
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:wporg/article-meta-date {"heading":"[last_updated]","displayType":"modified"} /-->
 
 	<!-- wp:wporg/article-meta-github {"heading":"<?php esc_html_e( 'Edit article', 'wporg' ); ?>","linkURL":"[article_edit_link]","linkText":"<?php esc_html_e( 'Improve it on GitHub', 'wporg' ); ?>"} /-->
 	

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/article-meta-date",
+	"version": "0.1.0",
+	"title": "Article Meta Date",
+	"category": "widgets",
+	"icon": "smiley",
+	"description": "",
+	"usesContext": [],
+	"attributes": {
+		"heading": {
+			"type": "string",
+			"default": ""
+		},
+		"displayType": {
+			"type": "string",
+			"default": "published"
+		}
+	},
+	"supports": {
+		"inserter": false
+	},
+	"textdomain": "wporg",
+	"editorScript": "file:./index.js"
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/block.php
@@ -45,7 +45,7 @@ function render( $attributes, $content, $block ) {
 		do_blocks(
 			sprintf(
 				'<!-- wp:post-date {"displayType":"%s"} /-->',
-				$attributes['displayType']
+				esc_js( $attributes['displayType'] ),
 			),
 		),
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/block.php
@@ -1,0 +1,52 @@
+<?php
+namespace WordPressdotorg\Theme\Developer_2023\Article_Meta_Date;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/article-meta-date',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	return sprintf(
+		do_blocks(
+			'<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+				<p style="font-style:normal;font-weight:700">%1$s</p>
+				<!-- /wp:paragraph -->
+
+				%2$s
+			</div>
+			<!-- /wp:group -->'
+		),
+		esc_html( $attributes['heading'] ),
+		do_blocks(
+			sprintf(
+				'<!-- wp:post-date {"displayType":"%s"} /-->',
+				$attributes['displayType']
+			),
+		),
+	);
+}

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/index.js
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-date/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../shared/dynamic-edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );


### PR DESCRIPTION
See https://github.com/WordPress/wporg-developer/issues/456

The article meta Last Updated field currently uses the modified date, but for GitHub handbooks this is the import date, not the GitHub edited date. This PR temporarily removes it, until we can get the actual edited date of the markdown file from GitHub. 

It follows the approach from https://github.com/WordPress/wporg-developer/pull/454, creating a block to be used for both dates, then filtering to remove the last updated date on GitHub handbooks only. The local handbooks for Plugins and Themes are unaffected.