### PR TITLE
Block Editor Handbook: Add redirect for experiemtns package that no longer exists

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
@@ -62,7 +62,8 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 			'explanations/glossary'                               => 'getting-started/glossary',
 			'how-to-guides/platform/custom-block-editor/tutorial' => 'how-to-guides/platform/custom-block-editor',
 			'reference-guides/block-api/versions'                 => 'reference-guides/block-api/block-api-versions',
-			
+			'reference-guides/packages/packages-experiments'      => 'reference-guides/packages/packages-private-apis',
+
 			// After handbook restructuring, January 2023.
 			'how-to-guides/block-tutorial/generate-blocks-with-wp-cli'        => 'getting-started/devenv/get-started-with-create-block',
 			'how-to-guides/block-tutorial/block-controls-toolbar-and-sidebar' => 'getting-started/fundamentals/block-in-the-editor',


### PR DESCRIPTION
Originally reported in the Gutenberg repository: https://github.com/WordPress/gutenberg/issues/58560

The `@wordpress/experiments` package has been renamed to `@wordpress/private-apis` package in the following PR: [#47839](https://github.com/WordPress/gutenberg/pull/47839)

Perhaps due to this, there seem to be two pages in the Block Editor Handbook: a page before the rename and a page after the rename.

- https://developer.wordpress.org/block-editor/reference-guides/packages/packages-experiments/
- https://developer.wordpress.org/block-editor/reference-guides/packages/packages-private-apis/

This PR redirects access to a package reference page that no longer exists to a new package reference page.

After that, we'll probably need to remove the old page (`block-editor/reference-guides/packages/packages-experiments/`) from the WP dashboard.