### PR TITLE
Remove jQuery from `user-notes.js`

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/user-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/user-content.php
@@ -185,7 +185,7 @@ class DevHub_User_Submitted_Content {
 			wp_enqueue_script(
 				'wporg-developer-user-notes',
 				get_stylesheet_directory_uri() . '/js/user-notes.js',
-				array( 'jquery', 'quicktags' ),
+				array( 'quicktags' ),
 				filemtime( dirname( __DIR__ ) . '/js/user-notes.js' ),
 				true
 			);

--- a/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
@@ -86,37 +86,36 @@
 	// Override tab within user notes textarea to actually insert a tab character.
 	// Copied from code within core's wp-admin/js/common.js.
 	commentForm.bind( 'keydown.wpevent_InsertTab', function ( e ) {
-		const element_target = e.target;
+		const elementTarget = e.target;
 		let scroll, sel;
 
 		if ( e.key === 'Escape' ) {
-			console.log( 'Escape' );
 			// When pressing Escape: Opera 12 and 27 blur form fields, IE 8 clears them.
 			e.preventDefault();
-			element_target.setAttribute( 'data-tab-out', 'true' );
+			elementTarget.setAttribute( 'data-tab-out', 'true' );
 			return;
 		}
 
 		if ( e.key !== 'Tab' || e.ctrlKey || e.altKey || e.shiftKey ) return;
 
-		if ( element_target.getAttribute( 'data-tab-out' ) === 'true' ) {
-			element_target.setAttribute( 'data-tab-out', 'false' );
+		if ( elementTarget.getAttribute( 'data-tab-out' ) === 'true' ) {
+			elementTarget.setAttribute( 'data-tab-out', 'false' );
 			return;
 		}
 
-		const selStart = element_target.selectionStart;
-		const selEnd = element_target.selectionEnd;
-		const val = element_target.value;
+		const selStart = elementTarget.selectionStart;
+		const selEnd = elementTarget.selectionEnd;
+		const val = elementTarget.value;
 
 		if ( document.selection ) {
-			element_target.focus();
+			elementTarget.focus();
 			sel = document.selection.createRange();
 			sel.text = '\t';
 		} else if ( selStart >= 0 ) {
-			scroll = element_target.scrollTop;
-			element_target.value = val.substring( 0, selStart ).concat( '\t', val.substring( selEnd ) );
-			element_target.selectionStart = element_target.selectionEnd = selStart + 1;
-			element_target.scrollTop = scroll;
+			scroll = elementTarget.scrollTop;
+			elementTarget.value = val.substring( 0, selStart ).concat( '\t', val.substring( selEnd ) );
+			elementTarget.selectionStart = elementTarget.selectionEnd = selStart + 1;
+			elementTarget.scrollTop = scroll;
 		}
 
 		if ( e.stopPropagation ) e.stopPropagation();

--- a/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
@@ -3,63 +3,82 @@
  *
  */
 
-( function( $ ) {
+( function () {
+	const commentForm = document.querySelector( '.comment-form textarea' );
+	let commentID = window.location.hash;
+	let wpAdminBar = 0;
 
-	var commentForm = $( '.comment-form textarea' );
-	var commentID = window.location.hash;
-	var wpAdminBar = 0;
-
-	// Check if the fragment identifier is a comment ID (e.g. #comment-63)
+	// Check if the fragment identifier is a comment ID (e.g. #comment-63).
 	if ( ! commentID.match( /#comment\-[0-9]+$/ ) ) {
 		commentID = '';
 	}
 
-	// Actions for when the page is ready
-	$( document ).ready( function() {
-		// Set wpAdminBar
-		wpAdminBar = $( '#wpadminbar' ).length ? 32 : 0;
-
+	// Actions for when the page is ready.
+	document.addEventListener( 'DOMContentLoaded', function () {
+		// Set wpAdminBar.
+		wpAdminBar = document.querySelector( '#wpadminbar' ).length ? 32 : 0;
 		// Display form and scroll to it
 		if ( '#respond' === window.location.hash ) {
 			showCommentForm();
 		}
-
-		if( ! wpAdminBar || ! commentID ) {
+		if ( ! wpAdminBar || ! commentID ) {
 			return;
 		}
-
-		var comment = $('#comments').find( commentID + '.depth-1' ).first();
-		if( ! comment.length  ) {
+		const comment = document
+			.querySelector( '#comments' )
+			.find( commentID + '.depth-1' )
+			.first();
+		if ( ! comment.length ) {
 			return;
 		}
 
 		// Scroll to top level comment and adjust for admin bar.
-		var pos = comment.offset();
-		$( 'html,body' ).animate( {
-			scrollTop: pos.top - wpAdminBar
-		}, 1 );
+		const pos = comment.getBoundingClientRect();
+		window.scrollTo( {
+			top: window.scrollY + pos.top - wpAdminBar,
+			behavior: 'smooth',
+		} );
 	} );
 
 	// Scroll to comment if comment date link is clicked
-	$( '#comments' ).on( 'click', '.comment-date', function( e ) {
+	$( '#comments' ).on( 'click', '.comment-date', function ( e ) {
 		// Scroll to comment and adjust for admin bar
 		// Add 16px for child comments
-		var pos = $( this ).offset();
-		$( 'html,body' ).animate( {
-			scrollTop: pos.top - wpAdminBar - 16
-		}, 1 );
+		const pos = $( this ).offset();
+		$( 'html,body' ).animate(
+			{
+				scrollTop: pos.top - wpAdminBar - 16,
+			},
+			1
+		);
+	} );
+
+	// Scroll to comment if comment date link is clicked.
+	document.querySelectorAll( '#comments .comment-date' ).forEach( ( element ) => {
+		element.addEventListener( 'click', function () {
+			// Scroll to comment and adjust for admin bar.
+			// Add 16px for child comments.
+			const pos = this.getBoundingClientRect();
+			const offsetTop = pos.top + window.scrollY;
+			window.scrollTo( {
+				top: offsetTop - wpAdminBar - 16,
+				behavior: 'smooth',
+			} );
+		} );
 	} );
 
 	function showCommentForm() {
-		var target = $( '#commentform #add-note-or-feedback' );
-		if ( target.length ) {
-			var pos = target.offset();
+		const target = document.querySelector( '#commentform #add-note-or-feedback' );
+		if ( target ) {
+			const pos = target.getBoundingClientRect();
+			const offsetTop = pos.top + window.scrollY;
 
-			$( 'html,body' ).animate( {
-				scrollTop: pos.top - wpAdminBar
-			}, 1000 );
+			window.scrollTo( {
+				top: offsetTop - wpAdminBar,
+				behavior: 'smooth',
+			} );
 
-			$('.wp-editor-area').focus();
+			document.querySelector( '.wp-editor-area' ).focus();
 		}
 	}
 
@@ -67,9 +86,11 @@
 		return;
 	}
 
-	$( '.table-of-contents a[href="#add-note-or-feedback"]' ).click( function( e ) {
-		e.preventDefault();
-		showCommentForm();
+	document.querySelectorAll( '.table-of-contents a[href="#add-note-or-feedback"]' ).forEach( ( element ) => {
+		element.addEventListener( 'click', function ( e ) {
+			e.preventDefault();
+			showCommentForm();
+		} );
 	} );
 
 	// Add php and js buttons to QuickTags.
@@ -79,43 +100,43 @@
 
 	// Override tab within user notes textarea to actually insert a tab character.
 	// Copied from code within core's wp-admin/js/common.js.
-	commentForm.bind('keydown.wpevent_InsertTab', function(e) {
-		var el = e.target, selStart, selEnd, val, scroll, sel;
+	commentForm.bind( 'keydown.wpevent_InsertTab', function ( e ) {
+		const element_target = e.target;
+		let scroll, sel;
 
-		if ( e.keyCode == 27 ) { // escape key
+		if ( e.key === 'Escape' ) {
+			// escape key
 			// when pressing Escape: Opera 12 and 27 blur form fields, IE 8 clears them
 			e.preventDefault();
-			$(el).data('tab-out', true);
+			element_target.setAttribute( 'data-tab-out', 'true' );
 			return;
 		}
 
-		if ( e.keyCode != 9 || e.ctrlKey || e.altKey || e.shiftKey ) // tab key
+		if ( e.key !== 'Tab' || e.ctrlKey || e.altKey || e.shiftKey )
+			// tab key
 			return;
 
-		if ( $(el).data('tab-out') ) {
-			$(el).data('tab-out', false);
+		if ( element_target.getAttribute( 'data-tab-out' ) === 'true' ) {
+			element_target.setAttribute( 'data-tab-out', 'false' );
 			return;
 		}
 
-		selStart = el.selectionStart;
-		selEnd = el.selectionEnd;
-		val = el.value;
+		const selStart = element_target.selectionStart;
+		const selEnd = element_target.selectionEnd;
+		const val = element_target.value;
 
 		if ( document.selection ) {
-			el.focus();
+			element_target.focus();
 			sel = document.selection.createRange();
 			sel.text = '\t';
 		} else if ( selStart >= 0 ) {
-			scroll = this.scrollTop;
-			el.value = val.substring(0, selStart).concat('\t', val.substring(selEnd) );
-			el.selectionStart = el.selectionEnd = selStart + 1;
-			this.scrollTop = scroll;
+			scroll = element_target.scrollTop;
+			element_target.value = val.substring( 0, selStart ).concat( '\t', val.substring( selEnd ) );
+			element_target.selectionStart = element_target.selectionEnd = selStart + 1;
+			element_target.scrollTop = scroll;
 		}
 
-		if ( e.stopPropagation )
-			e.stopPropagation();
-		if ( e.preventDefault )
-			e.preventDefault();
-	});
-
-} )( jQuery );
+		if ( e.stopPropagation ) e.stopPropagation();
+		if ( e.preventDefault ) e.preventDefault();
+	} );
+} )();

--- a/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
@@ -31,26 +31,13 @@
 		if ( ! comment.length ) {
 			return;
 		}
-
+		console.log( 'patata' );
 		// Scroll to top level comment and adjust for admin bar.
 		const pos = comment.getBoundingClientRect();
 		window.scrollTo( {
 			top: window.scrollY + pos.top - wpAdminBar,
 			behavior: 'smooth',
 		} );
-	} );
-
-	// Scroll to comment if comment date link is clicked
-	$( '#comments' ).on( 'click', '.comment-date', function ( e ) {
-		// Scroll to comment and adjust for admin bar
-		// Add 16px for child comments
-		const pos = $( this ).offset();
-		$( 'html,body' ).animate(
-			{
-				scrollTop: pos.top - wpAdminBar - 16,
-			},
-			1
-		);
 	} );
 
 	// Scroll to comment if comment date link is clicked.
@@ -64,6 +51,7 @@
 				top: offsetTop - wpAdminBar - 16,
 				behavior: 'smooth',
 			} );
+			console.log( 'patata' );
 		} );
 	} );
 
@@ -72,7 +60,7 @@
 		if ( target ) {
 			const pos = target.getBoundingClientRect();
 			const offsetTop = pos.top + window.scrollY;
-
+			console.log( 'patata' );
 			window.scrollTo( {
 				top: offsetTop - wpAdminBar,
 				behavior: 'smooth',
@@ -90,6 +78,7 @@
 		element.addEventListener( 'click', function ( e ) {
 			e.preventDefault();
 			showCommentForm();
+			console.log( 'patata' );
 		} );
 	} );
 

--- a/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
@@ -31,7 +31,6 @@
 		if ( ! comment.length ) {
 			return;
 		}
-		console.log( 'patata' );
 		// Scroll to top level comment and adjust for admin bar.
 		const pos = comment.getBoundingClientRect();
 		window.scrollTo( {
@@ -51,7 +50,6 @@
 				top: offsetTop - wpAdminBar - 16,
 				behavior: 'smooth',
 			} );
-			console.log( 'patata' );
 		} );
 	} );
 
@@ -60,7 +58,6 @@
 		if ( target ) {
 			const pos = target.getBoundingClientRect();
 			const offsetTop = pos.top + window.scrollY;
-			console.log( 'patata' );
 			window.scrollTo( {
 				top: offsetTop - wpAdminBar,
 				behavior: 'smooth',
@@ -78,7 +75,6 @@
 		element.addEventListener( 'click', function ( e ) {
 			e.preventDefault();
 			showCommentForm();
-			console.log( 'patata' );
 		} );
 	} );
 
@@ -94,16 +90,14 @@
 		let scroll, sel;
 
 		if ( e.key === 'Escape' ) {
-			// escape key
-			// when pressing Escape: Opera 12 and 27 blur form fields, IE 8 clears them
+			console.log( 'Escape' );
+			// When pressing Escape: Opera 12 and 27 blur form fields, IE 8 clears them.
 			e.preventDefault();
 			element_target.setAttribute( 'data-tab-out', 'true' );
 			return;
 		}
 
-		if ( e.key !== 'Tab' || e.ctrlKey || e.altKey || e.shiftKey )
-			// tab key
-			return;
+		if ( e.key !== 'Tab' || e.ctrlKey || e.altKey || e.shiftKey ) return;
 
 		if ( element_target.getAttribute( 'data-tab-out' ) === 'true' ) {
 			element_target.setAttribute( 'data-tab-out', 'false' );

--- a/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
@@ -41,12 +41,12 @@
 	document.querySelectorAll( '.comment-list .comment-date' ).forEach( ( element ) => {
 		element.addEventListener( 'click', function ( event ) {
 			// Scroll to comment and adjust for admin bar.
-			// Add 16px for child comments.
+			// Add 16px for child comments and 60px for the new header.
 			event.preventDefault();
 			const pos = this.getBoundingClientRect();
 			const offsetTop = pos.top + window.scrollY;
 			window.scrollTo( {
-				top: offsetTop - wpAdminBar - 16,
+				top: offsetTop - wpAdminBar - 76,
 				behavior: 'smooth',
 			} );
 		} );

--- a/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
@@ -16,7 +16,8 @@
 	// Actions for when the page is ready.
 	document.addEventListener( 'DOMContentLoaded', function () {
 		// Set wpAdminBar.
-		wpAdminBar = document.querySelector( '#wpadminbar' ).length ? 32 : 0;
+		wpAdminBar =
+			! document.querySelector( '#wpadminbar' ) || document.querySelector( '#wpadminbar' ).length ? 32 : 0;
 		// Display form and scroll to it
 		if ( '#respond' === window.location.hash ) {
 			showCommentForm();
@@ -24,11 +25,8 @@
 		if ( ! wpAdminBar || ! commentID ) {
 			return;
 		}
-		const comment = document
-			.querySelector( '#comments' )
-			.find( commentID + '.depth-1' )
-			.first();
-		if ( ! comment.length ) {
+		const comment = document.querySelector( `.comment-list ${ commentID } .depth-1` );
+		if ( ! comment || ! comment.length ) {
 			return;
 		}
 		// Scroll to top level comment and adjust for admin bar.
@@ -40,10 +38,11 @@
 	} );
 
 	// Scroll to comment if comment date link is clicked.
-	document.querySelectorAll( '#comments .comment-date' ).forEach( ( element ) => {
-		element.addEventListener( 'click', function () {
+	document.querySelectorAll( '.comment-list .comment-date' ).forEach( ( element ) => {
+		element.addEventListener( 'click', function ( event ) {
 			// Scroll to comment and adjust for admin bar.
 			// Add 16px for child comments.
+			event.preventDefault();
 			const pos = this.getBoundingClientRect();
 			const offsetTop = pos.top + window.scrollY;
 			window.scrollTo( {
@@ -67,7 +66,7 @@
 		}
 	}
 
-	if ( ! commentForm.length ) {
+	if ( ! commentForm || ! commentForm.length ) {
 		return;
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
+++ b/source/wp-content/themes/wporg-developer-2023/js/user-notes.js
@@ -89,13 +89,6 @@
 		const elementTarget = e.target;
 		let scroll, sel;
 
-		if ( e.key === 'Escape' ) {
-			// When pressing Escape: Opera 12 and 27 blur form fields, IE 8 clears them.
-			e.preventDefault();
-			elementTarget.setAttribute( 'data-tab-out', 'true' );
-			return;
-		}
-
 		if ( e.key !== 'Tab' || e.ctrlKey || e.altKey || e.shiftKey ) return;
 
 		if ( elementTarget.getAttribute( 'data-tab-out' ) === 'true' ) {


### PR DESCRIPTION
## What

Remove jQuery from `user-notes.js`

## Why

jQuery is known to inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. 
