### PR TITLE
Update Composer packages causing failures

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2679,12 +2679,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "a79757142e75d5339bffb82de45f5746d5dbe390"
+                "reference": "823e5de983acee45d1512ad73fa33e97223521e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/a79757142e75d5339bffb82de45f5746d5dbe390",
-                "reference": "a79757142e75d5339bffb82de45f5746d5dbe390",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/823e5de983acee45d1512ad73fa33e97223521e4",
+                "reference": "823e5de983acee45d1512ad73fa33e97223521e4",
                 "shasum": ""
             },
             "require": {
@@ -2725,7 +2725,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2024-11-13T04:16:01+00:00"
+            "time": "2025-12-01T06:37:31+00:00"
         },
         {
             "name": "wporg/wporg-parent-2021",
@@ -2733,12 +2733,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-parent-2021.git",
-                "reference": "b92fde685fd7edd37bdcf2842c15a45ebc06c269"
+                "reference": "55816453862ce3ed2cd70dc7f84f41c9e837d8d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/b92fde685fd7edd37bdcf2842c15a45ebc06c269",
-                "reference": "b92fde685fd7edd37bdcf2842c15a45ebc06c269",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/55816453862ce3ed2cd70dc7f84f41c9e837d8d7",
+                "reference": "55816453862ce3ed2cd70dc7f84f41c9e837d8d7",
                 "shasum": ""
             },
             "type": "wordpress-theme",
@@ -2746,7 +2746,7 @@
                 "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
                 "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
             },
-            "time": "2024-11-13T04:15:50+00:00"
+            "time": "2025-10-15T23:48:25+00:00"
         },
         {
             "name": "wporg/wporg-repo-tools",
@@ -2845,17 +2845,17 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "wporg/wporg-repo-tools": 20,
-        "wporg/wporg-mu-plugins": 20,
         "wordpress/phpdoc-parser": 20,
-        "wporg/wporg-parent-2021": 20
+        "wporg/wporg-mu-plugins": 20,
+        "wporg/wporg-parent-2021": 20,
+        "wporg/wporg-repo-tools": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"@wordpress/env": "9.2.0"
 	},
 	"scripts": {
-		"setup:tools": "yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs && composer --working-dir=./source/wp-content/plugins/phpdoc-parser install",
+      "setup:tools": "yarn && composer install || composer update 'wporg/*' && TEXTDOMAIN=wporg composer exec update-configs && composer --working-dir=./source/wp-content/plugins/phpdoc-parser install",
 		"setup": "yarn setup:wp && yarn parse",
 		"setup:wp": "wp-env run cli bash env/setup.sh",
 		"parse": "wp-env run cli wp devhub parse --user_id=1",


### PR DESCRIPTION
This updates the `wporg/wporg-mu-plugins` and `wporg/wporg-parent-2021` dependencies in Composer.

When running `yarn setup:tools` for the first time, the command will fail due to the pinned commit hashes being removed from these repositories.

It seems like this can happen through rebases, but it's not clear why this is happening for these two repositories.

This is a more targeted change than #549, which seems to run `composer update` without limiting the command to specific dependencies. I am only seeing these two repositories causing failures. The other dependencies should likely be upgraded more intentionally.