### PR TITLE
Update 3 column layout to handle ToC breakpoint changing

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -109,7 +109,7 @@ pre {
 		}
 	}
 
-	@media (min-width: 1200px) {
+	@media (min-width: 1300px) {
 		width: calc(100% - var(--local--sidebar--width) - var(--local--column-gap));
 
 		article {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/issues/566

Depends on https://github.com/WordPress/wporg-mu-plugins/pull/568, which changes the Table of Contents breakpoint where it becomes inline and collapsed to 1300px. In this theme we need to update the 3 column layout breakpoint (used for handbooks) to match.

The breakpoint change also affects the 2 column layouts used for single pages in other sections, like Code Reference, CLI Commands, etc.

## Screenshots

### Handbook

https://github.com/WordPress/wporg-developer/assets/1017872/16b16595-643a-414c-b89c-3145970693c2

### Single

https://github.com/WordPress/wporg-developer/assets/1017872/c27a7111-95a1-4552-8356-aa5937cdf059

## Testing

1. Ensure your mu-plugins is on the https://github.com/WordPress/wporg-mu-plugins/pull/568 branch
2. Test handbooks for the 3 column layout, and single Code Reference and CLI command pages for the 2 column layout
3. Check that the ToC becomes inline and collapsed at 1300px with both, and no overlap occurs with the content column.
