### PR TITLE
Fix copy button on comment code block.

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-comments/style.scss
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comments/style.scss
@@ -153,15 +153,17 @@ a):not(.wporg-developer-code-block a) {
 		display: none !important;
 	}
 
-	// Hide the file name in comments.
-	.wporg-developer-code-block {
-		.wp-code-block-button-container {
-			justify-content: end;
+	.wporg-developer-code-block .wp-code-block-button-container {
+		align-items: initial;
+	}
 
-			code {
-				display: none;
-			}
-		}
+	// Hide the file name in comments.
+	.wporg-developer-code-block .wp-code-block-button-container code {
+		display: none;
+	}
+
+	.wporg-developer-code-block .wp-code-block-button-container code + span {
+		grid-column: 2;
 	}
 }
 


### PR DESCRIPTION
Move the `copy` button to align on the right side regardless of the viewport width.



| Before | After |
|--------|--------|
|  <img width="663" alt="Screenshot 2024-07-19 at 2 10 09 PM" src="https://github.com/user-attachments/assets/031564fc-d30b-4d10-9bd1-c70c5f4d2b0c"> |  <img width="620" alt="Screenshot 2024-07-19 at 2 09 53 PM" src="https://github.com/user-attachments/assets/99e6edfb-e35f-4177-9320-5cbf9c1cac1f"> |






