### PR TITLE
Search Results Block: Strip markdown from excerpts

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/search-post/index.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/search-post/index.php
@@ -11,6 +11,7 @@ namespace WordPressdotorg\Theme\Developer_2023\Dynamic_Search_Post;
 use function DevHub\is_parsed_post_type;
 
 add_action( 'init', __NAMESPACE__ . '\init' );
+add_filter( 'get_the_excerpt', __NAMESPACE__ . '\strip_markdown_in_excerpt' );
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
@@ -26,6 +27,24 @@ function init() {
 			'render_callback' => __NAMESPACE__ . '\render',
 		)
 	);
+}
+
+/**
+ * Parse the markdown in a given string, then strip the resulting HTML.
+ *
+ * @param string $excerpt The post excerpt.
+ *
+ * @return string A string without markdown or HTML.
+ */
+function strip_markdown_in_excerpt( $excerpt ) {
+	// Load Jetpack Markdown if it's not already loaded.
+	if ( ! class_exists( 'WPCom_GHF_Markdown_Parser' ) && defined( 'JETPACK__PLUGIN_DIR' ) ) {
+		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/markdown.php';
+	}
+
+	$parser = new \WPCom_GHF_Markdown_Parser();
+	$html = $parser->transform( $excerpt );
+	return wp_strip_all_tags( $html );
 }
 
 /**


### PR DESCRIPTION
Fixes #465 — The markdown rendered in the excerpt matches one of the legacy notice shortcodes (`[tutorial]`), which is causing the shortcode processing to output here. It's also unexpected that the markdown would output in the search results, excerpts are typically plain text. This update parses the markdown and strips the resulting HTML, so that these excerpts behave more like native WordPress excerpts.

| Before | After |
|---|---|
| ![search-results-before](https://github.com/WordPress/wporg-developer/assets/541093/2d34a85a-8c96-401f-8d4a-819e7805205b) | ![search-results-after](https://github.com/WordPress/wporg-developer/assets/541093/61e5d83d-c12a-4caf-ae7f-dd4924592375) |
| ![ref-search-before](https://github.com/WordPress/wporg-developer/assets/541093/7c0acce8-e93f-463b-bd91-714f95a404e8) | ![ref-search-after](https://github.com/WordPress/wporg-developer/assets/541093/452e760a-2165-4e72-9672-793f95316ef5) |

To test:

- View a handbook search result, for example `/block-editor/?s=deprecation`
- There should be no broken-looking notices
- There should be no markdown

Try on the code reference too, there should be no change.