### PR TITLE
Update UI of Methods section to the table layout used by Related.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
@@ -74,7 +74,7 @@ function get_methods_content() {
 			$headings     = array( __( 'Name', 'wporg' ), __( 'Description', 'wporg' ) );
 
 			return sprintf(
-				'<!-- wp:wporg/code-table {"id":"uses","headings":%1$s,"rows":%2$s,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
+				'<!-- wp:wporg/code-table {"id":"uses","headings":%1$s,"rows":%2$s,"itemsToShow":100,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
 				wp_json_encode( $headings ),
 				wp_json_encode( get_row_data( $class_methods ) )
 			);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
@@ -48,7 +48,7 @@ function render( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
-		'<section %s>%s %s</section>',
+		'<section %1$s>%2$s %3$s</section>',
 		$wrapper_attributes,
 		$title_block,
 		do_blocks( $content )

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
@@ -111,5 +111,6 @@ function get_row_data( $class_methods ) {
 		);
 		wp_reset_postdata();
 	}
+
 	return $rows;
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
@@ -35,7 +35,7 @@ function render( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$content = get_methods_content();
+	$content = get_methods_content( $block->context['postId'] );
 
 	if ( empty( $content ) ) {
 		return '';
@@ -58,13 +58,14 @@ function render( $attributes, $content, $block ) {
 /**
  * Return code methods html.
  *
+ * @param int $post_id
  * @return string
  */
-function get_methods_content() {
+function get_methods_content( $post_id ) {
 	if ( 'wp-parser-class' === get_post_type() ) {
 		$class_methods = get_children(
 			array(
-				'post_parent' => get_the_ID(),
+				'post_parent' => $post_id,
 				'post_status' => 'publish',
 			)
 		);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-methods/block.php
@@ -75,7 +75,7 @@ function get_methods_content( $post_id ) {
 			$headings     = array( __( 'Name', 'wporg' ), __( 'Description', 'wporg' ) );
 
 			return sprintf(
-				'<!-- wp:wporg/code-table {"id":"uses","headings":%1$s,"rows":%2$s,"itemsToShow":100,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
+				'<!-- wp:wporg/code-table {"id":"uses","headings":%1$s,"rows":%2$s,"itemsToShow":150,"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} /--> ',
 				wp_json_encode( $headings ),
 				wp_json_encode( get_row_data( $class_methods ) )
 			);


### PR DESCRIPTION
Closes #384

This PR updates the UI of the Methods section to the table layout that's used by the Related section.
Dash is added for empty description. 
cc @WordPress/meta-design 

![table](https://github.com/WordPress/wporg-developer/assets/18050944/1b80908c-f9c2-4f4a-9b83-c56113b97ed9)

Do we want to show all the methods like it did previously, or only show a few (5 for the moment) and allow to expand?