### PR TITLE
Live snippets: Load WordPress implicitly

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -7,10 +7,10 @@ use function DevHub\get_see_tags;
 const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
 
 /**
- * ID of the shared WordPress bootstrap script tag. The bootstrap is identical
+ * ID of the shared WordPress run-before script tag. The script is identical
  * for every snippet, so a single element per page serves them all.
  */
-const PHP_CODE_SNIPPET_BOOTSTRAP_ID = 'wporg-code-snippet-bootstrap';
+const PHP_CODE_SNIPPET_RUN_BEFORE_ID = 'wporg-code-snippet-run-before';
 
 add_action( 'init', __NAMESPACE__ . '\init' );
 
@@ -127,9 +127,9 @@ function get_description_content( $post_id ) {
 			null
 		);
 
-		// Emit the shared WordPress bootstrap once, ahead of the snippets
+		// Emit the shared WordPress run-before script once, ahead of the snippets
 		// that reference it.
-		$output .= render_php_code_snippet_bootstrap_script();
+		$output .= render_php_code_snippet_run_before_script();
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -279,7 +279,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
 		'name'         => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'bootstrap'    => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+		'run-before'   => '#' . PHP_CODE_SNIPPET_RUN_BEFORE_ID,
 		'php-fragment' => '',
 	);
 
@@ -364,9 +364,9 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 }
 
 /**
- * Render the shared WordPress bootstrap script tag for PHP code snippets.
+ * Render the shared WordPress run-before script tag for PHP code snippets.
  *
- * Snippets reference this element from their `bootstrap` attribute so they
+ * Snippets reference this element from their `run-before` attribute so they
  * run with WordPress loaded, without repeating the wp-load boilerplate in
  * the visible example code. JSON encoding matches the snippet code payloads:
  * JSON_HEX_TAG escapes `<` so the payload stays inert in HTML.
@@ -376,23 +376,23 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  *
  * @return string
  */
