### PR TITLE
Fix "Improve it on GitHub" links don't go anywhere if the user is logged out.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
@@ -46,10 +46,10 @@ add_shortcode(
 add_shortcode(
 	'article_changelog_link',
 	function() {
-		// If this is a github page, use the edit URL to generate the
-		// commit history URL
 		global $post;
 		$markdown_source = get_markdown_edit_link( $post->ID );
+		// If this is a github page, use the edit URL to generate the
+		// commit history URL
 		if ( str_contains( $markdown_source, 'github.com' ) ) {
 			return str_replace( '/edit/', '/commits/', $markdown_source );
 		}

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
@@ -39,7 +39,7 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$title = get_the_title( $post_id );
-	$link_url = is_user_logged_in() ? $attributes['linkURL'] : wp_login_url( get_permalink() );
+	$link_url = $attributes['linkURL'];
 
 	return sprintf(
 		do_blocks(

--- a/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/article-meta-github/block.php
@@ -39,7 +39,7 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$title = get_the_title( $post_id );
-	$link_url = $attributes['linkURL'];
+	$link_url = is_user_logged_in() ? $attributes['linkURL'] : wp_login_url( get_permalink() );
 
 	return sprintf(
 		do_blocks(

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -32,13 +32,6 @@
 <!-- wp:group {"layout":{"type":"constrained","wideSize":"1280px","contentSize":"680px"},"tagName":"div","style":{"spacing":{"padding":{"top":"var:preset|spacing|40", "bottom":"var:preset|spacing|40", "left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:wporg/code-reference-comment-form {"align":"wide"} /-->
-
-	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space"}}}} -->
-	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--edge-space)">
-		<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
-	</div>
-	<!-- /wp:group -->
-
 </div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
Fixes #438

This PR ensures that when a user clicks on [Improve it on GitHub](https://github.com/WordPress/wporg-developer/blob/trunk/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php#L37) and [See list of changes](https://github.com/WordPress/wporg-developer/blob/trunk/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php#L49), they are first checked for login status. If not logged in, they are redirected to the login page. Since both links utilize [get_edit_post_link()](https://github.com/WordPress/wordpress-develop/blob/6.4/src/wp-includes/link-template.php#L1474), this results in a situation where if not logged in, users will be redirected back to the current page after clicking them.

![image](https://github.com/WordPress/wporg-developer/assets/18050944/9c9bda99-8128-4421-9b58-5631ed7d46d3)
Example: http://localhost:8888/block-editor/

---

Additionally, I have removed the article-meta pattern from the single page and kept it only for the handbook, because the Date part reflects the time when the post was added/modified in the theme, not the actual time the content was modified. Furthermore, on pages other than the handbook, content is not edited through GitHub. cc @ndiego 

![image](https://github.com/WordPress/wporg-developer/assets/18050944/1469d490-dc24-4797-b36e-4ef0af88c145)
Example: http://localhost:8888/reference/hooks/get_edit_post_link/

## Note

Now, after logging in, users will be redirected back to the page where they clicked the link, instead of being directly taken to the target page (GitHub). The main reason is that `get_edit_post_link()` can only retrieve the link to the target page after logging in, so it cannot be directly used as the redirect parameter in `wp_login_url()`. Any thoughts on this? Perhaps we could modify the handbook page to not use `get_edit_post_link()` in the [shortcode function](https://github.com/WordPress/wporg-developer/blob/trunk/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php#L34-L39) but instead return the edit link directly, without considering whether the user is logged in or not, since editing on GitHub also requires a separate login and fork.