### PR TITLE
Style preview loading spinner for user notes

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/style.css
+++ b/source/wp-content/themes/wporg-developer-2023/style.css
@@ -14,3 +14,15 @@
  * Note: only add styles here in cases where you can't achieve the style with
  * templates or theme.json settings.
  */
+
+ .spinner {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	vertical-align: middle;
+	margin-left: 6px;
+	background: url(/wp-admin/images/spinner.gif) no-repeat;
+	background-size: 16px 16px;
+}
+
+


### PR DESCRIPTION
Adds styling for the loading spinner shown in the Preview tab when editing or creating user notes, so the loading state is visible while the preview loads.

Fixes #534
