### PR TITLE
Add URL redirects for Interactivity API docs restructuring

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
@@ -112,6 +112,11 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 			'tutorials/devenv'                => 'getting-started/devenv',
 			'tutorials/devenv/docker-ubuntu'  => 'getting-started/devenv/docker-ubuntu',
 			'tutorials/block-based-theme'     => 'how-to-guides/themes/block-theme-overview',
+
+			// After IAPI restructuring, Feb 2025 - PRs #75357 & #74974.
+			'reference-guides/interactivity-api/api-reference'                                                              => 'reference-guides/interactivity-api/directives-and-store',
+			'reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state'    => 'reference-guides/interactivity-api/core-concepts/understanding-global-state-local-context-derived-state-and-config',
+
 		];
 
 		// General path redirects. (More specific path first.)


### PR DESCRIPTION
## What?

Adds two path redirects in the block editor importer to handle URL changes from recent Gutenberg IAPI documentation restructuring.

## Why?

Two Gutenberg PRs renamed Interactivity API pages, which breaks existing links on developer.wordpress.org:

- https://github.com/WordPress/gutenberg/pull/74974 — Renamed the api-reference page to directives-and-store to avoid the redundant "Interactivity API Reference > API Reference" hierarchy.
- https://github.com/WordPress/gutenberg/pull/75357#issuecomment-3913533716 — Renamed the core concepts state/context guide to include config in the slug (and fixed the undestanding typo), after expanding the guide to cover the non-reactive config concept.