### PR TITLE
Update Setup instructions with prerequisites

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"@wordpress/env": "9.2.0"
 	},
 	"scripts": {
-		"setup:tools": "yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs && composer --working-dir=./source/wp-content/plugins/phpdoc-parser install",
+		"setup:tools": "yarn update:tools && yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs && composer --working-dir=./source/wp-content/plugins/phpdoc-parser install",
 		"setup": "yarn setup:wp && yarn parse",
 		"setup:wp": "wp-env run cli bash env/setup.sh",
 		"parse": "wp-env run cli wp devhub parse --user_id=1",

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@
 * Node/npm
 * Yarn
 * Composer
+* PHP v7.4
 
 ### Setup
 


### PR DESCRIPTION
When running `yarn setup:tools` for the first time after cloning the repo locally, some errors may appear if `composer update` is not run first.

A specific PHP version is also a requirement that is not properly remarked on the `README.md`

See https://github.com/WordPress/wporg-developer/issues/514 

This PR propose a solution to tackle these issues and improve the contribution experience for first-timers.