### PR TITLE
Convert Github repository link to a button with text

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/command-github/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-github/block.php
@@ -43,9 +43,11 @@ function render( $attributes, $content, $block ) {
 	if ( $repo_url ) {
 		$content .= sprintf(
 			'
-			<a href="%s">
-				<img src="https://make.wordpress.org/cli/wp-content/plugins/wporg-cli/assets/images/github-mark.svg" class="icon-github" alt="GitHub" />
-			</a>
+			<div class="btn-group">
+				<a class="button" href="%s" style="padding-top: 0;">GitHub Repository
+					<img decoding="async" src="https://make.wordpress.org/cli/wp-content/plugins/wporg-cli/assets/images/github-mark.svg" class="icon-github" alt="GitHub">
+				</a>
+			</div>
 			',
 			esc_url( $repo_url )
 		);

--- a/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-github/style.scss
@@ -3,9 +3,9 @@
 	margin-block-start: 0 !important;
 
 	img {
-		width: 23px;
+		width: 18px;
 		position: relative;
-		top: 7px;
+		top: 5px;
 		margin-inline-end: 10px;
 	}
 


### PR DESCRIPTION
In the WP-CLI repository it was pointed out that the [GitHub repository icon link isn't super obvious](https://github.com/wp-cli/wp-cli/issues/5227) on the page.

This PR attempts to fix that, but wrapping the icon in a more familiar button layout, with the label "GitHub Repository".
