### PR TITLE
Handbooks: Wrap tables in block markup

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -652,7 +652,11 @@ function filter_standards_content( $content ) {
 	$content = preg_replace_callback(
 		'!<table.*?</table>!is',
 		function( $matches ) {
-			return '<figure class="wp-block-table is-style-borderless">' . $matches[0] . '</figure>';
+			return do_blocks(
+				'<!-- wp:table {"className":"is-style-borderless"} --><figure class="wp-block-table is-style-borderless">' .
+				$matches[0] .
+				'</figure><!-- /wp:table -->'
+			);
 		},
 		$content
 	);


### PR DESCRIPTION
Fixes #492 — This wraps any `table`s in handbooks in the table block code and runs `do_blocks` so that the core styles are injected correctly.

| Before | After |
|---|---|
| <img width="1021" alt="Screenshot 2024-02-02 at 5 46 37 PM" src="https://github.com/WordPress/wporg-developer/assets/541093/0232c918-a053-4dac-ad48-1ed2a7887d88"> | <img width="1038" alt="Screenshot 2024-02-02 at 5 46 31 PM" src="https://github.com/WordPress/wporg-developer/assets/541093/e2c48844-b236-4cdf-b296-d0c49704af3f"> |

To test:

- View any handbook page with a table, ex `/block-editor/getting-started/faq/`
- There should be no white border around the table cells