### PR TITLE
Chapters and ToC: Internal scroll

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-sidebar.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-sidebar.php
@@ -7,7 +7,7 @@
 
 ?>
 
-<!-- wp:wporg/sidebar-container {"style":{"spacing":{"margin":{"bottom":"40px"}}}} -->
+<!-- wp:wporg/sidebar-container -->
 
 	<!-- wp:wporg/table-of-contents /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -21,7 +21,6 @@
 	}
 
 	.wporg-chapter-list__list {
-		margin-top: var(--wp--preset--spacing--20);
 
 		@media (max-width: 767px) {
 			display: none;

--- a/source/wp-content/themes/wporg-developer-2023/src/code-comment-form/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comment-form/style.scss
@@ -2,25 +2,3 @@
 	margin-block-start: var(--wp--style--block-gap);
 	margin-block-end: var(--wp--style--block-gap);
 }
-
-.wp-block-wporg-code-reference-comment-form-content {
-	display: flex;
-	flex-direction: column;
-	max-width: var(--wp--style--global--content-size);
-
-	@media screen and (min-width: 1200px) {
-		max-width: unset;
-		flex-direction: row;
-		justify-content: space-between;
-		gap: var(--wp--preset--spacing--40);
-
-		.comment-respond {
-			min-width: var(--wp--style--global--content-size);
-		}
-
-		.comment-rules {
-			padding-top: var(--wp--preset--spacing--30);
-		}
-	}
-}
-

--- a/source/wp-content/themes/wporg-developer-2023/src/code-comment-form/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comment-form/style.scss
@@ -1,4 +1,8 @@
-.wp-block-wporg-code-reference-comment-form p {
-	margin-block-start: var(--wp--style--block-gap);
-	margin-block-end: var(--wp--style--block-gap);
+.wp-block-wporg-code-reference-comment-form {
+	padding-bottom: var(--wp--style--block-gap);
+
+	p {
+		margin-block-start: var(--wp--style--block-gap);
+		margin-block-end: var(--wp--style--block-gap);
+	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -85,7 +85,7 @@ pre {
 		flex-direction: row !important;
 		column-gap: var(--local--column-gap);
 
-		/* Left sidebar */
+		/* Left sidebar: Chapter List */
 		> .wp-block-wporg-sidebar-container {
 			width: var(--local--sidebar--width);
 			inset-inline-start: var(--wp--preset--spacing--edge-space);
@@ -109,7 +109,7 @@ pre {
 			margin-left: auto;
 			margin-right: auto;
 
-			/* Right sidebar */
+			/* Right sidebar: ToC */
 			.wp-block-wporg-sidebar-container {
 				inset-inline-end: var(--wp--preset--spacing--edge-space);
 			}

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -71,6 +71,7 @@ pre {
 .has-three-columns {
 	--local--sidebar--width: 232px;
 	--local--column-gap: 40px;
+	justify-content: flex-end;
 
 	> * {
 		width: 100%;
@@ -84,8 +85,10 @@ pre {
 		flex-direction: row !important;
 		column-gap: var(--local--column-gap);
 
-		aside {
+		/* Left sidebar */
+		> .wp-block-wporg-sidebar-container {
 			width: var(--local--sidebar--width);
+			inset-inline-start: var(--wp--preset--spacing--edge-space);
 		}
 
 		main {
@@ -105,10 +108,11 @@ pre {
 			max-width: 960px;
 			margin-left: auto;
 			margin-right: auto;
-		}
 
-		.wp-block-wporg-sidebar-container {
-			inset-inline-end: var(--wp--preset--spacing--edge-space);
+			/* Right sidebar */
+			.wp-block-wporg-sidebar-container {
+				inset-inline-end: var(--wp--preset--spacing--edge-space);
+			}
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -69,7 +69,7 @@ pre {
 }
 
 .has-three-columns {
-	--local--sidebar--width: 232px;
+	--local--sidebar--width: 248px;
 	--local--column-gap: 40px;
 	justify-content: flex-end;
 

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -81,11 +81,20 @@ pre {
 		order: 1;
 	}
 
+	/* Left sidebar: Chapter List */
+	> .wp-block-wporg-sidebar-container {
+		margin-top: var(--wp--preset--spacing--20);
+	}
+
+	/* Right sidebar: ToC */
+	article .wp-block-wporg-sidebar-container {
+		margin-bottom: var(--wp--preset--spacing--50);
+	}
+
 	@media (min-width: 768px) {
 		flex-direction: row !important;
 		column-gap: var(--local--column-gap);
 
-		/* Left sidebar: Chapter List */
 		> .wp-block-wporg-sidebar-container {
 			width: var(--local--sidebar--width);
 			inset-inline-start: var(--wp--preset--spacing--edge-space);
@@ -109,7 +118,6 @@ pre {
 			margin-left: auto;
 			margin-right: auto;
 
-			/* Right sidebar: ToC */
 			.wp-block-wporg-sidebar-container {
 				inset-inline-end: var(--wp--preset--spacing--edge-space);
 			}

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -29,7 +29,7 @@
 		</main>
 		<!-- /wp:group -->
 
-		<!-- wp:wporg/sidebar-container {"hasBackToTop":false} -->
+		<!-- wp:wporg/sidebar-container {"hasBackToTop":false,"inlineBreakpoint": "768px"} -->
 
 			<!-- wp:wporg/chapter-list /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -5,11 +5,11 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 	
-	<!-- wp:group {"align":"full","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-	<div class="wp-block-group alignfull has-three-columns" style="margin-top:var(--wp--preset--spacing--20)">
+	<!-- wp:group {"align":"full","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
+	<div class="wp-block-group alignfull has-three-columns">
 		
-		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
-		<main class="wp-block-group alignwide">
+		<!-- wp:group {"tagName":"main","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+		<main class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
 
 			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 			<article class="wp-block-group" style="margin-top:0px">
@@ -29,7 +29,11 @@
 		</main>
 		<!-- /wp:group -->
 
-		<!-- wp:wporg/chapter-list {"style":{"spacing":{"margin":{"bottom":"20px"}}}} /-->
+		<!-- wp:wporg/sidebar-container {"hasBackToTop":false} -->
+
+			<!-- wp:wporg/chapter-list /-->
+
+		<!-- /wp:wporg/sidebar-container -->
 
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -16,9 +16,12 @@
 			<!-- wp:pattern {"slug":"wporg-developer-2023/article-sidebar"} /-->
 
 			<!-- wp:wporg/code-reference-deprecated /-->
+
 			<!-- wp:wporg/code-reference-private-access /-->
 
 			<!-- wp:pattern {"slug":"wporg-developer-2023/single-content"} /-->
+
+			<!-- wp:wporg/code-reference-comment-form /-->
 
 		</article>
 		<!-- /wp:group -->
@@ -27,12 +30,6 @@
 	<!-- /wp:group -->
 
 </main>
-<!-- /wp:group -->
-
-<!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"tagName":"div","style":{"spacing":{"padding":{"top":"var:preset|spacing|40", "bottom":"var:preset|spacing|40", "left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:wporg/code-reference-comment-form {"align":"wide"} /-->
-</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -159,7 +159,7 @@
 			"wporg-sidebar-container": {
 				"spacing": {
 					"margin": {
-						"top": "130px"
+						"top": "150px"
 					}
 				}
 			},

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -159,7 +159,7 @@
 			"wporg-sidebar-container": {
 				"spacing": {
 					"margin": {
-						"top": "150px"
+						"top": "130px"
 					}
 				}
 			},


### PR DESCRIPTION
Closes #453 

Depends on https://github.com/WordPress/wporg-mu-plugins/pull/554, which makes the sidebar container scroll internally once it becomes fixed.

Wraps the Chapters List in a sidebar container so that it behaves the same as the ToC, but without the 'Back to top' link.

On the Code Reference the comment form rules have been moved under the form so that they no longer clash with the ToC. It now only has to reduce in height when the footer becomes visible, see [discussion](https://github.com/WordPress/wporg-developer/issues/453#issuecomment-1867192556).

The scrolling areas have custom scrollbars so that they appear on hover. This has been inspired by the React docs ([example](https://react.dev/reference/react/legacy)), and should help users discover that these are scrollable more easily. With the typical Mac OS setting of hidden scrollbars, it is not immediately obvious. Note that this does not work in Firefox.

### Screenshots

#### Code reference

https://github.com/WordPress/wporg-developer/assets/1017872/aa029416-67eb-4ec0-84e4-a93122193758

#### Block Editor

https://github.com/WordPress/wporg-developer/assets/1017872/f72896fc-a8f3-41da-b259-23e1e671a1a5

### Testing

1. Ensure your mu-plugins is on https://github.com/WordPress/wporg-mu-plugins/pull/554
2. Test pages with short ToC and/or Chapter List
3. Test pages with long ToC and/or Chapter List
4. Test for regressions on small screens, there should be no change
5. Test in different browsers (check scrollbars)