### PR TITLE
Update third-party GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,16 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
             - name: Install NodeJS
-              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
+              uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
               with:
                   node-version-file: '.nvmrc'
                   cache: 'yarn'
 
             - name: Setup PHP with PECL extension
-              uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
+              uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
               with:
                 php-version: '7.4'
               env:
@@ -55,7 +55,7 @@ jobs:
                   sed -i "s/Version: $current_version/Version: $new_version/" style.css
 
             - name: Commit and push
-              uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
+              uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # 1.5
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   branch: build

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,16 +14,16 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
             - name: Install NodeJS
-              uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.3.0
+              uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
               with:
                   node-version-file: '.nvmrc'
                   cache: yarn
 
             - name: Setup PHP with PECL extension
-              uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
+              uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
               with:
                 php-version: '7.4'
               env:


### PR DESCRIPTION
This updates all GitHub actions to their latest versions. Because some of these are really outdated, they are causing some deprecated notices for the `save-state` command (which will be removed in the near future.

[Here is an example of a workflow failing](https://github.com/WordPress/wporg-developer/actions/runs/20173575957) due to the age of these dependencies.

Updates performed:
- `actions/checkout` from 2.4.0 to 6.0.1
- `actions/setup-node` from 3.1.0 to 6.1.0
- `shivammathur/setup-php` from 2.22.0 to 2.36.0
- `actions-js/push` from 1.3 to 1.5