### PR TITLE
Set yarn version to v1 (classic)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-classic.cjs

--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
 	},
 	"workspaces": [
 		"source/wp-content/themes/wporg-developer-2023"
-	]
+	],
+	"packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Run the following command to ensure that the correct yarn version is
used when using the project on machines that have newer yarn versions
installed:

```sh
yarn set version classic
```

Without this change, newer yarn versions would not work well with this repo,
and would automatically attempt to upgrade the lockfile.

---

Alternatively, this project could switch to newer versions of yarn or recent versions of `npm`. Other WordPress projects are using `npm` and that may be preferable.