### PR TITLE
Don't load translations too early

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/explanations.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/explanations.php
@@ -10,15 +10,6 @@
  * for various Code Reference post types.
  */
 class WPORG_Explanations {
-
-	/**
-	 * List of Code Reference post types.
-	 *
-	 * @access public
-	 * @var array
-	 */
-	public $post_types = array();
-
 	/**
 	 * Explanations post type slug.
 	 *
@@ -41,8 +32,6 @@ class WPORG_Explanations {
 	 * @access public
 	 */
 	public function __construct() {
-		$this->post_types = DevHub\get_parsed_post_types();
-
 		$this->screen_ids = [ $this->exp_post_type, "edit-{$this->exp_post_type}" ];
 
 		// Setup.
@@ -116,7 +105,7 @@ class WPORG_Explanations {
 	 * @access public
 	 */
 	public function remove_editor_support() {
-		foreach ( $this->post_types as $type ) {
+		foreach ( DevHub\get_parsed_post_types() as $type ) {
 			remove_post_type_support( $type, 'editor' );
 		}
 	}
@@ -216,7 +205,7 @@ class WPORG_Explanations {
 	 * @param WP_Post $post Current post object.
 	 */
 	public function post_to_expl_controls( $post ) {
-		if ( ! in_array( $post->post_type, $this->post_types ) ) {
+		if ( ! in_array( $post->post_type, DevHub\get_parsed_post_types() ) ) {
 			return;
 		}
 
@@ -311,7 +300,7 @@ class WPORG_Explanations {
 
 		$screen = $wp_the_query->get_queried_object();
 
-		if ( is_admin() || empty( $screen->post_type ) || ! is_singular( $this->post_types ) ) {
+		if ( is_admin() || empty( $screen->post_type ) || ! is_singular( DevHub\get_parsed_post_types() ) ) {
 			return;
 		}
 
@@ -411,7 +400,7 @@ class WPORG_Explanations {
 	 * @return array (Maybe) filtered row actions.
 	 */
 	public function expl_row_action( $actions, $post ) {
-		if ( ! in_array( $post->post_type, \DevHub\get_parsed_post_types() ) ) {
+		if ( ! in_array( $post->post_type, DevHub\get_parsed_post_types() ) ) {
 			return $actions;
 		}
 

--- a/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
@@ -10,25 +10,12 @@
  * and Method-editing screens.
  */
 class WPORG_Edit_Parsed_Content {
-
-	/**
-	 * Post types array.
-	 *
-	 * Includes the Code Reference post types.
-	 *
-	 * @access public
-	 * @var array
-	 */
-	public $post_types;
-
 	/**
 	 * Constructor.
 	 *
 	 * @access public
 	 */
 	public function __construct() {
-		$this->post_types = DevHub\get_parsed_post_types();
-
 		// Data.
 		add_action( 'add_meta_boxes',              array( $this, 'add_meta_boxes'        ) );
 		add_action( 'save_post',                   array( $this, 'save_post'             ) );
@@ -52,7 +39,7 @@ class WPORG_Edit_Parsed_Content {
 	 * @access public
 	 */
 	public function add_meta_boxes() {
-		if ( in_array( $screen = get_current_screen()->id, $this->post_types ) ) {
+		if ( in_array( $screen = get_current_screen()->id, DevHub\get_parsed_post_types() ) ) {
 			remove_meta_box( 'postexcerpt', $screen, 'normal' );
 			add_meta_box( 'wporg_parsed_content', __( 'Parsed Content', 'wporg' ), array( $this, 'parsed_meta_box_cb' ), $screen, 'normal' );
 		}
@@ -166,7 +153,7 @@ class WPORG_Edit_Parsed_Content {
 	 */
 	public function admin_enqueue_scripts() {
 		// Only enqueue 'wporg-parsed-content' script and styles on Code Reference post type screens.
-		if ( in_array( get_current_screen()->id, $this->post_types ) ) {
+		if ( in_array( get_current_screen()->id, DevHub\get_parsed_post_types() ) ) {
 			wp_enqueue_script(
 				'wporg-parsed-content',
 				get_stylesheet_directory_uri() . '/js/parsed-content.js',


### PR DESCRIPTION
`DevHub\get_parsed_post_types` is executed directly in the constructor, without going through a hook. Because get_parsed_post_types contains a translation function, the following error will be displayed if `WP_DEBUG` is `true`.

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the wporg domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) in /var/www/html/wp-includes/functions.php on line 6131 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6131) in /var/www/html/wp-includes/functions.php on line 7182 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6131) in /var/www/html/wp-admin/admin-header.php on line 14
```

This error is annoying when developing locally, so let's call `get_parsed_post_types` each time it's needed, rather than in the constructor.

Since this function just returns a simple array, there should be no performance issues with running it inline.