### PR TITLE
Fix copy code text twice

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/js/function-reference.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/function-reference.js
@@ -42,7 +42,9 @@ jQuery( function ( $ ) {
 		$copyButton.on( 'click', function ( event ) {
 			event.preventDefault();
 			clearTimeout( timeoutId );
-			const code = $element.find( 'code' ).text();
+			// first() is used here as sometimes there are additional <code> tags in user-generated content,
+			// which causes copying the text twice.
+			const code = $element.find( 'code' ).first().text();
 			if ( ! code ) {
 				return;
 			}


### PR DESCRIPTION
Fixes #485

The issue arises because users add an extra `<code>` tag before the `[php]` shortcode in their generated content, resulting in an additional layer of `<code>` tags. This causes `find( 'code' )` to select two elements, leading to the text being copied twice. `first()` is added here to fix the problem.
![image](https://github.com/WordPress/wporg-developer/assets/18050944/0b41a3a6-93eb-456c-a37e-81b8573cb9e5)

**How to test**
1. See if it only copies once on `themes/template-files-section/page-template-files/`. (Two layers of `<code>` tag)
2. Also check the source on the reference page as well `reference/functions/is_admin/`. (One layers of `<code>` tag)