### PR TITLE
Add redirects for the Block Editor Handbook.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
@@ -62,6 +62,11 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 			'explanations/glossary'                               => 'getting-started/glossary',
 			'how-to-guides/platform/custom-block-editor/tutorial' => 'how-to-guides/platform/custom-block-editor',
 			'reference-guides/block-api/versions'                 => 'reference-guides/block-api/block-api-versions',
+			
+			// After handbook restructuring, January 2023.
+			'how-to-guides/block-tutorial/generate-blocks-with-wp-cli'        => 'getting-started/devenv/get-started-with-create-block',
+			'how-to-guides/block-tutorial/block-controls-toolbar-and-sidebar' => 'getting-started/fundamentals/block-in-the-editor',
+			'how-to-guides/block-tutorial/writing-your-first-block-type'      => 'getting-started/tutorial',
 
 			// After handbook restructuring, December 2023.
 			'getting-started/create-block'                                            => 'getting-started/tutorial',


### PR DESCRIPTION
This PR corresponds to https://github.com/WordPress/gutenberg/pull/58358. 

Two pages in the Block Editor Handbook are being removed, and we need to implement redirects to the new sections. The [Generate Blocks with WP-CLI](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/generate-blocks-with-wp-cli/) had been removed awhile ago, but the redirect was never created. So this PR also adds that. 