### PR TITLE
Load WordPress before interactive PHP snippets

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -278,9 +278,9 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
-		'name'                => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'auto-prepend-script' => '#' . PHP_CODE_SNIPPET_AUTO_PREPEND_ID,
-		'php-fragment'        => '',
+		'name'                  => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'auto-prepend-script'   => '#' . PHP_CODE_SNIPPET_AUTO_PREPEND_ID,
+		'implicit-php-open-tag' => '',
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -259,7 +259,16 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		return '';
 	}
 
-	$code = wp_json_encode( $snippet['code'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+	$code = $snippet['code'];
+
+	// The two class_list() examples in WordPress 7.1 load WordPress themselves.
+	// Remove once the parser strips this or Core ships without it.
+	$preamble = "<?php\nrequire '/wordpress/wp-load.php';\n";
+	if ( str_starts_with( $code, $preamble ) ) {
+		$code = substr( $code, strlen( $preamble ) );
+	}
+
+	$code = wp_json_encode( $code, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 	if ( ! is_string( $code ) ) {
 		return '';
 	}

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -280,7 +280,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	$attributes = array(
 		'name'                  => $post_slug . '-' . ( $index + 1 ) . '.php',
 		'auto-prepend-script'   => '#' . PHP_CODE_SNIPPET_AUTO_PREPEND_ID,
-		'implicit-php-open-tag' => '',
+		'implicit-php-open-tag' => true,
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -7,10 +7,10 @@ use function DevHub\get_see_tags;
 const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
 
 /**
- * ID of the shared WordPress run-before script tag. The script is identical
+ * ID of the shared WordPress auto-prepend script tag. The script is identical
  * for every snippet, so a single element per page serves them all.
  */
-const PHP_CODE_SNIPPET_RUN_BEFORE_ID = 'wporg-code-snippet-run-before';
+const PHP_CODE_SNIPPET_AUTO_PREPEND_ID = 'wporg-code-snippet-auto-prepend';
 
 add_action( 'init', __NAMESPACE__ . '\init' );
 
@@ -127,9 +127,9 @@ function get_description_content( $post_id ) {
 			null
 		);
 
-		// Emit the shared WordPress run-before script once, ahead of the snippets
-		// that reference it.
-		$output .= render_php_code_snippet_run_before_script();
+		// Emit the shared WordPress auto-prepend script once, ahead of the
+		// snippets that reference it.
+		$output .= render_php_code_snippet_auto_prepend_script();
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -278,9 +278,9 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
-		'name'         => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'run-before'   => '#' . PHP_CODE_SNIPPET_RUN_BEFORE_ID,
-		'php-fragment' => '',
+		'name'                => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'auto-prepend-script' => '#' . PHP_CODE_SNIPPET_AUTO_PREPEND_ID,
+		'php-fragment'        => '',
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {
@@ -364,35 +364,38 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 }
 
 /**
- * Render the shared WordPress run-before script tag for PHP code snippets.
+ * Render the shared WordPress auto-prepend script tag for PHP code snippets.
  *
- * Snippets reference this element from their `run-before` attribute so they
- * run with WordPress loaded, without repeating the wp-load boilerplate in
- * the visible example code. JSON encoding matches the snippet code payloads:
- * JSON_HEX_TAG escapes `<` so the payload stays inert in HTML.
+ * Snippets reference this element from their `auto-prepend-script` attribute
+ * so it runs before the visible example, mirroring PHP's auto_prepend_file
+ * directive. JSON encoding matches the snippet code payloads: JSON_HEX_TAG
+ * escapes `<` so the payload stays inert in HTML.
  *
  * Only the first call renders the tag, so a page with several code
  * descriptions still holds a single element with this ID.
  *
  * @return string
  */
-function render_php_code_snippet_run_before_script() {
+function render_php_code_snippet_auto_prepend_script() {
 	static $rendered = false;
 	if ( $rendered ) {
 		return '';
 	}
 
-	$run_before = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
-	if ( ! is_string( $run_before ) ) {
+	$auto_prepend_script = wp_json_encode(
+		"<?php require_once '/wordpress/wp-load.php';",
+		JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
+	);
+	if ( ! is_string( $auto_prepend_script ) ) {
 		return '';
 	}
 
 	$rendered = true;
 
 	return wp_get_inline_script_tag(
-		$run_before,
+		$auto_prepend_script,
 		array(
-			'id'   => PHP_CODE_SNIPPET_RUN_BEFORE_ID,
+			'id'   => PHP_CODE_SNIPPET_AUTO_PREPEND_ID,
 			'type' => 'application/x-php+json',
 		)
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -8,7 +8,8 @@ const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-s
 
 /**
  * ID of the shared WordPress auto-prepend script tag. The script is identical
- * for every snippet, so a single element per page serves them all.
+ * for every snippet, so a single element per page, printed in the footer,
+ * serves them all.
  */
 const PHP_CODE_SNIPPET_AUTO_PREPEND_ID = 'wporg-code-snippet-auto-prepend';
 
@@ -127,9 +128,12 @@ function get_description_content( $post_id ) {
 			null
 		);
 
-		// Emit the shared WordPress auto-prepend script once, ahead of the
-		// snippets that reference it.
-		$output .= render_php_code_snippet_auto_prepend_script();
+		// Print the shared WordPress auto-prepend script once per page. The
+		// code reference blocks render twice per request (once for the table
+		// of contents, once for the content), so the script is printed from
+		// `wp_footer` rather than inline; registering the same callback again
+		// is a no-op.
+		add_action( 'wp_footer', __NAMESPACE__ . '\print_php_code_snippet_auto_prepend_script' );
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -364,27 +368,20 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 }
 
 /**
- * Render the shared WordPress auto-prepend script tag for PHP code snippets.
+ * Print the shared WordPress auto-prepend script tag for PHP code snippets.
  *
- * @return string
+ * Hooked to `wp_footer` when a page renders snippets.
  */
-function render_php_code_snippet_auto_prepend_script() {
-	static $rendered = false;
-	if ( $rendered ) {
-		return '';
-	}
-
+function print_php_code_snippet_auto_prepend_script() {
 	$auto_prepend_script = wp_json_encode(
 		"<?php require_once '/wordpress/wp-load.php';",
 		JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
 	);
 	if ( ! is_string( $auto_prepend_script ) ) {
-		return '';
+		return;
 	}
 
-	$rendered = true;
-
-	return wp_get_inline_script_tag(
+	wp_print_inline_script_tag(
 		$auto_prepend_script,
 		array(
 			'id'   => PHP_CODE_SNIPPET_AUTO_PREPEND_ID,

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -7,10 +7,10 @@ use function DevHub\get_see_tags;
 const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
 
 /**
- * ID of the shared WordPress bootstrap script tag. The bootstrap is identical
+ * ID of the shared WordPress run-before script tag. The script is identical
  * for every snippet, so a single element per page serves them all.
  */
-const PHP_CODE_SNIPPET_BOOTSTRAP_ID = 'wporg-code-snippet-bootstrap';
+const PHP_CODE_SNIPPET_RUN_BEFORE_ID = 'wporg-code-snippet-run-before';
 
 add_action( 'init', __NAMESPACE__ . '\init' );
 
@@ -127,9 +127,9 @@ function get_description_content( $post_id ) {
 			null
 		);
 
-		// Emit the shared WordPress bootstrap once, ahead of the snippets
+		// Emit the shared WordPress run-before script once, ahead of the snippets
 		// that reference it.
-		$output .= render_php_code_snippet_bootstrap_script();
+		$output .= render_php_code_snippet_run_before_script();
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -279,7 +279,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
 		'name'         => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'bootstrap'    => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+		'run-before'   => '#' . PHP_CODE_SNIPPET_RUN_BEFORE_ID,
 		'php-fragment' => '',
 	);
 
@@ -364,9 +364,9 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 }
 
 /**
- * Render the shared WordPress bootstrap script tag for PHP code snippets.
+ * Render the shared WordPress run-before script tag for PHP code snippets.
  *
- * Snippets reference this element from their `bootstrap` attribute so they
+ * Snippets reference this element from their `run-before` attribute so they
  * run with WordPress loaded, without repeating the wp-load boilerplate in
  * the visible example code. JSON encoding matches the snippet code payloads:
  * JSON_HEX_TAG escapes `<` so the payload stays inert in HTML.
@@ -376,23 +376,23 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  *
  * @return string
  */
-function render_php_code_snippet_bootstrap_script() {
+function render_php_code_snippet_run_before_script() {
 	static $rendered = false;
 	if ( $rendered ) {
 		return '';
 	}
 
-	$bootstrap = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
-	if ( ! is_string( $bootstrap ) ) {
+	$run_before = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $run_before ) ) {
 		return '';
 	}
 
 	$rendered = true;
 
 	return wp_get_inline_script_tag(
-		$bootstrap,
+		$run_before,
 		array(
-			'id'   => PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+			'id'   => PHP_CODE_SNIPPET_RUN_BEFORE_ID,
 			'type' => 'application/x-php+json',
 		)
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -6,6 +6,12 @@ use function DevHub\get_see_tags;
 
 const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
 
+/**
+ * ID of the shared WordPress bootstrap script tag. The bootstrap is identical
+ * for every snippet, so a single element per page serves them all.
+ */
+const PHP_CODE_SNIPPET_BOOTSTRAP_ID = 'wporg-code-snippet-bootstrap';
+
 add_action( 'init', __NAMESPACE__ . '\init' );
 
 /**
@@ -123,7 +129,7 @@ function get_description_content( $post_id ) {
 
 		// Emit the shared WordPress bootstrap once, ahead of the snippets
 		// that reference it.
-		$output .= render_php_code_snippet_bootstrap_script( $post_id );
+		$output .= render_php_code_snippet_bootstrap_script();
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -273,7 +279,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
 		'name'      => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'bootstrap' => '#' . get_php_code_snippet_bootstrap_id( $post_id ),
+		'bootstrap' => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {
@@ -364,19 +370,28 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  * the visible example code. JSON encoding matches the snippet code payloads:
  * JSON_HEX_TAG escapes `<` so the payload stays inert in HTML.
  *
- * @param int $post_id Post ID.
+ * Only the first call renders the tag, so a page with several code
+ * descriptions still holds a single element with this ID.
+ *
  * @return string
  */
-function render_php_code_snippet_bootstrap_script( $post_id ) {
+function render_php_code_snippet_bootstrap_script() {
+	static $rendered = false;
+	if ( $rendered ) {
+		return '';
+	}
+
 	$bootstrap = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 	if ( ! is_string( $bootstrap ) ) {
 		return '';
 	}
 
+	$rendered = true;
+
 	return wp_get_inline_script_tag(
 		$bootstrap,
 		array(
-			'id'   => get_php_code_snippet_bootstrap_id( $post_id ),
+			'id'   => PHP_CODE_SNIPPET_BOOTSTRAP_ID,
 			'type' => 'application/x-php+json',
 		)
 	);
@@ -394,16 +409,6 @@ function render_php_code_snippet_bootstrap_script( $post_id ) {
  */
 function get_php_code_snippet_blueprint_id( $post_id, $key ) {
 	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . rawurlencode( $key );
-}
-
-/**
- * Return a stable script ID for the shared WordPress bootstrap.
- *
- * @param int $post_id Post ID.
- * @return string
- */
-function get_php_code_snippet_bootstrap_id( $post_id ) {
-	return 'wporg-code-snippet-bootstrap-' . absint( $post_id );
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -361,19 +361,23 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  *
  * Snippets reference this element from their `bootstrap` attribute so they
  * run with WordPress loaded, without repeating the wp-load boilerplate in
- * the visible example code. The payload never reaches the browser as
- * executable JavaScript: `application/x-php` scripts are inert until the
- * snippet component reads them.
+ * the visible example code. JSON encoding matches the snippet code payloads:
+ * JSON_HEX_TAG escapes `<` so the payload stays inert in HTML.
  *
  * @param int $post_id Post ID.
  * @return string
  */
 function render_php_code_snippet_bootstrap_script( $post_id ) {
+	$bootstrap = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $bootstrap ) ) {
+		return '';
+	}
+
 	return wp_get_inline_script_tag(
-		"<?php require_once '/wordpress/wp-load.php';",
+		$bootstrap,
 		array(
 			'id'   => get_php_code_snippet_bootstrap_id( $post_id ),
-			'type' => 'application/x-php',
+			'type' => 'application/x-php+json',
 		)
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -120,6 +120,10 @@ function get_description_content( $post_id ) {
 			array(),
 			null
 		);
+
+		// Emit the shared WordPress bootstrap once, ahead of the snippets
+		// that reference it.
+		$output .= render_php_code_snippet_bootstrap_script( $post_id );
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -268,7 +272,8 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
-		'name' => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'name'      => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'bootstrap' => '#' . get_php_code_snippet_bootstrap_id( $post_id ),
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {
@@ -352,6 +357,28 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 }
 
 /**
+ * Render the shared WordPress bootstrap script tag for PHP code snippets.
+ *
+ * Snippets reference this element from their `bootstrap` attribute so they
+ * run with WordPress loaded, without repeating the wp-load boilerplate in
+ * the visible example code. The payload never reaches the browser as
+ * executable JavaScript: `application/x-php` scripts are inert until the
+ * snippet component reads them.
+ *
+ * @param int $post_id Post ID.
+ * @return string
+ */
+function render_php_code_snippet_bootstrap_script( $post_id ) {
+	return wp_get_inline_script_tag(
+		"<?php require_once '/wordpress/wp-load.php';",
+		array(
+			'id'   => get_php_code_snippet_bootstrap_id( $post_id ),
+			'type' => 'application/x-php',
+		)
+	);
+}
+
+/**
  * Return a stable script ID for a snippet Blueprint.
  *
  * URL encoding preserves distinct Blueprint keys while removing the ASCII
@@ -363,6 +390,16 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  */
 function get_php_code_snippet_blueprint_id( $post_id, $key ) {
 	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . rawurlencode( $key );
+}
+
+/**
+ * Return a stable script ID for the shared WordPress bootstrap.
+ *
+ * @param int $post_id Post ID.
+ * @return string
+ */
+function get_php_code_snippet_bootstrap_id( $post_id ) {
+	return 'wporg-code-snippet-bootstrap-' . absint( $post_id );
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -278,8 +278,9 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
-		'name'      => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'bootstrap' => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+		'name'         => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'bootstrap'    => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+		'php-fragment' => '',
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -366,14 +366,6 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 /**
  * Render the shared WordPress auto-prepend script tag for PHP code snippets.
  *
- * Snippets reference this element from their `auto-prepend-script` attribute
- * so it runs before the visible example, mirroring PHP's auto_prepend_file
- * directive. JSON encoding matches the snippet code payloads: JSON_HEX_TAG
- * escapes `<` so the payload stays inert in HTML.
- *
- * Only the first call renders the tag, so a page with several code
- * descriptions still holds a single element with this ID.
- *
  * @return string
  */
 function render_php_code_snippet_auto_prepend_script() {


### PR DESCRIPTION
Readers of Code Reference examples should see and edit only the code that documents the API, not the Playground-specific `require '/wordpress/wp-load.php';` boilerplate, while still running examples with WordPress loaded, including after editing them.

This wires the theme side of WordPress/wordpress-playground#4262:

- Prints one shared auto-prepend element from `wp_footer` on each reference page that renders snippets:
  ```html
  <script id="wporg-code-snippet-auto-prepend" type="application/x-php+json">"<?php require_once '/wordpress/wp-load.php';"</script>
  ```
  The payload is JSON-encoded with the `+json` script type, matching how the block already emits snippet code and expected output. `JSON_HEX_TAG` keeps `<` escaped so the payload stays inert in HTML. The code reference blocks render twice per request (once for the table of contents, once for the content), so the script is printed from a named `wp_footer` callback rather than inline; repeat registration is a no-op.
- Stamps `auto-prepend-script="#wporg-code-snippet-auto-prepend"` and `implicit-php-open-tag` on every `<php-snippet>` the code-description block emits, including placeholder-placed and appended-fallback snippets.
- Strips the `<?php` / `require '/wordpress/wp-load.php';` preamble from the two `class_list()` examples that shipped in WordPress 7.1, so they keep running under `implicit-php-open-tag`. WordPress/wordpress-develop#13267 removes the preamble from the docblocks themselves; the strip goes once the parser strips it or Core ships without it.

`auto-prepend-script` mirrors PHP's `auto_prepend_file` `php.ini` directive while taking a selector for an inert HTML script element. The selected script is a complete PHP file with its own opening tag. Parser-provided examples omit the opening tag, so `implicit-php-open-tag` adds it without displaying it in the editor. The shared ID is safe because the script is emitted only once per page.

Depends on WordPress/wordpress-playground#4262, deployed to playground.wordpress.net.

The Playground-handbook import path (`inc/import-playground.php`) is untouched. Those embeds reproduce Playground documentation examples authored for their own execution context.

## Testing

Import parser data containing interactive snippets, open a Code Reference page, and confirm the page source contains exactly one `wporg-code-snippet-auto-prepend` script, in the footer; every `<php-snippet>` carries the matching `auto-prepend-script` attribute and `implicit-php-open-tag`; and examples run with WordPress loaded while displaying no opening tag or `wp-load.php` boilerplate.
