### PR TITLE
Trim browser-only chrome from ?output_format=md requests

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/functions.php
+++ b/source/wp-content/themes/wporg-developer-2023/functions.php
@@ -119,6 +119,11 @@ require __DIR__ . '/inc/autocomplete.php';
 require __DIR__ . '/inc/search.php';
 
 /**
+ * Suppress unwanted sections on ?output_format=md requests.
+ */
+require __DIR__ . '/inc/markdown-output.php';
+
+/**
  * Parser customizations.
  */
 require __DIR__ . '/inc/parser.php';

--- a/source/wp-content/themes/wporg-developer-2023/inc/markdown-output.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/markdown-output.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Suppress sections that don't belong in the markdown rendering.
+ *
+ * The html-to-md mu-plugin converts the full HTML template output to markdown
+ * whenever a request asks for it (via ?output_format=md, ?output_format=markdown,
+ * or an `Accept: text/markdown` header). Several theme blocks add content that
+ * is meaningful in the browser but pure noise in a markdown body intended for
+ * LLMs or scripted consumers — the in-article TOC, user-contributed notes, and
+ * the comment form / login prompt.
+ *
+ * Short-circuit each of those blocks via `pre_render_block` so we don't even
+ * run their render callbacks (which query comments, notes, etc.) on markdown
+ * requests.
+ *
+ * @package WordPressdotorg\Theme\Developer_2023
+ */
+
+namespace WordPressdotorg\Theme\Developer_2023\Markdown_Output;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Block names suppressed when the request asked for markdown.
+ */
+const SUPPRESSED_BLOCKS = array(
+	'wporg/sidebar-container',           // Sidebar wrapper — also adds the "↑ Back to top" tail.
+	'wporg/table-of-contents',           // "In this article" sidebar TOC.
+	'wporg/code-reference-comment-form', // Login prompt + comment form + heading.
+	'wporg/code-reference-comments',     // Rendered list of user notes.
+	'wporg/code-reference-user-notes',   // Standalone notes block.
+	'wporg/code-reference-comment-edit', // Edit-note form.
+);
+
+/**
+ * Theme patterns to suppress. Each is rendered as a `core/pattern` block with
+ * the listed slug as an attribute — they're handbook-page footers that either
+ * duplicate frontmatter ("First published" / "Last updated") or add UI-only
+ * navigation that doesn't make sense in a static markdown render ("Previous: …",
+ * "Next: …").
+ */
+const SUPPRESSED_PATTERNS = array(
+	'wporg-developer-2023/article-meta',
+	'wporg-developer-2023/article-meta-block-editor',
+	'wporg-developer-2023/article-meta-github',
+	'wporg-developer-2023/handbook-pagination',
+);
+
+add_filter( 'pre_render_block', __NAMESPACE__ . '\\maybe_suppress_block', 10, 2 );
+add_filter( 'render_block_data', __NAMESPACE__ . '\\maybe_expand_code_table', 10 );
+add_filter( 'render_block_wporg/code-reference-parameters', __NAMESPACE__ . '\\maybe_space_param_dt', 10 );
+add_filter( 'html_to_markdown_frontmatter_fields', __NAMESPACE__ . '\\strip_author_field', 10 );
+
+/**
+ * Detection mirrors the html-to-md mu-plugin so this stays accurate even when
+ * the mu-plugin's detection changes (since these run in the same request).
+ */
+function is_markdown_request(): bool {
+	$by_query  = in_array( $_GET['output_format'] ?? '', array( 'md', 'markdown' ), true );
+	$by_accept = 1 === preg_match( '~^text/(?:x-)?markdown(?:[,;]|$)~', $_SERVER['HTTP_ACCEPT'] ?? '' );
+
+	return $by_query || $by_accept;
+}
+
+/**
+ * Short-circuit the suppressed blocks on markdown requests.
+ *
+ * Returning a non-null value from `pre_render_block` skips the entire render
+ * pipeline for that block — its render_callback never fires, so we save the
+ * comments / notes queries that those callbacks would otherwise run.
+ *
+ * @param string|null $pre   The pre-rendered HTML, or null to render normally.
+ * @param array       $block The parsed block.
+ * @return string|null
+ */
+function maybe_suppress_block( $pre, $block ) {
+	if ( null !== $pre ) {
+		return $pre;
+	}
+	if ( ! is_markdown_request() ) {
+		return $pre;
+	}
+
+	$name = $block['blockName'] ?? '';
+
+	if ( in_array( $name, SUPPRESSED_BLOCKS, true ) ) {
+		return '';
+	}
+
+	if ( 'core/pattern' === $name && in_array( $block['attrs']['slug'] ?? '', SUPPRESSED_PATTERNS, true ) ) {
+		return '';
+	}
+
+	return $pre;
+}
+
+/**
+ * Force `wporg/code-table` to render every row on markdown requests.
+ *
+ * The block hides rows beyond `itemsToShow` (default 5) behind a JS-driven
+ * "Show more" / "Show less" toggle. In the markdown rendering the JS never
+ * runs, so the hidden rows are silently lost. Bumping the attribute keeps
+ * every Changelog / Related / etc. row in the body.
+ *
+ * @param array $parsed_block The parsed block data.
+ * @return array
+ */
+function maybe_expand_code_table( $parsed_block ) {
+	if ( 'wporg/code-table' !== ( $parsed_block['blockName'] ?? '' ) ) {
+		return $parsed_block;
+	}
+	if ( ! is_markdown_request() ) {
+		return $parsed_block;
+	}
+
+	$parsed_block['attrs']['itemsToShow'] = PHP_INT_MAX;
+
+	return $parsed_block;
+}
+
+/**
+ * Insert spaces between the inline spans inside each parameter `<dt>` so the
+ * markdown rendering reads `$var string required` instead of `$varstringrequired`.
+ *
+ * The `<dt>` is `<code>$var</code><span class="type">…</span><span class="required">…</span>`
+ * with no whitespace between siblings — CSS handles the layout in the browser,
+ * so adding plain ASCII whitespace here is invisible to web view but gives the
+ * HTML-to-markdown converter the separator it needs.
+ *
+ * @param string $html Rendered block HTML.
+ * @return string
+ */
+function maybe_space_param_dt( $html ) {
+	if ( ! is_markdown_request() ) {
+		return $html;
+	}
+
+	return str_replace(
+		array( '</code><span class="type">', '</span><span class="required">' ),
+		array( '</code> <span class="type">', '</span> <span class="required">' ),
+		$html
+	);
+}
+
+/**
+ * Drop the `author` YAML frontmatter field on developer.wordpress.org.
+ *
+ * The post author rarely reflects who wrote a developer-docs page — handbook
+ * pages get re-attributed during imports, code-reference posts are owned by
+ * the parser bot, and the author line just consumes tokens without telling
+ * the consumer anything actionable.
+ *
+ * @param array $fields YAML key => value pairs.
+ * @return array
+ */
+function strip_author_field( $fields ) {
+	unset( $fields['author'] );
+
+	return $fields;
+}


