### PR TITLE
Add WordPress Playground CLI boot script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ phpcs.xml.dist
 /source/wp-content/themes/*
 
 # ...except the actual source of this project.
+!/source/wp-content/blueprint.json
 !/source/wp-content/themes
 !/source/wp-content/themes/wporg-developer-2023

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"@wordpress/env": "11.0.0"
 	},
 	"scripts": {
+		"playground": "npx @wp-playground/cli start --no-auto-mount --mount=./source/wp-content/mu-plugins:/wordpress/wp-content/mu-plugins --mount=./env/0-sandbox.php:/wordpress/wp-content/mu-plugins/0-sandbox.php --mount=./source/wp-content/plugins:/wordpress/wp-content/plugins --mount=./source/wp-content/themes:/wordpress/wp-content/themes --blueprint=./source/wp-content/blueprint.json",
 		"setup:tools": "yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs && composer --working-dir=./source/wp-content/plugins/phpdoc-parser install",
 		"setup": "yarn setup:wp && yarn parse",
 		"setup:wp": "wp-env run cli bash env/setup.sh",

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,16 @@
 
 1. Log in with username `admin` and password `password`.
 
+### WordPress Playground
+
+To run the environment without Docker, use WordPress Playground:
+
+```bash
+yarn playground
+```
+
+The Playground setup mounts the same WordPress.org sandbox bootstrap used by `wp-env`, activates the local plugins and theme, and creates the starter pages.
+
 ### Environment management
 
 These must be run in the project's root folder, _not_ in theme/plugin subfolders.

--- a/source/wp-content/blueprint.json
+++ b/source/wp-content/blueprint.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "../../node_modules/@wp-playground/blueprints/blueprint-schema.json",
+	"landingPage": "/",
+	"preferredVersions": {
+		"php": "8.4",
+		"wp": "latest"
+	},
+	"features": {
+		"intl": true,
+		"networking": true
+	},
+	"login": true,
+	"siteOptions": {
+		"blogname": "Developer.WordPress.org Local"
+	},
+	"steps": [
+		{
+			"step": "defineWpConfigConsts",
+			"consts": {
+				"WP_DEBUG": true,
+				"SCRIPT_DEBUG": true,
+				"WP_DEBUG_LOG": true,
+				"WP_ENVIRONMENT_TYPE": "local",
+				"JETPACK_DEV_DEBUG": true,
+				"WPORG_SANDBOXED": true
+			}
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php\nrequire_once '/wordpress/wp-load.php';\nrequire_once ABSPATH . 'wp-admin/includes/plugin.php';\n\n$plugins = array(\n\t'gutenberg/gutenberg.php',\n\t'handbook/handbook.php',\n\t'wporg-markdown/plugin.php',\n\t'code-syntax-block/index.php',\n\t'posts-to-posts/posts-to-posts.php',\n\t'wordpress-importer/wordpress-importer.php',\n\t'jetpack/jetpack.php',\n);\n\nforeach ( $plugins as $plugin ) {\n\tif ( file_exists( WP_PLUGIN_DIR . '/' . $plugin ) && ! is_plugin_active( $plugin ) ) {\n\t\tactivate_plugin( $plugin, '', false, true );\n\t}\n}\n\nswitch_theme( 'wporg-developer-2023' );\n\n$pages = array(\n\t'home' => array(\n\t\t'post_title' => 'Home',\n\t\t'post_name' => 'home',\n\t),\n\t'reference' => array(\n\t\t'post_title' => 'Reference',\n\t\t'post_name' => 'reference',\n\t),\n\t'resource' => array(\n\t\t'post_title' => 'Resource',\n\t\t'post_name' => 'resource',\n\t),\n);\n\n$page_ids = array();\nforeach ( $pages as $key => $page ) {\n\t$existing = get_page_by_path( $page['post_name'] );\n\tif ( $existing ) {\n\t\t$page_ids[ $key ] = $existing->ID;\n\t\tcontinue;\n\t}\n\n\t$page_ids[ $key ] = wp_insert_post( array(\n\t\t'post_type' => 'page',\n\t\t'post_title' => $page['post_title'],\n\t\t'post_status' => 'publish',\n\t\t'post_name' => $page['post_name'],\n\t) );\n}\n\nif ( empty( get_page_by_path( 'resource/dashicons' ) ) ) {\n\twp_insert_post( array(\n\t\t'post_type' => 'page',\n\t\t'post_title' => 'Dashicons',\n\t\t'post_status' => 'publish',\n\t\t'post_name' => 'dashicons',\n\t\t'post_parent' => isset( $page_ids['resource'] ) ? $page_ids['resource'] : 0,\n\t) );\n}\n\nif ( ! empty( $page_ids['home'] ) ) {\n\tupdate_option( 'page_on_front', $page_ids['home'] );\n\tupdate_option( 'show_on_front', 'page' );\n}\n\nupdate_option( 'permalink_structure', '/%year%/%monthnum%/%postname%/' );\nflush_rewrite_rules();\n"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

This adds a Docker-free local boot path using WordPress Playground CLI. Running `yarn playground` starts `npx @wp-playground/cli`, mounts the repo's local `wp-content` pieces, and applies a Playground blueprint that prepares a usable DevHub site.

The command uses explicit mounts instead of Playground's auto-mounting so it can mirror the important `wp-env` mapping for `env/0-sandbox.php`. That sandbox bootstrap needs to appear at `/wordpress/wp-content/mu-plugins/0-sandbox.php`, while the rest of `source/wp-content/mu-plugins`, `plugins`, and `themes` are mounted from the repo.

The new `source/wp-content/blueprint.json` handles the WordPress-side setup: it defines local/debug constants, keeps the environment type local, activates the expected plugins, switches to `wporg-developer-2023`, creates the starter pages, sets the front page, and configures permalinks. The README now documents `yarn playground` as the no-Docker entry point.

## Testing

The normal command for local use is:

```bash
yarn playground
```

For verification, I ran the same script with a few extra Playground CLI flags:

```bash
yarn playground --skip-browser --port=9400 --reset
```

Those flags make the test deterministic and terminal-friendly: `--skip-browser` avoids opening a browser, `--port=9400` gives a predictable URL for `curl`, and `--reset` recreates the stored Playground site so the blueprint is tested against a clean install.

After startup, I requested the homepage with cookies enabled for Playground auto-login. The response reached `200 OK` and rendered `WordPress Developer Resources | Developer.WordPress.org` with `wporg-developer-2023` theme assets.