### PR TITLE
Fix the position of the Table of Contents

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
+++ b/source/wp-content/themes/wporg-developer-2023/patterns/cli-commands.php
@@ -13,8 +13,8 @@
 	<!-- wp:group {"align":"left","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
 	<div class="wp-block-group alignleft has-three-columns">
 		
-		<!-- wp:group {"tagName":"main","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<main class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
 			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 			<article class="wp-block-group" style="margin-top:0px">

--- a/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/style/style.scss
@@ -3,11 +3,6 @@
  * templates or theme.json settings.
  */
 
-body.handbook-landing-page,
-body.post-type-archive-command {
-	--wp--custom--wporg-sidebar-container--spacing--margin--top: 100px;
-}
-
 .wporg-breadcrumbs {
 	// If the breadcrumbs are present, the space after them needs to be reduced.
 	// The next content is typically the search field.

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-command.html
@@ -8,8 +8,8 @@
 	<!-- wp:group {"align":"left","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
 	<div class="wp-block-group alignleft has-three-columns">
 		
-		<!-- wp:group {"tagName":"main","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<main class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
 			<!-- wp:group {"tagName":"article"} -->
 			<article class="wp-block-group">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-block-editor.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-block-editor.html
@@ -8,8 +8,8 @@
 	<!-- wp:group {"align":"left","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
 	<div class="wp-block-group alignleft has-three-columns">
 		
-		<!-- wp:group {"tagName":"main","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<main class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
 			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 			<article class="wp-block-group" style="margin-top:0px">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook-github.html
@@ -8,8 +8,8 @@
 	<!-- wp:group {"align":"left","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
 	<div class="wp-block-group alignleft has-three-columns">
 		
-		<!-- wp:group {"tagName":"main","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<main class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
 			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 			<article class="wp-block-group" style="margin-top:0px">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single-handbook.html
@@ -8,8 +8,8 @@
 	<!-- wp:group {"align":"left","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
 	<div class="wp-block-group alignleft has-three-columns">
 		
-		<!-- wp:group {"tagName":"main","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<main class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
 			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
 			<article class="wp-block-group" style="margin-top:0px">

--- a/source/wp-content/themes/wporg-developer-2023/templates/single.html
+++ b/source/wp-content/themes/wporg-developer-2023/templates/single.html
@@ -8,8 +8,8 @@
 	<!-- wp:group {"align":"left","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
 	<div class="wp-block-group alignleft has-three-columns">
 		
-		<!-- wp:group {"tagName":"main","className":"alignwide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<main class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
 
 			<!-- wp:group {"tagName":"article"} -->
 			<article class="wp-block-group">

--- a/source/wp-content/themes/wporg-developer-2023/theme.json
+++ b/source/wp-content/themes/wporg-developer-2023/theme.json
@@ -158,13 +158,6 @@
 				"paddingVertical": "calc(( var(--wp--custom--select--height) - (var(--wp--custom--select--font-size) * var(--wp--custom--select--line-height))) / 2)",
 				"borderRadius": "var(--wp--custom--button--border--radius)"
 			},
-			"wporg-sidebar-container": {
-				"spacing": {
-					"margin": {
-						"top": "150px"
-					}
-				}
-			},
 			"wporg-command-github": {
 				"color": {
 					"open": "var(--wp--custom--color--green-60)",


### PR DESCRIPTION
A change in Gutenberg 18.5 broke the 3 column layout which controls the position of the table of contents. This PR updates the templates to be compatible with the [changes to the 3 column layout in the parent theme](https://github.com/WordPress/wporg-parent-2021/pull/140).

See https://github.com/WordPress/wporg-parent-2021/issues/139

Depends on https://github.com/WordPress/wporg-parent-2021/pull/140 and https://github.com/WordPress/wporg-mu-plugins/pull/624

### Screenshots

| Before | After |
|-|-|
| ![developer wordpress org_reference_functions_add_theme_support_](https://github.com/WordPress/wporg-developer/assets/1017872/5c47b394-397e-4170-bf2a-55bbb54f1c02) | ![developer wordpress org_reference_functions_add_theme_support_ (1)](https://github.com/WordPress/wporg-developer/assets/1017872/35aed0ee-c4cd-4764-abb8-e3f003689fcb) |
