### PR TITLE
Interactive snippets: render the snippet source as a code block

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1746,9 +1746,10 @@ namespace DevHub {
 
 			// The parser rendered the description with Parsedown at import, so
 			// it arrives as complete HTML and `wpautop()` has nothing to add.
-			// What it does add is wrong: it wraps a snippet placeholder comment
-			// in a paragraph (or leaves an unclosed one inside a list item),
-			// and it turns the DocBlock's line wrapping into `<br>`.
+			// What it does add is wrong: it wraps the `[code]` shortcode text
+			// and the snippet placeholder comment in paragraphs (or leaves an
+			// unclosed one inside a list item). Both expand to a `<pre>`, which
+			// closes the paragraph and is ejected from it by the HTML parser.
 			$wpautop_priority = has_filter( 'the_content', 'wpautop' );
 			if ( false !== $wpautop_priority ) {
 				remove_filter( 'the_content', 'wpautop', $wpautop_priority );

--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1744,7 +1744,21 @@ namespace DevHub {
 			// Remove the filter that adds the code reference block to the content.
 			remove_filter( 'the_content', 'DevHub\filter_code_content', 4 );
 
+			// The parser rendered the description with Parsedown at import, so
+			// it arrives as complete HTML and `wpautop()` has nothing to add.
+			// What it does add is wrong: it wraps a snippet placeholder comment
+			// in a paragraph (or leaves an unclosed one inside a list item),
+			// and it turns the DocBlock's line wrapping into `<br>`.
+			$wpautop_priority = has_filter( 'the_content', 'wpautop' );
+			if ( false !== $wpautop_priority ) {
+				remove_filter( 'the_content', 'wpautop', $wpautop_priority );
+			}
+
 			$description = apply_filters( 'the_content', apply_filters( 'get_the_content' , $description ) );
+
+			if ( false !== $wpautop_priority ) {
+				add_filter( 'the_content', 'wpautop', $wpautop_priority );
+			}
 
 			// Re-add the filter that adds this block to the content.
 			add_filter( 'the_content', 'DevHub\filter_code_content', 4 );

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -268,8 +268,8 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		$code = substr( $code, strlen( $preamble ) );
 	}
 
-	$code = wp_json_encode( $code, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
-	if ( ! is_string( $code ) ) {
+	$json_encoded_code = wp_json_encode( $code, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $json_encoded_code ) ) {
 		return '';
 	}
 
@@ -318,9 +318,17 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		$output .= render_php_code_snippet_blueprint_script( $attributes['blueprint'], $snippet['blueprint'] );
 	}
 
-	$snippet_output = '<php-snippet>';
+	/*
+	 * A `<pre>` start tag closes an open `<p>`, and the description renders
+	 * snippets inside one: `wpautop()` puts a bare placeholder comment in a
+	 * paragraph. Without a wrapper the parser carries the code block alone out
+	 * of the paragraph, tearing it off the element it belongs to. A `<div>`
+	 * closes the paragraph the same way but takes the whole snippet with it,
+	 * so the code block stays where it was written.
+	 */
+	$snippet_output = '<div class="wporg-php-snippet"><php-snippet>';
 	$snippet_output .= wp_get_inline_script_tag(
-		$code,
+		$json_encoded_code,
 		array( 'type' => 'application/x-php+json' )
 	);
 
@@ -331,7 +339,8 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		);
 	}
 
-	$snippet_output .= '</php-snippet>';
+	$snippet_output .= render_php_code_snippet_source( $code );
+	$snippet_output .= '</php-snippet></div>';
 
 	$tags = new \WP_HTML_Tag_Processor( $snippet_output );
 	if ( $tags->next_tag( 'php-snippet' ) ) {
@@ -344,6 +353,35 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	$output .= $snippet_output;
 
 	return $output;
+}
+
+/**
+ * Render the snippet source as a code block.
+ *
+ * `<php-snippet>` builds its interface in a shadow root with no slot, so this
+ * markup is what a reader sees before the Playground script upgrades the
+ * element, and all they see if it never loads.
+ *
+ * @param string $code Snippet PHP source.
+ * @return string
+ */
+function render_php_code_snippet_source( $code ) {
+	// The Tag Processor can replace text but cannot create it, so the code
+	// element carries a placeholder for `set_modifiable_text()` to overwrite.
+	$html = new \WP_HTML_Tag_Processor(
+		'<pre class="wp-block-code"><code class="language-php">placeholder</code></pre>'
+	);
+
+	if (
+		! $html->next_tag( 'CODE' ) ||
+		! $html->next_token() ||
+		'#text' !== $html->get_token_type() ||
+		! $html->set_modifiable_text( $code )
+	) {
+		return '';
+	}
+
+	return $html->get_updated_html();
 }
 
 /**

--- a/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-description/block.php
@@ -318,15 +318,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 		$output .= render_php_code_snippet_blueprint_script( $attributes['blueprint'], $snippet['blueprint'] );
 	}
 
-	/*
-	 * A `<pre>` start tag closes an open `<p>`, and the description renders
-	 * snippets inside one: `wpautop()` puts a bare placeholder comment in a
-	 * paragraph. Without a wrapper the parser carries the code block alone out
-	 * of the paragraph, tearing it off the element it belongs to. A `<div>`
-	 * closes the paragraph the same way but takes the whole snippet with it,
-	 * so the code block stays where it was written.
-	 */
-	$snippet_output = '<div class="wporg-php-snippet"><php-snippet>';
+	$snippet_output = '<php-snippet>';
 	$snippet_output .= wp_get_inline_script_tag(
 		$json_encoded_code,
 		array( 'type' => 'application/x-php+json' )
@@ -340,7 +332,7 @@ function render_php_code_snippet( $post_id, $index, $snippet, $setup_blueprints,
 	}
 
 	$snippet_output .= render_php_code_snippet_source( $code );
-	$snippet_output .= '</php-snippet></div>';
+	$snippet_output .= '</php-snippet>';
 
 	$tags = new \WP_HTML_Tag_Processor( $snippet_output );
 	if ( $tags->next_tag( 'php-snippet' ) ) {


### PR DESCRIPTION
Add a `<pre><code>` fallback inside `<php-snippet>` so the source is readable before the Playground module loads, or when JavaScript is unavailable. The element's shadow root hides the fallback after initialization.

Depends on #595. Without it, `wpautop()` encloses snippet placeholders in paragraphs. The fallback's `<pre>` start tag closes the paragraph, causing the HTML parser to place the fallback outside `<php-snippet>`.

`render_php_snippet()` builds the markup from one template using the HTML API. `set_modifiable_text()` preserves literal character references such as `&lt;egg&gt;` in the displayed source. The expected-output script is omitted when no output is specified; an empty string remains valid expected output.

Validation:

- Sandbox HTML for `WP_HTML_Tag_Processor::class_list()` has the fallback inside `<php-snippet>`, with text matching the JSON source.
- Four snippet placements were checked in a browser with the Playground module loaded and blocked, along with escaping round trips and nested content filters.
- PHP syntax, whitespace checks, and 15 template-rendering cases passed, covering source and attribute escaping and absent versus empty expected output.

Implemented with Claude Code and reviewed by me; template refactor and description edits with Codex.
