### PR TITLE
Code Reference: Related: Fix extra empty links

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-related/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-related/block.php
@@ -93,7 +93,7 @@ function get_row_data( $posts ) {
 
 		$rows[] = array(
 			sprintf(
-				'<a href="%1$s">%2$s%3$s</a><code>%4$s</code></a>',
+				'<a href="%1$s">%2$s%3$s</a><code>%4$s</code>',
 				get_permalink(),
 				get_the_title(),
 				$is_function ? '()' : '',


### PR DESCRIPTION
Fixes #432 — These extra links are coming from the `autolink_references` function, which did not account for content already in a link. So it was creating `<a href="https://developer.wordpress.org/reference/functions/parse_blocks/"><a href="https://developer.wordpress.org/reference/functions/parse_blocks/" rel="function">parse_blocks()</a></a>`, and the browser interpreted that as two separate links, one empty. Now, `autolink_references` will check if the current piece is inside a link, and skip it if so.

An alternate solution was to wrap the used/uses title in a span, and let `autolink_references` handle the linking, but the approach in this PR will also handle other cases where content is already linked.

There is one difference between the autolinked tag — it includes a `rel="function"`. Should that be added to this link?

👩🏻‍💻 I was surprised that `autolink_references` was run over the block output, but it comes from the fact that `the_content` filters are applied, because the theme jumps in to `the_content` early to hijack the post display. I remember we did this on purpose, but this is one of the unexpected consequences.

No screenshots, there should be no visual change.

**To test**

1. View any code reference page, scroll to the related section
2. Either tab or inspect element to check that there is only one link per row
