### PR TITLE
Migrate JavaScript linting to flat config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # Configs from wporg-repo-tools.
 .eslintrc.js
+eslint.config.js
 .prettierrc.js
 .stylelintrc
 phpcs.xml.dist

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"private": true,
 	"dependencies": {
-		"@wordpress/scripts": "31.5.0"
+		"@wordpress/scripts": "32.6.0"
 	},
 	"devDependencies": {
 		"@wordpress/env": "11.0.0"

--- a/source/wp-content/themes/wporg-developer-2023/package.json
+++ b/source/wp-content/themes/wporg-developer-2023/package.json
@@ -9,8 +9,8 @@
 		"@wordpress/i18n": "^6.24.0"
 	},
 	"devDependencies": {
-		"@wordpress/eslint-plugin": "^24.2.0",
-		"@wordpress/scripts": "31.5.0"
+		"@wordpress/eslint-plugin": "^25.6.0",
+		"@wordpress/scripts": "32.6.0"
 	},
 	"eslintConfig": {
 		"extends": "../../../../.eslintrc.js",
@@ -33,7 +33,7 @@
 	"scripts": {
 		"build": "wp-scripts build",
 		"start": "wp-scripts start",
-		"lint:js": "wp-scripts lint-js src",
+		"lint:js": "wp-scripts lint-js --config ../../../../eslint.config.js src",
 		"lint:css": "wp-scripts lint-style *.css src/**/*.scss",
 		"format": "wp-scripts format src"
 	}


### PR DESCRIPTION
## Summary

- upgrade the root and theme to `@wordpress/scripts` 32.6.0
- upgrade the theme's ESLint plugin to the compatible 25.x release
- point the workspace lint command at the shared root flat config
- ignore the generated `eslint.config.js` alongside the other generated tooling configs

This fixes CI after `wporg-repo-tools` began generating `eslint.config.js`. The previous `wp-scripts` 31 lint command selected flat-config mode but still passed the removed `--ignore-path` option.

## Testing

Tested under Node 20 to match CI:

- `yarn workspace wporg-developer-2023 lint:js`
- `yarn workspace wporg-developer-2023 lint:css`
- `yarn workspace wporg-developer-2023 build`

All pass. The build retains its existing Sass deprecation warnings.