-function render_php_code_snippet_bootstrap_script() {
+function render_php_code_snippet_run_before_script() {
 	static $rendered = false;
 	if ( $rendered ) {
 		return '';
 	}
 
-	$bootstrap = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
-	if ( ! is_string( $bootstrap ) ) {
+	$run_before = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $run_before ) ) {
 		return '';
 	}
 
 	$rendered = true;
 
 	return wp_get_inline_script_tag(
-		$bootstrap,
+		$run_before,
 		array(
-			'id'   => PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+			'id'   => PHP_CODE_SNIPPET_RUN_BEFORE_ID,
 			'type' => 'application/x-php+json',
 		)
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -6,6 +6,12 @@ use function DevHub\get_see_tags;
 
 const PHP_CODE_SNIPPET_SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
 
+/**
+ * ID of the shared WordPress bootstrap script tag. The bootstrap is identical
+ * for every snippet, so a single element per page serves them all.
+ */
+const PHP_CODE_SNIPPET_BOOTSTRAP_ID = 'wporg-code-snippet-bootstrap';
+
 add_action( 'init', __NAMESPACE__ . '\init' );
 
 /**
@@ -123,7 +129,7 @@ function get_description_content( $post_id ) {
 
 		// Emit the shared WordPress bootstrap once, ahead of the snippets
 		// that reference it.
-		$output .= render_php_code_snippet_bootstrap_script( $post_id );
+		$output .= render_php_code_snippet_bootstrap_script();
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -273,7 +279,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
 		'name'      => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'bootstrap' => '#' . get_php_code_snippet_bootstrap_id( $post_id ),
+		'bootstrap' => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {
@@ -364,19 +370,28 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  * the visible example code. JSON encoding matches the snippet code payloads:
  * JSON_HEX_TAG escapes `<` so the payload stays inert in HTML.
  *
- * @param int $post_id Post ID.
+ * Only the first call renders the tag, so a page with several code
+ * descriptions still holds a single element with this ID.
+ *
  * @return string
  */
-function render_php_code_snippet_bootstrap_script( $post_id ) {
+function render_php_code_snippet_bootstrap_script() {
+	static $rendered = false;
+	if ( $rendered ) {
+		return '';
+	}
+
 	$bootstrap = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 	if ( ! is_string( $bootstrap ) ) {
 		return '';
 	}
 
+	$rendered = true;
+
 	return wp_get_inline_script_tag(
 		$bootstrap,
 		array(
-			'id'   => get_php_code_snippet_bootstrap_id( $post_id ),
+			'id'   => PHP_CODE_SNIPPET_BOOTSTRAP_ID,
 			'type' => 'application/x-php+json',
 		)
 	);
@@ -394,16 +409,6 @@ function render_php_code_snippet_bootstrap_script( $post_id ) {
  */
 function get_php_code_snippet_blueprint_id( $post_id, $key ) {
 	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . rawurlencode( $key );
-}
-
-/**
- * Return a stable script ID for the shared WordPress bootstrap.
- *
- * @param int $post_id Post ID.
- * @return string
- */
-function get_php_code_snippet_bootstrap_id( $post_id ) {
-	return 'wporg-code-snippet-bootstrap-' . absint( $post_id );
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -361,19 +361,23 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  *
  * Snippets reference this element from their `bootstrap` attribute so they
  * run with WordPress loaded, without repeating the wp-load boilerplate in
- * the visible example code. The payload never reaches the browser as
- * executable JavaScript: `application/x-php` scripts are inert until the
- * snippet component reads them.
+ * the visible example code. JSON encoding matches the snippet code payloads:
+ * JSON_HEX_TAG escapes `<` so the payload stays inert in HTML.
  *
  * @param int $post_id Post ID.
  * @return string
  */
 function render_php_code_snippet_bootstrap_script( $post_id ) {
+	$bootstrap = wp_json_encode( "<?php require_once '/wordpress/wp-load.php';", JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $bootstrap ) ) {
+		return '';
+	}
+
 	return wp_get_inline_script_tag(
-		"<?php require_once '/wordpress/wp-load.php';",
+		$bootstrap,
 		array(
 			'id'   => get_php_code_snippet_bootstrap_id( $post_id ),
-			'type' => 'application/x-php',
+			'type' => 'application/x-php+json',
 		)
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -120,6 +120,10 @@ function get_description_content( $post_id ) {
 			array(),
 			null
 		);
+
+		// Emit the shared WordPress bootstrap once, ahead of the snippets
+		// that reference it.
+		$output .= render_php_code_snippet_bootstrap_script( $post_id );
 	}
 
 	// Emit the referenced setup Blueprint <script> tags once, up front.
@@ -268,7 +272,8 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
-		'name' => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'name'      => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'bootstrap' => '#' . get_php_code_snippet_bootstrap_id( $post_id ),
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {
@@ -352,6 +357,28 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
 }
 
 /**
+ * Render the shared WordPress bootstrap script tag for PHP code snippets.
+ *
+ * Snippets reference this element from their `bootstrap` attribute so they
+ * run with WordPress loaded, without repeating the wp-load boilerplate in
+ * the visible example code. The payload never reaches the browser as
+ * executable JavaScript: `application/x-php` scripts are inert until the
+ * snippet component reads them.
+ *
+ * @param int $post_id Post ID.
+ * @return string
+ */
+function render_php_code_snippet_bootstrap_script( $post_id ) {
+	return wp_get_inline_script_tag(
+		"<?php require_once '/wordpress/wp-load.php';",
+		array(
+			'id'   => get_php_code_snippet_bootstrap_id( $post_id ),
+			'type' => 'application/x-php',
+		)
+	);
+}
+
+/**
  * Return a stable script ID for a snippet Blueprint.
  *
  * URL encoding preserves distinct Blueprint keys while removing the ASCII
@@ -363,6 +390,16 @@ function render_php_code_snippet_blueprint_script( $id, $blueprint ) {
  */
 function get_php_code_snippet_blueprint_id( $post_id, $key ) {
 	return 'wporg-code-snippet-blueprint-' . absint( $post_id ) . '-' . rawurlencode( $key );
+}
+
+/**
+ * Return a stable script ID for the shared WordPress bootstrap.
+ *
+ * @param int $post_id Post ID.
+ * @return string
+ */
+function get_php_code_snippet_bootstrap_id( $post_id ) {
+	return 'wporg-code-snippet-bootstrap-' . absint( $post_id );
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -278,8 +278,9 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 
 	$inline_blueprint_id = get_php_code_snippet_blueprint_id( $post_id, 'inline:' . ( $index + 1 ) );
 	$attributes = array(
-		'name'      => $post_slug . '-' . ( $index + 1 ) . '.php',
-		'bootstrap' => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+		'name'         => $post_slug . '-' . ( $index + 1 ) . '.php',
+		'bootstrap'    => '#' . PHP_CODE_SNIPPET_BOOTSTRAP_ID,
+		'php-fragment' => '',
 	);
 
 	if ( array_key_exists( 'blueprint', $snippet ) ) {


### PR DESCRIPTION
Readers of Code Reference examples should see and edit only the code that documents the API—not the Playground-specific `require '/wordpress/wp-load.php';` boilerplate—while still running examples with WordPress loaded, including after editing them.

This wires the theme side of WordPress/wordpress-playground#4261:

- Emits one shared run-before element per reference page that renders snippets, alongside the existing setup Blueprint scripts:
  ```html
  <script id="wporg-code-snippet-run-before" type="application/x-php+json">"\u003C?php require_once '/wordpress/wp-load.php';"</script>
  ```
  The payload is JSON-encoded with the `+json` script type, matching how the block already emits snippet code and expected output. `JSON_HEX_TAG` keeps `<` escaped so the payload remains inert in HTML.
- Stamps `run-before="#wporg-code-snippet-run-before"` and `php-fragment` on every `<php-snippet>` emitted by the code-description block, including placeholder-placed and appended-fallback snippets.

The shared script is a complete PHP file with its own opening tag. Parser-provided examples remain fragments, so `php-fragment` adds their opening tag without displaying it in the editor.

This depends on WordPress/wordpress-playground#4262 and should land after that component change.

The Playground-handbook import path (`inc/import-playground.php`) remains untouched. Those embeds reproduce Playground documentation examples authored for their own execution context.

## Testing

Import parser data containing interactive snippets, open a Code Reference page, and confirm the page source contains exactly one `wporg-code-snippet-run-before` script; every `<php-snippet>` carries the matching `run-before` attribute and `php-fragment`; and examples run with WordPress loaded while displaying no opening tag or `wp-load.php` boilerplate.