### PR DESCRIPTION
## Summary

When a request asks for the markdown rendering (via `?output_format=md`, `?output_format=markdown`, or an `Accept: text/markdown` header), the [html-to-md mu-plugin](https://github.com/dmsnell/html-to-md) converts the full template output to markdown. Several pieces of that output are meaningful in the browser but pure noise in a markdown body intended for LLMs and scripted consumers.

This PR adds a single `inc/markdown-output.php` whose filters fire only when `is_markdown_request()` is true, leaving the browser rendering untouched.

### What it suppresses on markdown requests

- "In this article" sidebar TOC and its "↑ Back to top" tail (`wporg/sidebar-container`, `wporg/table-of-contents`)
- User Contributed Notes — heading, login prompt, comment form, list of notes, edit form (`wporg/code-reference-comment-form`, `wporg/code-reference-comments`, `wporg/code-reference-user-notes`, `wporg/code-reference-comment-edit`)
- Handbook page footer patterns: `article-meta` ("First published" / "Last updated" — already in the YAML frontmatter) and `handbook-pagination` ("Previous:" / "Next:" nav)
- The `author` YAML frontmatter field (rarely reflects authorship of the rendered content on this site)

### What it improves

- `wporg/code-table` rows past `itemsToShow` are JS-hidden behind a "Show more" toggle; bumped to `PHP_INT_MAX` on markdown requests so the full Changelog / Related tables render inline
- Parameter `<dt>` markup is `<code>$var</code><span class="type">…</span><span class="required">…</span>` with CSS spacing — inject whitespace between the spans on markdown requests so the line reads `` `$var` string required `` instead of `` `$var`stringrequired ``

### Mechanism

- `pre_render_block` short-circuits suppressed blocks (and `core/pattern` by slug) — render callbacks and their queries never run
- `render_block_data` mutates `wporg/code-table`'s `itemsToShow` attr
- `render_block_wporg/code-reference-parameters` injects parameter spacing into the rendered HTML
- `html_to_markdown_frontmatter_fields` drops the `author` key

## Test plan

- [ ] Visit `?output_format=md` on a function page — confirm TOC, Back-to-top, and User Contributed Notes are gone; Changelog and Related render every row; parameters read with spaces
- [ ] Visit `?output_format=md` on a handbook page — confirm no "First published / Last updated" footer or Previous/Next nav
- [ ] Visit either page in a browser (no query arg) — confirm no visible change to the rendered page
- [ ] `Accept: text/markdown` header without query arg behaves the same as `?output_format=md`