### PR TITLE
Add extension points for Code Reference source links

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1252,7 +1252,7 @@ namespace DevHub {
 		 *                        if no source file is associated with the post.
 		 * @param int    $post_id Post ID of the parsed function, method, hook, or class.
 		 */
-		$url = apply_filters( 'wporg_developer_github_source_file_link', $url, $post_id );
+		$url = apply_filters( 'devhub-github-source-file-link', $url, $post_id );
 
 		return esc_url( $url );
 	}

--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1213,7 +1213,7 @@ namespace DevHub {
 		if ( ! empty( $source_file ) ) {
 			$url = 'https://core.trac.wordpress.org/browser/tags/' . get_current_version() . '/src/' . $source_file;
 			// Line number.
-			if ( $line_number = get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ) {
+			if ( $line_number = get_post_meta( $post_id, '_wp-parser_line_num', true ) ) {
 				$url .= "#L{$line_number}";
 			}
 		}
@@ -1237,13 +1237,22 @@ namespace DevHub {
 		if ( ! empty( $source_file ) ) {
 			$url = 'https://github.com/WordPress/wordpress-develop/blob/' . get_current_version() . '/src/' . $source_file;
 			// Line number.
-			if ( $line_number = get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ) {
+			if ( $line_number = get_post_meta( $post_id, '_wp-parser_line_num', true ) ) {
 				$url .= "#L{$line_number}";
-				if ( $end_line_number = get_post_meta( get_the_ID(), '_wp-parser_end_line_num', true ) ) {
+				if ( $end_line_number = get_post_meta( $post_id, '_wp-parser_end_line_num', true ) ) {
 					$url .= "-L{$end_line_number}";
 				}
 			}
 		}
+
+		/**
+		 * Filters the GitHub source file URL for a parsed post type.
+		 *
+		 * @param string $url     The URL to the source file on GitHub. Empty string
+		 *                        if no source file is associated with the post.
+		 * @param int    $post_id Post ID of the parsed function, method, hook, or class.
+		 */
+		$url = apply_filters( 'wporg_developer_github_source_file_link', $url, $post_id );
 
 		return esc_url( $url );
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/block.php
@@ -75,23 +75,29 @@ function get_source_content( $post_id ) {
 	if ( ! empty( $source_file ) ) {
 		$source_code = post_type_has_source_code( $post_type ) ? get_source_code( $post_id ) : '';
 
-		$view_reference_button = sprintf(
+		$buttons = array();
+
+		$buttons[] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( get_source_file_archive_link( $source_file ) ),
 			__( 'View all references', 'wporg' )
 		);
 
-		$view_trac_button = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( get_source_file_link( $post_id ) ),
-			__( 'View on Trac', 'wporg' )
-		);
+		/**
+		 * Filters whether to show the Trac source link for a parsed post type.
+		 *
+		 * @param bool $show_trac_link Whether to show the Trac source link. Default true.
+		 * @param int  $post_id        Post ID of the parsed function, method, hook, or class.
+		 */
+		$show_trac_link = apply_filters( 'wporg_developer_show_trac_source_link', true, $post_id );
 
-		$view_github_button = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( get_github_source_file_link( $post_id ) ),
-			__( 'View on GitHub', 'wporg' )
-		);
+		if ( $show_trac_link ) {
+			$buttons[] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_source_file_link( $post_id ) ),
+				__( 'View on Trac', 'wporg' )
+			);
+		}
 
 		if ( ! empty( $source_code ) ) {
 			$output .= do_blocks(
@@ -103,10 +109,14 @@ function get_source_content( $post_id ) {
 				)
 			);
 
-			$output .= sprintf( '<p class="wporg-dot-link-list">%s</p>', implode( ' ', array( $view_reference_button, $view_trac_button, $view_github_button ) ) );
-		} else {
-			$output .= sprintf( '<p class="wporg-dot-link-list">%s</p>', implode( ' ', array( $view_reference_button, $view_trac_button ) ) );
+			$buttons[] = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_github_source_file_link( $post_id ) ),
+				__( 'View on GitHub', 'wporg' )
+			);
 		}
+
+		$output .= sprintf( '<p class="wporg-dot-link-list">%s</p>', implode( ' ', $buttons ) );
 	}
 
 	return $output;

