### PR TITLE
Render parsed DocBlock PHP snippets with php-snippet

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -114,13 +114,21 @@ function get_description_content( $post_id ) {
 	}
 
 	if ( $has_snippets ) {
-		enqueue_php_code_snippet_script();
+		wp_enqueue_script_module(
+			'wporg-developer-php-code-snippet',
+			PHP_CODE_SNIPPET_SCRIPT_URL,
+			array(),
+			null
+		);
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
 	foreach ( array_keys( $used_setup_blueprints ) as $name ) {
 		if ( isset( $setup_blueprints[ $name ] ) ) {
-			$output .= render_blueprint_script( get_setup_blueprint_id( $post_id, $name ), $setup_blueprints[ $name ] );
+			$output .= render_php_code_snippet_blueprint_script(
+				get_php_code_snippet_setup_blueprint_id( $post_id, $name ),
+				$setup_blueprints[ $name ]
+			);
 		}
 	}
 
@@ -167,18 +175,6 @@ function get_description_content( $post_id ) {
 }
 
 /**
- * Enqueue the web component that renders and runs PHP snippets.
- */
-function enqueue_php_code_snippet_script() {
-	wp_enqueue_script_module(
-		'wporg-developer-php-code-snippet',
-		PHP_CODE_SNIPPET_SCRIPT_URL,
-		array(),
-		null
-	);
-}
-
-/**
  * Render parser snippet placeholders in HTML comments.
  *
  * @param string $description      Description HTML.
@@ -190,18 +186,25 @@ function enqueue_php_code_snippet_script() {
  * @return string
  */
 function render_php_code_snippet_placeholders( $description, $post_id, $snippets, $setup_blueprints, &$used_blueprints, &$placed ) {
-	$processor = new Code_Snippet_Placeholder_Processor( $description );
+	$processor = new PHP_Code_Snippet_Placeholder_Processor( $description );
 
 	while ( $processor->next_token() ) {
 		if ( \WP_HTML_Tag_Processor::COMMENT_AS_HTML_COMMENT !== $processor->get_comment_type() ) {
 			continue;
 		}
 
-		$index = get_php_code_snippet_placeholder_index( $processor->get_modifiable_text() );
-		if ( null === $index ) {
+		$comment_text = $processor->get_modifiable_text();
+		$prefix       = ' wp-parser-code-snippet:';
+		if ( ! str_starts_with( $comment_text, $prefix ) || ! str_ends_with( $comment_text, ' ' ) ) {
 			continue;
 		}
 
+		$index = substr( $comment_text, strlen( $prefix ), -1 );
+		if ( ! ctype_digit( $index ) ) {
+			continue;
+		}
+
+		$index = (int) $index;
 		if ( ! isset( $snippets[ $index ] ) || ! is_array( $snippets[ $index ] ) ) {
 			$processor->replace_current_token( '' );
 			continue;
@@ -221,28 +224,6 @@ function render_php_code_snippet_placeholders( $description, $post_id, $snippets
 	}
 
 	return $processor->get_updated_html();
-}
-
-/**
- * Return the parser snippet placeholder index from exact HTML comment text.
- *
- * @param string $comment_text HTML comment text.
- * @return int|null
- */
-function get_php_code_snippet_placeholder_index( $comment_text ) {
-	$prefix = ' wp-parser-code-snippet:';
-	$suffix = ' ';
-
-	if ( ! str_starts_with( $comment_text, $prefix ) || ! str_ends_with( $comment_text, $suffix ) ) {
-		return null;
-	}
-
-	$index = substr( $comment_text, strlen( $prefix ), -strlen( $suffix ) );
-	if ( ! ctype_digit( $index ) ) {
-		return null;
-	}
-
-	return (int) $index;
 }
 
 /**
@@ -268,9 +249,15 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		return '';
 	}
 
-	$code       = $snippet['code'];
+	$code      = $snippet['code'];
+	$post_slug = get_post_field( 'post_name', $post_id );
+	if ( ! $post_slug ) {
+		$post_slug = 'example';
+	}
+
+	$inline_blueprint_id = 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . absint( $index + 1 );
 	$attributes = array(
-		'name' => get_php_code_snippet_name( $post_id, $index ),
+		'name' => $post_slug . '-' . ( $index + 1 ) . '.php',
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {
@@ -279,10 +266,10 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 			isset( $setup_blueprints[ $snippet['blueprint'] ] ) &&
 			is_array( $setup_blueprints[ $snippet['blueprint'] ] )
 		) {
-			$attributes['blueprint']                 = get_setup_blueprint_id( $post_id, $snippet['blueprint'] );
+			$attributes['blueprint']                 = get_php_code_snippet_setup_blueprint_id( $post_id, $snippet['blueprint'] );
 			$used_blueprints[ $snippet['blueprint'] ] = true;
 		} elseif ( is_array( $snippet['blueprint'] ) ) {
-			$attributes['blueprint'] = get_inline_blueprint_id( $post_id, $index );
+			$attributes['blueprint'] = $inline_blueprint_id;
 		} else {
 			// Keep snippets with unusable setup visible without offering a Run action that cannot succeed.
 			$attributes['runnable'] = 'false';
@@ -291,13 +278,14 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$output = '';
 
-	if ( isset( $attributes['blueprint'] ) && $attributes['blueprint'] === get_inline_blueprint_id( $post_id, $index ) ) {
-		$output .= render_blueprint_script( $attributes['blueprint'], $snippet['blueprint'] );
+	if ( isset( $attributes['blueprint'] ) && $attributes['blueprint'] === $inline_blueprint_id ) {
+		$output .= render_php_code_snippet_blueprint_script( $attributes['blueprint'], $snippet['blueprint'] );
 	}
 
 	$snippet_output = '<php-snippet>';
 	$snippet_output .= wp_get_inline_script_tag(
-		escape_php_source_script_contents( $code ),
+		// Prevent the HTML parser from closing the script before the component reads the PHP source.
+		str_ireplace( '</script', '<\/script', $code ),
 		array( 'type' => 'application/x-php' )
 	);
 
@@ -309,7 +297,16 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	}
 
 	$snippet_output .= '</php-snippet>';
-	$output         .= render_php_code_snippet_element( $snippet_output, $attributes );
+
+	$tags = new \WP_HTML_Tag_Processor( $snippet_output );
+	if ( $tags->next_tag( 'php-snippet' ) ) {
+		foreach ( $attributes as $name => $value ) {
+			$tags->set_attribute( $name, $value );
+		}
+		$snippet_output = $tags->get_updated_html();
+	}
+
+	$output .= $snippet_output;
 
 	return $output;
 }
@@ -321,7 +318,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
  * @param array  $blueprint Blueprint data.
  * @return string
  */
-function render_blueprint_script( $id, $blueprint ) {
+function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 	if ( ! is_array( $blueprint ) ) {
 		return '';
 	}
@@ -341,49 +338,13 @@ function render_blueprint_script( $id, $blueprint ) {
 }
 
 /**
- * Render the php-snippet element with its attributes.
- *
- * @param string $html       php-snippet element markup.
- * @param array  $attributes Attributes keyed by name.
- * @return string
- */
-function render_php_code_snippet_element( $html, $attributes ) {
-	$tags = new \WP_HTML_Tag_Processor( $html );
-	if ( ! $tags->next_tag( 'php-snippet' ) ) {
-		return $html;
-	}
-
-	foreach ( $attributes as $name => $value ) {
-		$tags->set_attribute( $name, $value );
-	}
-
-	return $tags->get_updated_html();
-}
-
-/**
- * Return a stable snippet file name.
- *
- * @param int $post_id Post ID.
- * @param int $index   Zero-based snippet index.
- * @return string
- */
-function get_php_code_snippet_name( $post_id, $index ) {
-	$slug = get_post_field( 'post_name', $post_id );
-	if ( ! $slug ) {
-		$slug = 'example';
-	}
-
-	return sanitize_file_name( $slug . '-' . ( $index + 1 ) . '.php' );
-}
-
-/**
  * Return a stable script ID for a reusable setup Blueprint.
  *
  * @param int    $post_id Post ID.
  * @param string $name    Blueprint name.
  * @return string
  */
-function get_setup_blueprint_id( $post_id, $name ) {
+function get_php_code_snippet_setup_blueprint_id( $post_id, $name ) {
 	$slug = sanitize_title( $name );
 
 	if ( '' === $slug ) {
@@ -394,30 +355,9 @@ function get_setup_blueprint_id( $post_id, $name ) {
 }
 
 /**
- * Return a stable script ID for an inline setup Blueprint.
- *
- * @param int $post_id Post ID.
- * @param int $index   Zero-based snippet index.
- * @return string
- */
-function get_inline_blueprint_id( $post_id, $index ) {
-	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . absint( $index + 1 );
-}
-
-/**
- * Escape PHP source for embedding in script tags.
- *
- * @param string $content Script tag content.
- * @return string
- */
-function escape_php_source_script_contents( $content ) {
-	return str_ireplace( '</script', '<\/script', $content );
-}
-
-/**
  * HTML processor for replacing parser snippet placeholder comments.
  */
-class Code_Snippet_Placeholder_Processor extends \WP_HTML_Tag_Processor {
+class PHP_Code_Snippet_Placeholder_Processor extends \WP_HTML_Tag_Processor {
 	/**
 	 * Replace the currently matched token with HTML.
 	 *

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -69,14 +69,71 @@ function get_description_content( $post_id ) {
 
 	$description = get_description( $post_id );
 	$see_tags    = get_see_tags( $post_id );
-	$snippets    = get_code_snippets_content( $post_id );
 
-	if ( ! $description && ! $see_tags && ! $snippets ) {
+	$snippets = get_post_meta( $post_id, '_wp-parser_code_snippets', true );
+	if ( ! is_array( $snippets ) ) {
+		$snippets = array();
+	}
+	$setup_blueprints = get_post_meta( $post_id, '_wp-parser_setup_blueprints', true );
+	if ( ! is_array( $setup_blueprints ) ) {
+		$setup_blueprints = array();
+	}
+
+	$used_setup_blueprints = array();
+	$placed                = array();
+
+	// Render each snippet in place, where the parser left its placeholder
+	// ( <!-- wp-parser-code-snippet:N --> ), so snippets stay between the
+	// surrounding prose instead of collapsing to the end of the description.
+	$description = preg_replace_callback(
+		'/<!--\s*wp-parser-code-snippet:(\d+)\s*-->/',
+		function ( $matches ) use ( $post_id, $snippets, $setup_blueprints, &$used_setup_blueprints, &$placed ) {
+			$index = (int) $matches[1];
+			if ( ! isset( $snippets[ $index ] ) || ! is_array( $snippets[ $index ] ) ) {
+				return '';
+			}
+			$placed[ $index ] = true;
+			return render_php_code_snippet( $post_id, $index, $snippets[ $index ], $setup_blueprints, $used_setup_blueprints );
+		},
+		(string) $description
+	);
+
+	// Fallback: any snippet without a placeholder (e.g. metadata imported from an
+	// older parser that stripped fences without leaving markers) is appended, so
+	// nothing is silently dropped.
+	$appended = '';
+	foreach ( array_values( $snippets ) as $index => $snippet ) {
+		if ( isset( $placed[ $index ] ) ) {
+			continue;
+		}
+		if ( ! is_array( $snippet ) || ( $snippet['type'] ?? '' ) !== 'php-code-snippet' ) {
+			continue;
+		}
+		$appended .= render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints, $used_setup_blueprints );
+	}
+
+	$has_snippets = ! empty( $placed ) || '' !== $appended;
+
+	if ( ! $description && ! $see_tags && ! $has_snippets ) {
 		return '';
 	}
 
+	if ( $has_snippets ) {
+		enqueue_php_code_snippet_script();
+	}
+
+	// Emit the referenced setup Blueprint <script> tags once, up front.
+	foreach ( array_keys( $used_setup_blueprints ) as $name ) {
+		if ( isset( $setup_blueprints[ $name ] ) ) {
+			$output .= render_blueprint_script( get_setup_blueprint_id( $post_id, $name ), $setup_blueprints[ $name ] );
+		}
+	}
+
 	$output .= $description;
-	$output .= $snippets;
+
+	if ( '' !== $appended ) {
+		$output .= '<div class="wporg-code-snippets">' . $appended . '</div>';
+	}
 
 	if ( $see_tags ) {
 		$output .= '<h3 class="has-heading-5-font-size">' . __( 'See also', 'wporg' ) . '</h3>';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -254,10 +254,17 @@ function render_php_code_snippet_placeholders( $description, $post_id, $snippets
 			continue;
 		}
 
-		$placed[ $index ] = true;
-		$processor->replace_current_token(
-			render_php_code_snippet( $post_id, $index, $snippets[ $index ], $setup_blueprints, $used_blueprints )
+		$snippet_output = render_php_code_snippet(
+			$post_id,
+			$index,
+			$snippets[ $index ],
+			$setup_blueprints,
+			$used_blueprints
 		);
+		$processor->replace_current_token( $snippet_output );
+		if ( '' !== $snippet_output ) {
+			$placed[ $index ] = true;
+		}
 	}
 
 	return $processor->get_updated_html();
@@ -296,6 +303,10 @@ function get_php_code_snippet_placeholder_index( $comment_text ) {
  * @return string
  */
 function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints, &$used_blueprints ) {
+	if ( ( $snippet['type'] ?? '' ) !== 'php-code-snippet' ) {
+		return '';
+	}
+
 	if ( ! isset( $snippet['code'] ) || ! is_string( $snippet['code'] ) ) {
 		return '';
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -360,10 +360,12 @@ function render_blueprint_script( $id, $blueprint ) {
 		return '';
 	}
 
-	return sprintf(
-		'<script id="%s" type="application/json">%s</script>',
-		esc_attr( $id ),
-		escape_script_data( (string) $blueprint )
+	return wp_get_inline_script_tag(
+		$blueprint,
+		array(
+			'id'   => $id,
+			'type' => 'application/json',
+		)
 	);
 }
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -126,7 +126,7 @@ function get_description_content( $post_id ) {
 	foreach ( array_keys( $used_setup_blueprints ) as $name ) {
 		if ( isset( $setup_blueprints[ $name ] ) ) {
 			$output .= render_php_code_snippet_blueprint_script(
-				get_php_code_snippet_setup_blueprint_id( $post_id, $name ),
+				get_php_code_snippet_blueprint_id( $post_id, 'setup:' . $name ),
 				$setup_blueprints[ $name ]
 			);
 		}
@@ -255,7 +255,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		$post_slug = 'example';
 	}
 
-	$inline_blueprint_id = 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . absint( $index + 1 );
+	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
 		'name' => $post_slug . '-' . ( $index + 1 ) . '.php',
 	);
@@ -266,7 +266,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 			isset( $setup_blueprints[ $snippet['blueprint'] ] ) &&
 			is_array( $setup_blueprints[ $snippet['blueprint'] ] )
 		) {
-			$attributes['blueprint']                 = get_php_code_snippet_setup_blueprint_id( $post_id, $snippet['blueprint'] );
+			$attributes['blueprint']                 = get_php_code_snippet_blueprint_id( $post_id, 'setup:' . $snippet['blueprint'] );
 			$used_blueprints[ $snippet['blueprint'] ] = true;
 		} elseif ( is_array( $snippet['blueprint'] ) ) {
 			$attributes['blueprint'] = $inline_blueprint_id;
@@ -338,20 +338,17 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 }
 
 /**
- * Return a stable script ID for a reusable setup Blueprint.
+ * Return a stable script ID for a snippet Blueprint.
+ *
+ * URL encoding preserves distinct Blueprint keys while removing the ASCII
+ * whitespace that HTML IDs prohibit.
  *
  * @param int    $post_id Post ID.
- * @param string $name    Blueprint name.
+ * @param string $key     Blueprint key.
  * @return string
  */
-function get_php_code_snippet_setup_blueprint_id( $post_id, $name ) {
-	$slug = sanitize_title( $name );
-
-	if ( '' === $slug ) {
-		$slug = substr( md5( $name ), 0, 8 );
-	}
-
-	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . $slug;
+function get_php_code_snippet_blueprint_id( $post_id, $key ) {
+	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . rawurlencode( $key );
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -4,6 +4,8 @@ namespace WordPressdotorg\Theme\Developer_2023\Dynamic_Code_Description;
 use function DevHub\get_description;
 use function DevHub\get_see_tags;
 
+const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
+
 add_action( 'init', __NAMESPACE__ . '\init' );
 add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_php_code_snippet_script_type', 10, 3 );
 
@@ -130,14 +132,15 @@ function get_code_snippets_content( $post_id ) {
 		$setup_blueprints = array();
 	}
 
-	$snippet_output = '';
+	$snippet_output        = '';
+	$used_setup_blueprints = array();
 
 	foreach ( array_values( $snippets ) as $index => $snippet ) {
 		if ( ! is_array( $snippet ) || ( $snippet['type'] ?? '' ) !== 'php-code-snippet' ) {
 			continue;
 		}
 
-		$snippet_output .= render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints );
+		$snippet_output .= render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints, $used_setup_blueprints );
 	}
 
 	if ( '' === $snippet_output ) {
@@ -148,12 +151,8 @@ function get_code_snippets_content( $post_id ) {
 
 	$output = '<div class="wporg-code-snippets">';
 
-	foreach ( $setup_blueprints as $name => $blueprint ) {
-		if ( ! is_string( $name ) || '' === $name ) {
-			continue;
-		}
-
-		$output .= render_blueprint_script( get_setup_blueprint_id( $post_id, $name ), $blueprint );
+	foreach ( array_keys( $used_setup_blueprints ) as $name ) {
+		$output .= render_blueprint_script( get_setup_blueprint_id( $post_id, $name ), $setup_blueprints[ $name ] );
 	}
 
 	$output .= $snippet_output;
@@ -168,7 +167,7 @@ function get_code_snippets_content( $post_id ) {
 function enqueue_php_code_snippet_script() {
 	wp_enqueue_script(
 		'wporg-developer-php-code-snippet',
-		'https://playground.wordpress.net/php-code-snippet.js',
+		PHP_CODE_SNIPPET_SCRIPT_URL,
 		array(),
 		null,
 		true
@@ -201,17 +200,27 @@ function add_php_code_snippet_script_type( $tag, $handle, $src ) {
  * @param int   $index            Zero-based snippet index.
  * @param array $snippet          Snippet data.
  * @param array $setup_blueprints Reusable setup Blueprints keyed by name.
+ * @param array $used_blueprints  Reusable setup Blueprint names referenced by rendered snippets.
  * @return string
  */
-function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints ) {
-	$code       = $snippet['code'] ?? '';
+function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints, &$used_blueprints ) {
+	if ( ! isset( $snippet['code'] ) || ! is_string( $snippet['code'] ) ) {
+		return '';
+	}
+
+	if ( isset( $snippet['expected_output'] ) && ! is_string( $snippet['expected_output'] ) ) {
+		return '';
+	}
+
+	$code       = $snippet['code'];
 	$attributes = array(
 		'name' => get_php_code_snippet_name( $post_id, $index ),
 	);
 
 	if ( isset( $snippet['blueprint'] ) ) {
 		if ( is_string( $snippet['blueprint'] ) && array_key_exists( $snippet['blueprint'], $setup_blueprints ) ) {
-			$attributes['blueprint'] = get_setup_blueprint_id( $post_id, $snippet['blueprint'] );
+			$attributes['blueprint']                 = get_setup_blueprint_id( $post_id, $snippet['blueprint'] );
+			$used_blueprints[ $snippet['blueprint'] ] = true;
 		} elseif ( is_array( $snippet['blueprint'] ) || is_string( $snippet['blueprint'] ) ) {
 			$attributes['blueprint'] = get_inline_blueprint_id( $post_id, $index );
 		}
@@ -225,10 +234,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints 
 
 	$output .= '<php-snippet' . render_php_code_snippet_attributes( $attributes ) . '>';
 	$output .= '<script type="application/x-php">' . escape_script_data( $code ) . '</script>';
-
-	if ( array_key_exists( 'expected_output', $snippet ) ) {
-		$output .= '<script type="text/expected-output">' . escape_script_data( $snippet['expected_output'] ) . '</script>';
-	}
+	$output .= '<script type="text/expected-output">' . escape_script_data( $snippet['expected_output'] ?? '' ) . '</script>';
 
 	$output .= '</php-snippet>';
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -264,11 +264,11 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		if (
 			is_string( $snippet['blueprint'] ) &&
 			isset( $setup_blueprints[ $snippet['blueprint'] ] ) &&
-			is_array( $setup_blueprints[ $snippet['blueprint'] ] )
+			( is_array( $setup_blueprints[ $snippet['blueprint'] ] ) || is_object( $setup_blueprints[ $snippet['blueprint'] ] ) )
 		) {
 			$attributes['blueprint']                 = get_php_code_snippet_blueprint_id( $post_id, 'setup:' . $snippet['blueprint'] );
 			$used_blueprints[ $snippet['blueprint'] ] = true;
-		} elseif ( is_array( $snippet['blueprint'] ) ) {
+		} elseif ( is_array( $snippet['blueprint'] ) || is_object( $snippet['blueprint'] ) ) {
 			$attributes['blueprint'] = $inline_blueprint_id;
 		} else {
 			// Keep snippets with unusable setup visible without offering a Run action that cannot succeed.
@@ -314,12 +314,16 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 /**
  * Render a setup Blueprint script tag.
  *
- * @param string $id        Script tag ID.
- * @param array  $blueprint Blueprint data.
+ * @param string       $id        Script tag ID.
+ * @param array|object $blueprint Blueprint data.
  * @return string
  */
 function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
-	if ( ! is_array( $blueprint ) ) {
+	if ( is_array( $blueprint ) ) {
+		// The parser's JSON importer uses associative arrays. Cast only the
+		// Blueprint root back to its required JSON object type before encoding.
+		$blueprint = (object) $blueprint;
+	} elseif ( ! is_object( $blueprint ) ) {
 		return '';
 	}
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -5,6 +5,7 @@ use function DevHub\get_description;
 use function DevHub\get_see_tags;
 
 add_action( 'init', __NAMESPACE__ . '\init' );
+add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_php_code_snippet_script_type', 10, 3 );
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
@@ -66,12 +67,14 @@ function get_description_content( $post_id ) {
 
 	$description = get_description( $post_id );
 	$see_tags    = get_see_tags( $post_id );
+	$snippets    = get_code_snippets_content( $post_id );
 
-	if ( ! $description && ! $see_tags ) {
+	if ( ! $description && ! $see_tags && ! $snippets ) {
 		return '';
 	}
 
 	$output .= $description;
+	$output .= $snippets;
 
 	if ( $see_tags ) {
 		$output .= '<h3 class="has-heading-5-font-size">' . __( 'See also', 'wporg' ) . '</h3>';
@@ -107,4 +110,216 @@ function get_description_content( $post_id ) {
 	}
 
 	return $output;
+}
+
+/**
+ * Return runnable code examples parsed from the DocBlock description.
+ *
+ * @param int $post_id Post ID.
+ * @return string
+ */
+function get_code_snippets_content( $post_id ) {
+	$snippets = get_post_meta( $post_id, '_wp-parser_code_snippets', true );
+
+	if ( empty( $snippets ) || ! is_array( $snippets ) ) {
+		return '';
+	}
+
+	$setup_blueprints = get_post_meta( $post_id, '_wp-parser_setup_blueprints', true );
+	if ( ! is_array( $setup_blueprints ) ) {
+		$setup_blueprints = array();
+	}
+
+	$snippet_output = '';
+
+	foreach ( array_values( $snippets ) as $index => $snippet ) {
+		if ( ! is_array( $snippet ) || ( $snippet['type'] ?? '' ) !== 'php-code-snippet' ) {
+			continue;
+		}
+
+		$snippet_output .= render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints );
+	}
+
+	if ( '' === $snippet_output ) {
+		return '';
+	}
+
+	enqueue_php_code_snippet_script();
+
+	$output = '<div class="wporg-code-snippets">';
+
+	foreach ( $setup_blueprints as $name => $blueprint ) {
+		if ( ! is_string( $name ) || '' === $name ) {
+			continue;
+		}
+
+		$output .= render_blueprint_script( get_setup_blueprint_id( $post_id, $name ), $blueprint );
+	}
+
+	$output .= $snippet_output;
+	$output .= '</div>';
+
+	return $output;
+}
+
+/**
+ * Enqueue the web component that renders and runs PHP snippets.
+ */
+function enqueue_php_code_snippet_script() {
+	wp_enqueue_script(
+		'wporg-developer-php-code-snippet',
+		'https://playground.wordpress.net/php-code-snippet.js',
+		array(),
+		null,
+		true
+	);
+}
+
+/**
+ * Load the PHP snippet web component as an ES module.
+ *
+ * @param string $tag    The script tag.
+ * @param string $handle The script handle.
+ * @param string $src    The script source URL.
+ * @return string
+ */
+function add_php_code_snippet_script_type( $tag, $handle, $src ) {
+	if ( 'wporg-developer-php-code-snippet' !== $handle ) {
+		return $tag;
+	}
+
+	return sprintf(
+		'<script type="module" src="%s"></script>' . "\n",
+		esc_url( $src )
+	);
+}
+
+/**
+ * Render a single PHP code snippet.
+ *
+ * @param int   $post_id          Post ID.
+ * @param int   $index            Zero-based snippet index.
+ * @param array $snippet          Snippet data.
+ * @param array $setup_blueprints Reusable setup Blueprints keyed by name.
+ * @return string
+ */
+function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints ) {
+	$code       = $snippet['code'] ?? '';
+	$attributes = array(
+		'name' => get_php_code_snippet_name( $post_id, $index ),
+	);
+
+	if ( isset( $snippet['blueprint'] ) ) {
+		if ( is_string( $snippet['blueprint'] ) && array_key_exists( $snippet['blueprint'], $setup_blueprints ) ) {
+			$attributes['blueprint'] = get_setup_blueprint_id( $post_id, $snippet['blueprint'] );
+		} elseif ( is_array( $snippet['blueprint'] ) || is_string( $snippet['blueprint'] ) ) {
+			$attributes['blueprint'] = get_inline_blueprint_id( $post_id, $index );
+		}
+	}
+
+	$output = '';
+
+	if ( isset( $attributes['blueprint'] ) && $attributes['blueprint'] === get_inline_blueprint_id( $post_id, $index ) ) {
+		$output .= render_blueprint_script( $attributes['blueprint'], $snippet['blueprint'] );
+	}
+
+	$output .= '<php-snippet' . render_php_code_snippet_attributes( $attributes ) . '>';
+	$output .= '<script type="application/x-php">' . escape_script_data( $code ) . '</script>';
+
+	if ( array_key_exists( 'expected_output', $snippet ) ) {
+		$output .= '<script type="text/expected-output">' . escape_script_data( $snippet['expected_output'] ) . '</script>';
+	}
+
+	$output .= '</php-snippet>';
+
+	return $output;
+}
+
+/**
+ * Render a setup Blueprint script tag.
+ *
+ * @param string       $id        Script tag ID.
+ * @param array|string $blueprint Blueprint data.
+ * @return string
+ */
+function render_blueprint_script( $id, $blueprint ) {
+	if ( is_array( $blueprint ) ) {
+		$blueprint = wp_json_encode( $blueprint );
+	}
+
+	return sprintf(
+		'<script id="%s" type="application/json">%s</script>',
+		esc_attr( $id ),
+		escape_script_data( (string) $blueprint )
+	);
+}
+
+/**
+ * Render attributes for the php-snippet element.
+ *
+ * @param array $attributes Attributes keyed by name.
+ * @return string
+ */
+function render_php_code_snippet_attributes( $attributes ) {
+	$output = '';
+
+	foreach ( $attributes as $name => $value ) {
+		$output .= sprintf( ' %s="%s"', esc_attr( $name ), esc_attr( $value ) );
+	}
+
+	return $output;
+}
+
+/**
+ * Return a stable snippet file name.
+ *
+ * @param int $post_id Post ID.
+ * @param int $index   Zero-based snippet index.
+ * @return string
+ */
+function get_php_code_snippet_name( $post_id, $index ) {
+	$slug = get_post_field( 'post_name', $post_id );
+	if ( ! $slug ) {
+		$slug = 'example';
+	}
+
+	return sanitize_file_name( $slug . '-' . ( $index + 1 ) . '.php' );
+}
+
+/**
+ * Return a stable script ID for a reusable setup Blueprint.
+ *
+ * @param int    $post_id Post ID.
+ * @param string $name    Blueprint name.
+ * @return string
+ */
+function get_setup_blueprint_id( $post_id, $name ) {
+	$slug = sanitize_title( $name );
+
+	if ( '' === $slug ) {
+		$slug = substr( md5( $name ), 0, 8 );
+	}
+
+	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . $slug;
+}
+
+/**
+ * Return a stable script ID for an inline setup Blueprint.
+ *
+ * @param int $post_id Post ID.
+ * @param int $index   Zero-based snippet index.
+ * @return string
+ */
+function get_inline_blueprint_id( $post_id, $index ) {
+	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . absint( $index + 1 );
+}
+
+/**
+ * Escape content inside script tags while preserving ordinary PHP/HTML text.
+ *
+ * @param string $content Script tag content.
+ * @return string
+ */
+function escape_script_data( $content ) {
+	return str_ireplace( '</script', '<\/script', $content );
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -332,7 +332,10 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	}
 
 	$output .= '<php-snippet' . render_php_code_snippet_attributes( $attributes ) . '>';
-	$output .= '<script type="application/x-php">' . escape_script_data( $code ) . '</script>';
+	$output .= wp_get_inline_script_tag(
+		escape_php_source_script_contents( $code ),
+		array( 'type' => 'application/x-php' )
+	);
 
 	if ( array_key_exists( 'expected_output', $snippet ) ) {
 		$output .= '<script type="text/expected-output">' . escape_script_data( $snippet['expected_output'] ) . '</script>';
@@ -427,6 +430,16 @@ function get_setup_blueprint_id( $post_id, $name ) {
  */
 function get_inline_blueprint_id( $post_id, $index ) {
 	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . absint( $index + 1 );
+}
+
+/**
+ * Escape PHP source for embedding in script tags.
+ *
+ * @param string $content Script tag content.
+ * @return string
+ */
+function escape_php_source_script_contents( $content ) {
+	return str_ireplace( '</script', '<\/script', $content );
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -208,7 +208,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		return '';
 	}
 
-	if ( isset( $snippet['expected_output'] ) && ! is_string( $snippet['expected_output'] ) ) {
+	if ( array_key_exists( 'expected_output', $snippet ) && ! is_string( $snippet['expected_output'] ) ) {
 		return '';
 	}
 
@@ -234,7 +234,10 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$output .= '<php-snippet' . render_php_code_snippet_attributes( $attributes ) . '>';
 	$output .= '<script type="application/x-php">' . escape_script_data( $code ) . '</script>';
-	$output .= '<script type="text/expected-output">' . escape_script_data( $snippet['expected_output'] ?? '' ) . '</script>';
+
+	if ( array_key_exists( 'expected_output', $snippet ) ) {
+		$output .= '<script type="text/expected-output">' . escape_script_data( $snippet['expected_output'] ) . '</script>';
+	}
 
 	$output .= '</php-snippet>';
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -338,7 +338,10 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	);
 
 	if ( array_key_exists( 'expected_output', $snippet ) ) {
-		$output .= '<script type="text/expected-output">' . escape_script_data( $snippet['expected_output'] ) . '</script>';
+		$output .= wp_get_inline_script_tag(
+			$snippet['expected_output'],
+			array( 'type' => 'text/expected-output' )
+		);
 	}
 
 	$output .= '</php-snippet>';
@@ -439,16 +442,6 @@ function get_inline_blueprint_id( $post_id, $index ) {
  * @return string
  */
 function escape_php_source_script_contents( $content ) {
-	return str_ireplace( '</script', '<\/script', $content );
-}
-
-/**
- * Escape content inside script tags while preserving ordinary PHP/HTML text.
- *
- * @param string $content Script tag content.
- * @return string
- */
-function escape_script_data( $content ) {
 	return str_ireplace( '</script', '<\/script', $content );
 }
 

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -331,20 +331,21 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		$output .= render_blueprint_script( $attributes['blueprint'], $snippet['blueprint'] );
 	}
 
-	$output .= '<php-snippet' . render_php_code_snippet_attributes( $attributes ) . '>';
-	$output .= wp_get_inline_script_tag(
+	$snippet_output = '<php-snippet>';
+	$snippet_output .= wp_get_inline_script_tag(
 		escape_php_source_script_contents( $code ),
 		array( 'type' => 'application/x-php' )
 	);
 
 	if ( array_key_exists( 'expected_output', $snippet ) ) {
-		$output .= wp_get_inline_script_tag(
+		$snippet_output .= wp_get_inline_script_tag(
 			$snippet['expected_output'],
 			array( 'type' => 'text/expected-output' )
 		);
 	}
 
-	$output .= '</php-snippet>';
+	$snippet_output .= '</php-snippet>';
+	$output         .= render_php_code_snippet_element( $snippet_output, $attributes );
 
 	return $output;
 }
@@ -376,19 +377,23 @@ function render_blueprint_script( $id, $blueprint ) {
 }
 
 /**
- * Render attributes for the php-snippet element.
+ * Render the php-snippet element with its attributes.
  *
- * @param array $attributes Attributes keyed by name.
+ * @param string $html       php-snippet element markup.
+ * @param array  $attributes Attributes keyed by name.
  * @return string
  */
-function render_php_code_snippet_attributes( $attributes ) {
-	$output = '';
-
-	foreach ( $attributes as $name => $value ) {
-		$output .= sprintf( ' %s="%s"', esc_attr( $name ), esc_attr( $value ) );
+function render_php_code_snippet_element( $html, $attributes ) {
+	$tags = new \WP_HTML_Tag_Processor( $html );
+	if ( ! $tags->next_tag( 'php-snippet' ) ) {
+		return $html;
 	}
 
-	return $output;
+	foreach ( $attributes as $name => $value ) {
+		$tags->set_attribute( $name, $value );
+	}
+
+	return $tags->get_updated_html();
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -309,12 +309,19 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		'name' => get_php_code_snippet_name( $post_id, $index ),
 	);
 
-	if ( isset( $snippet['blueprint'] ) ) {
-		if ( is_string( $snippet['blueprint'] ) && array_key_exists( $snippet['blueprint'], $setup_blueprints ) ) {
+	if ( array_key_exists( 'blueprint', $snippet ) ) {
+		if (
+			is_string( $snippet['blueprint'] ) &&
+			isset( $setup_blueprints[ $snippet['blueprint'] ] ) &&
+			is_array( $setup_blueprints[ $snippet['blueprint'] ] )
+		) {
 			$attributes['blueprint']                 = get_setup_blueprint_id( $post_id, $snippet['blueprint'] );
 			$used_blueprints[ $snippet['blueprint'] ] = true;
-		} elseif ( is_array( $snippet['blueprint'] ) || is_string( $snippet['blueprint'] ) ) {
+		} elseif ( is_array( $snippet['blueprint'] ) ) {
 			$attributes['blueprint'] = get_inline_blueprint_id( $post_id, $index );
+		} else {
+			// Keep snippets with unusable setup visible without offering a Run action that cannot succeed.
+			$attributes['runnable'] = 'false';
 		}
 	}
 
@@ -339,13 +346,18 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 /**
  * Render a setup Blueprint script tag.
  *
- * @param string       $id        Script tag ID.
- * @param array|string $blueprint Blueprint data.
+ * @param string $id        Script tag ID.
+ * @param array  $blueprint Blueprint data.
  * @return string
  */
 function render_blueprint_script( $id, $blueprint ) {
-	if ( is_array( $blueprint ) ) {
-		$blueprint = wp_json_encode( $blueprint );
+	if ( ! is_array( $blueprint ) ) {
+		return '';
+	}
+
+	$blueprint = wp_json_encode( $blueprint, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $blueprint ) ) {
+		return '';
 	}
 
 	return sprintf(

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -84,17 +84,13 @@ function get_description_content( $post_id ) {
 	// Render each snippet in place, where the parser left its placeholder
 	// ( <!-- wp-parser-code-snippet:N --> ), so snippets stay between the
 	// surrounding prose instead of collapsing to the end of the description.
-	$description = preg_replace_callback(
-		'/<!--\s*wp-parser-code-snippet:(\d+)\s*-->/',
-		function ( $matches ) use ( $post_id, $snippets, $setup_blueprints, &$used_setup_blueprints, &$placed ) {
-			$index = (int) $matches[1];
-			if ( ! isset( $snippets[ $index ] ) || ! is_array( $snippets[ $index ] ) ) {
-				return '';
-			}
-			$placed[ $index ] = true;
-			return render_php_code_snippet( $post_id, $index, $snippets[ $index ], $setup_blueprints, $used_setup_blueprints );
-		},
-		(string) $description
+	$description = render_php_code_snippet_placeholders(
+		(string) $description,
+		$post_id,
+		$snippets,
+		$setup_blueprints,
+		$used_setup_blueprints,
+		$placed
 	);
 
 	// Fallback: any snippet without a placeholder (e.g. metadata imported from an
@@ -227,6 +223,66 @@ function enqueue_php_code_snippet_script() {
 		array(),
 		null
 	);
+}
+
+/**
+ * Render parser snippet placeholders in HTML comments.
+ *
+ * @param string $description      Description HTML.
+ * @param int    $post_id          Post ID.
+ * @param array  $snippets         Parsed snippets.
+ * @param array  $setup_blueprints Reusable setup Blueprints keyed by name.
+ * @param array  $used_blueprints  Reusable setup Blueprint names referenced by rendered snippets.
+ * @param array  $placed           Snippet indexes rendered in place.
+ * @return string
+ */
+function render_php_code_snippet_placeholders( $description, $post_id, $snippets, $setup_blueprints, &$used_blueprints, &$placed ) {
+	$processor = new Code_Snippet_Placeholder_Processor( $description );
+
+	while ( $processor->next_token() ) {
+		if ( \WP_HTML_Tag_Processor::COMMENT_AS_HTML_COMMENT !== $processor->get_comment_type() ) {
+			continue;
+		}
+
+		$index = get_php_code_snippet_placeholder_index( $processor->get_modifiable_text() );
+		if ( null === $index ) {
+			continue;
+		}
+
+		if ( ! isset( $snippets[ $index ] ) || ! is_array( $snippets[ $index ] ) ) {
+			$processor->replace_current_token( '' );
+			continue;
+		}
+
+		$placed[ $index ] = true;
+		$processor->replace_current_token(
+			render_php_code_snippet( $post_id, $index, $snippets[ $index ], $setup_blueprints, $used_blueprints )
+		);
+	}
+
+	return $processor->get_updated_html();
+}
+
+/**
+ * Return the parser snippet placeholder index from exact HTML comment text.
+ *
+ * @param string $comment_text HTML comment text.
+ * @return int|null
+ */
+function get_php_code_snippet_placeholder_index( $comment_text ) {
+	$prefix = ' wp-parser-code-snippet:';
+	$suffix = ' ';
+
+	if ( ! str_starts_with( $comment_text, $prefix ) || ! str_ends_with( $comment_text, $suffix ) ) {
+		return null;
+	}
+
+	$index = substr( $comment_text, strlen( $prefix ), -strlen( $suffix ) );
+	if ( ! ctype_digit( $index ) ) {
+		return null;
+	}
+
+	return (int) $index;
 }
 
 /**
@@ -367,4 +423,23 @@ function get_inline_blueprint_id( $post_id, $index ) {
  */
 function escape_script_data( $content ) {
 	return str_ireplace( '</script', '<\/script', $content );
+}
+
+/**
+ * HTML processor for replacing parser snippet placeholder comments.
+ */
+class Code_Snippet_Placeholder_Processor extends \WP_HTML_Tag_Processor {
+	/**
+	 * Replace the currently matched token with HTML.
+	 *
+	 * @param string $html Replacement HTML.
+	 */
+	public function replace_current_token( $html ) {
+		$bookmark_name = 'wporg-code-snippet-placeholder';
+
+		$this->set_bookmark( $bookmark_name );
+		$span                    = $this->bookmarks[ $bookmark_name ];
+		$this->lexical_updates[] = new \WP_HTML_Text_Replacement( $span->start, $span->length, $html );
+		$this->release_bookmark( $bookmark_name );
+	}
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -167,53 +167,6 @@ function get_description_content( $post_id ) {
 }
 
 /**
- * Return runnable code examples parsed from the DocBlock description.
- *
- * @param int $post_id Post ID.
- * @return string
- */
-function get_code_snippets_content( $post_id ) {
-	$snippets = get_post_meta( $post_id, '_wp-parser_code_snippets', true );
-
-	if ( empty( $snippets ) || ! is_array( $snippets ) ) {
-		return '';
-	}
-
-	$setup_blueprints = get_post_meta( $post_id, '_wp-parser_setup_blueprints', true );
-	if ( ! is_array( $setup_blueprints ) ) {
-		$setup_blueprints = array();
-	}
-
-	$snippet_output        = '';
-	$used_setup_blueprints = array();
-
-	foreach ( array_values( $snippets ) as $index => $snippet ) {
-		if ( ! is_array( $snippet ) || ( $snippet['type'] ?? '' ) !== 'php-code-snippet' ) {
-			continue;
-		}
-
-		$snippet_output .= render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints, $used_setup_blueprints );
-	}
-
-	if ( '' === $snippet_output ) {
-		return '';
-	}
-
-	enqueue_php_code_snippet_script();
-
-	$output = '<div class="wporg-code-snippets">';
-
-	foreach ( array_keys( $used_setup_blueprints ) as $name ) {
-		$output .= render_blueprint_script( get_setup_blueprint_id( $post_id, $name ), $setup_blueprints[ $name ] );
-	}
-
-	$output .= $snippet_output;
-	$output .= '</div>';
-
-	return $output;
-}
-
-/**
  * Enqueue the web component that renders and runs PHP snippets.
  */
 function enqueue_php_code_snippet_script() {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -7,7 +7,6 @@ use function DevHub\get_see_tags;
 const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
 
 add_action( 'init', __NAMESPACE__ . '\init' );
-add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_php_code_snippet_script_type', 10, 3 );
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
@@ -222,31 +221,11 @@ function get_code_snippets_content( $post_id ) {
  * Enqueue the web component that renders and runs PHP snippets.
  */
 function enqueue_php_code_snippet_script() {
-	wp_enqueue_script(
+	wp_enqueue_script_module(
 		'wporg-developer-php-code-snippet',
 		PHP_CODE_SNIPPET_SCRIPT_URL,
 		array(),
-		null,
-		true
-	);
-}
-
-/**
- * Load the PHP snippet web component as an ES module.
- *
- * @param string $tag    The script tag.
- * @param string $handle The script handle.
- * @param string $src    The script source URL.
- * @return string
- */
-function add_php_code_snippet_script_type( $tag, $handle, $src ) {
-	if ( 'wporg-developer-php-code-snippet' !== $handle ) {
-		return $tag;
-	}
-
-	return sprintf(
-		'<script type="module" src="%s"></script>' . "\n",
-		esc_url( $src )
+		null
 	);
 }
 


### PR DESCRIPTION
Renders PHP examples parsed from DocBlocks as runnable WordPress Playground snippets in their original positions in code reference descriptions.

WordPress/phpdoc-parser#258 removes `php interactive` fenced examples from `long_description`, stores the structured snippets and setup Blueprints as post metadata, and leaves exact `<!-- wp-parser-code-snippet:N -->` placeholders behind. Without a theme-side renderer, those examples disappear after import. This PR replaces the placeholders with `<php-snippet>` elements, emits only the setup Blueprints they reference, preserves Blueprint JSON object shapes through post meta, and loads the web component only when a snippet is rendered. A snippet whose declared Blueprint is missing or malformed remains visible without a Run action. Metadata imported without a placeholder is appended rather than dropped.

<img src="https://github.com/adamziel/wporg-developer/releases/download/pr-screenshot-php-snippets-2026-06-08/actual-wporg-code-path-snippets-fixed.png" alt="A code reference page showing three runnable PHP examples with expected output" width="900">

## Testing

Import parser data from WordPress/phpdoc-parser#258, then open a code reference page containing standalone, inline-Blueprint, and shared-Blueprint examples. Confirm each snippet appears where its fence was, valid snippets run and show their expected output, empty and nested-empty Blueprint objects remain JSON objects, and a snippet with an unusable Blueprint has no Run action.


