### PR TITLE
Enhancement: Set posts per page to 1000 in the block editor importer

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php
@@ -12,6 +12,8 @@ class DevHub_Block_Editor_Importer extends DevHub_Docs_Importer {
 			'block-editor',
 			$manifest
 		);
+		
+		$this->posts_per_page = 1000;
 
 		add_filter( 'template_redirect', array( $this, 'redirects' ), 1 );
 		add_filter( 'handbook_label', array( $this, 'change_handbook_label' ), 10, 2 );


### PR DESCRIPTION
## What

Increases the `posts_per_page` limit for the Block Editor Handbook importer from 500 to 1000.

## Why

The base `Importer` class ([`wporg-markdown/inc/class-importer.php`](https://github.com/WordPress/wporg-developer/blob/trunk/source/wp-content/plugins/wporg-markdown/inc/class-importer.php#L41)) defaults to querying a maximum of 500 existing handbook posts when running `import_manifest()`. This limit is used to build a lookup table of existing posts so the importer can decide whether to update or create each manifest entry.

The Block Editor Handbook manifest currently has ~530 entries. With the upcoming addition of per-block reference pages ([WordPress/gutenberg#77350](https://github.com/WordPress/gutenberg/pull/77350)), the manifest will grow to ~700+ entries.

When the manifest exceeds the 500-post query limit, each subsequent cron run of `devhub_blocks_import_manifest` fails to find all existing posts in the lookup table. Posts beyond the limit are treated as new, causing:

- **Duplicate posts** with incrementing slugs (`how-to-guides-2`, `how-to-guides-3`, etc.)
- **Orphaned children** at the top level, because the parent post lookup also fails
- **Snowball effect**: each duplicate increases the total post count, pushing more posts beyond the limit on the next run

The `yarn setup` script triggers `devhub_blocks_import_manifest` twice across two cron batches, which is enough to reproduce the issue on a fresh environment.

## How

Overrides `$this->posts_per_page = 1000` in `DevHub_Block_Editor_Importer::init()` after calling `parent::do_init()`. This is scoped to the block editor handbook only, leaving other handbooks (which have far fewer entries) unaffected.

## Testing

1. Clone the repo and apply this change
2. Edit `import-block-editor.php` to point the manifest at [gutenberg#77350](https://github.com/WordPress/gutenberg/pull/77350):

```php
$manifest = 'https://raw.githubusercontent.com/WordPress/gutenberg/refs/pull/77350/head/docs/manifest.json';
```

3. Run `wp-env destroy && wp-env start && yarn setup`
4. Visit `http://localhost:8888/block-editor/` — the sidebar should have no duplicate entries
5. Verify with: `wp-env run cli wp db query "SELECT COUNT(*) FROM wp_posts WHERE post_type='blocks-handbook' AND post_title='How-to Guides' AND post_status='publish'"` — should return `1`

**Without this fix**, the same steps produce 12+ duplicate "How-to Guides" entries and orphaned pages throughout the sidebar.