### PR TITLE
Move handbook meta info inside complementary landmark

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -7,7 +7,7 @@
 
 ?>
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"},"margin":{"top":"20","bottom":"0"},"blockGap":"var:preset|spacing|10"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"className":"entry-meta","layout":{"type":"flex","orientation":"vertical"}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"},"margin":{"top":"20","bottom":"0"},"blockGap":"5px"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"className":"entry-meta","layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group entry-meta" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:20px;margin-bottom:0;padding-top:var(--wp--preset--spacing--20)">
 
 	<!-- wp:wporg/article-meta-date {"heading":"<?php esc_html_e( 'First published', 'wporg' ); ?>"} /-->

--- a/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/article-meta.php
@@ -7,8 +7,8 @@
 
 ?>
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|20"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left","verticalAlignment":"top"},"className":"entry-meta"} -->
-<div class="wp-block-group entry-meta" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"},"margin":{"top":"20","bottom":"0"},"blockGap":"var:preset|spacing|10"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"className":"entry-meta","layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group entry-meta" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:20px;margin-bottom:0;padding-top:var(--wp--preset--spacing--20)">
 
 	<!-- wp:wporg/article-meta-date {"heading":"<?php esc_html_e( 'First published', 'wporg' ); ?>"} /-->
 

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/block.php
@@ -70,8 +70,9 @@ function render( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
-		'<aside %1$s><nav>%2$s<ul class="wporg-chapter-list__list">%3$s</ul></nav></aside>',
+		'<aside %1$s>%2$s<nav>%3$s<ul class="wporg-chapter-list__list">%4$s</ul></nav></aside>',
 		$wrapper_attributes,
+		do_blocks( '<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->' ),
 		$header,
 		$content
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/chapter-list/style.scss
@@ -3,6 +3,9 @@
 	--local--icon-size: calc(var(--local--line-height) * 1em);
 	line-height: var(--local--line-height);
 
+	display: flex;
+	flex-direction: column-reverse;
+
 	@media (max-width: 767px) {
 		border: 1px solid var(--wp--preset--color--light-grey-1);
 		border-radius: 2px;

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -135,12 +135,20 @@ pre {
 
 // Wrap meta on smaller screens. Double class needed to override core style.
 .entry-meta.entry-meta {
+	a {
+		color: var(--wp--custom--link--color--text);
+		text-decoration: underline;
+	}
 
 	@media (max-width: 781px) {
 		flex-wrap: wrap;
+		margin: 0 !important;
+		padding: 15px var(--wp--preset--spacing--20) !important;
+		flex-direction: row;
+		gap: 20px !important;
 
 		> * {
-			min-width: calc(50% - var(--wp--preset--spacing--20) / 2);
+			min-width: 30%;
 		}
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -19,8 +19,6 @@
 
 				<!-- wp:post-content /-->
 
-				<!-- wp:pattern {"slug":"wporg-developer-2023/article-meta"} /-->
-
 				<!-- wp:pattern {"slug":"wporg-developer-2023/handbook-pagination"} /-->
 
 			</article>
@@ -30,7 +28,6 @@
 		<!-- /wp:group -->
 
 		<!-- wp:wporg/sidebar-container {"hasBackToTop":false,"inlineBreakpoint": "768px"} -->
-
 			<!-- wp:wporg/chapter-list /-->
 
 		<!-- /wp:wporg/sidebar-container -->


### PR DESCRIPTION
Closes #400.

This PR moves the handbook meta above the chapter list in the HTML hierarchy and then uses flex order to visually place it below the chapter list, and also adding a dividing line between them. 

Below is a screencast that shows when entering the complementary landmark, the screen reader first reads the handbook content and then the chapter list, which I suppose meets the request. Regarding the desktop view and @jasmussen's question about how it would look in mobile view when the three columns just became rows, could @WordPress/meta-design take a look and give some feedback?

https://github.com/WordPress/wporg-developer/assets/18050944/ff0604a9-a5e4-4bd4-863b-40627498b4bf