--- a/source/wp-content/themes/wporg-developer-2023/src/code-source/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-source/block.php
@@ -89,7 +89,7 @@ function get_source_content( $post_id ) {
 		 * @param bool $show_trac_link Whether to show the Trac source link. Default true.
 		 * @param int  $post_id        Post ID of the parsed function, method, hook, or class.
 		 */
-		$show_trac_link = apply_filters( 'wporg_developer_show_trac_source_link', true, $post_id );
+		$show_trac_link = apply_filters( 'devhub-show-trac-source-link', true, $post_id );
 
 		if ( $show_trac_link ) {
 			$buttons[] = sprintf(
@@ -103,7 +103,7 @@ function get_source_content( $post_id ) {
 			$output .= do_blocks(
 				sprintf(
 					'<!-- wp:code {"lineNumbers":true} --><pre class="wp-block-code" data-start="%1$s" aria-label="%2$s"><code id="wporg-source-code" lang="php" class="language-php line-numbers">%3$s</code></pre><!-- /wp:code -->',
-					esc_attr( get_post_meta( get_the_ID(), '_wp-parser_line_num', true ) ),
+					esc_attr( get_post_meta( $post_id, '_wp-parser_line_num', true ) ),
 					__( 'Function source code', 'wporg' ),
 					htmlentities( $source_code )
 				)


### PR DESCRIPTION
Fixes #577

Useful for documentation previews on WordPress/wordpress-develop trunk and PRs. Allows for documentation links to point to the right place and to remove trac documentation links (which will be invalid, PR commits will only exist on GitHub).

See https://github.com/WordPress/wordpress-develop/pull/12954.

Two filters. Zero behavior change unless you install one.

**`devhub-github-source-file-link`** — filters the full URL returned by `DevHub\get_github_source_file_link()`, with the post ID. Runs before `esc_url()`, and also fires when there is no source file (empty string), so consumers see every call. The helper is filtered, not the block, because usage-info links go through the same helper. Filtering only the block would miss them.

**`devhub-show-trac-source-link`** — checked in the `wporg/code-reference-source` block before the Trac anchor is built. Return `false` and the markup is never emitted. No CSS hiding, no output-buffer rewriting — that approach is fragile and wrong. Trac simply has no URL for a commit from a fork, so a preview environment needs to drop the link, not disguise it.

One adjacent fix: both helpers read the line-number meta via `get_the_ID()` even when called with an explicit `$post_id`. That was a bug. They now use `$post_id`. Output is identical on singular pages, where the two are always equal today; it is correct now when they are not.

## Manual testing

Drop this in `wp-content/mu-plugins/source-link-test.php`:

```php
<?php
// Point GitHub source links at an exact commit, drop the Trac link.
add_filter(
	'devhub-github-source-file-link',
	function ( $url, $post_id ) {
		return preg_replace(
			'#^https://github\.com/WordPress/wordpress-develop/blob/[^/]+/#',
			'https://github.com/WordPress/wordpress-develop/blob/0123456789abcdef0123456789abcdef01234567/',
			$url
		);
	},
	10,
	2
);

add_filter( 'devhub-show-trac-source-link', '__return_false' );
```

Load any Code Reference page (function, method, hook, class). Expected: the GitHub link points at the fake commit SHA with the original path and `#L<start>-L<end>` fragment intact, in both the source block and the "Source:" usage-info line. "View on Trac" is gone. Remove the file and the page renders exactly as production does today.

## Verification

This repo has no PHP test infrastructure — CI lints JS/CSS only — so I verified end-to-end in a Playground `run-blueprint` boot with a fabricated `wp-parser-function` post (source-file term, line metas, stored source code):

- Defaults unchanged: `https://github.com/WordPress/wordpress-develop/blob/6.9/src/wp-includes/functions.php#L100-L150`, `https://core.trac.wordpress.org/browser/tags/6.9/src/wp-includes/functions.php#L100`; block renders all three buttons.
- Filtered: `https://github.com/fork/wordpress-develop/blob/0123456789abcdef0123456789abcdef01234567/src/wp-includes/functions.php#L100-L150` — path and fragment intact in the helper return value and the block markup.
- Both filters received the correct post IDs.
- Trac suppressed: the block drops the Trac link; a post without stored source code drops to "View all references" only.
- `get_source_file_link()` is untouched by the GitHub filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
