### PR TITLE
Escape attributes and content in Code Reference blocks

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/src/code-comments/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comments/block.php
@@ -56,19 +56,18 @@ function render( $attributes, $content, $block ) {
 		);
 	}
 
-	ob_start(); // Capture all output
-
 	$ordered_comments = wporg_developer_get_ordered_notes();
 
 	if ( empty( $ordered_comments ) ) {
 		return '';
 	}
 
+	ob_start(); // Capture all output
 	wporg_developer_list_notes( $ordered_comments, array() );
 
 	$output = ob_get_clean();
 
-	// filter_code_content() re-parses this output via do_blocks(), so neutralize any block delimiter before it reaches the parser.
+	// This output is block-parsed a second time (core's do_blocks at the_content priority 9), so neutralize any block delimiter in it.
 	$output = preg_replace( '/<!--(\s*\/?wp:)/', '&lt;!--$1', $output );
 
 	$wrapper_attributes = get_block_wrapper_attributes( [ 'data-nosnippet' => 'true' ] );

--- a/source/wp-content/themes/wporg-developer-2023/src/code-comments/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-comments/block.php
@@ -68,16 +68,14 @@ function render( $attributes, $content, $block ) {
 
 	$output = ob_get_clean();
 
-	$title_block = sprintf(
-		'<!-- wp:heading --><h2 class="wp-block-heading">%s</h2><!-- /wp:heading -->',
-		__( 'User Contributed Notes', 'wporg' )
-	);
+	// filter_code_content() re-parses this output via do_blocks(), so neutralize any block delimiter before it reaches the parser.
+	$output = preg_replace( '/<!--(\s*\/?wp:)/', '&lt;!--$1', $output );
 
 	$wrapper_attributes = get_block_wrapper_attributes( [ 'data-nosnippet' => 'true' ] );
 	return sprintf(
-		'<section %1$s>%2$s <ol class="comment-list">%3$s</ol></section>',
+		'<section %1$s><h2 class="wp-block-heading">%2$s</h2> <ol class="comment-list">%3$s</ol></section>',
 		$wrapper_attributes,
-		$title_block,
+		esc_html__( 'User Contributed Notes', 'wporg' ),
 		$output
 	);
 }

--- a/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
@@ -25,7 +25,11 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes ) {
-	$table  = '<!-- wp:table {"className":"' . $attributes['className'] . '"} --><figure class="wp-block-table ' . $attributes['className'] . '">';
+	$class_name = isset( $attributes['className'] ) ? (string) $attributes['className'] : '';
+
+	// Escape className for the class attribute and JSON-encode it for the delimiter.
+	$table  = '<!-- wp:table {"className":' . wp_json_encode( $class_name ) . '} -->';
+	$table .= '<figure class="' . esc_attr( 'wp-block-table ' . $class_name ) . '">';
 	$table .= '<table>';
 	$table .= '<thead>';
 	$table .= '<tr>';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-table/block.php
@@ -27,8 +27,8 @@ function init() {
 function render( $attributes ) {
 	$class_name = isset( $attributes['className'] ) ? (string) $attributes['className'] : '';
 
-	// Escape className for the class attribute and JSON-encode it for the delimiter.
-	$table  = '<!-- wp:table {"className":' . wp_json_encode( $class_name ) . '} -->';
+	// serialize_block_attributes() keeps className from breaking out of the delimiter comment.
+	$table  = '<!-- wp:table ' . serialize_block_attributes( array( 'className' => $class_name ) ) . ' -->';
 	$table .= '<figure class="' . esc_attr( 'wp-block-table ' . $class_name ) . '">';
 	$table .= '<table>';
 	$table .= '<thead>';

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/block.json
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/block.json
@@ -15,6 +15,7 @@
 		},
 		"tagName": {
 			"type": "string",
+			"enum": [ "h1", "h2", "h3", "h4", "h5", "h6", "p", "dt", "div", "span" ],
 			"default": "h1"
 		}
 	},

--- a/source/wp-content/themes/wporg-developer-2023/src/code-title/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/code-title/block.php
@@ -46,10 +46,15 @@ function render( $attributes, $content, $block ) {
 		);
 	}
 
+	// tagName is an element name, not an attribute value, so allow-list it instead of esc_attr().
+	$allowed_tags = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'dt', 'div', 'span' );
+	$tag_name     = isset( $attributes['tagName'] ) ? strtolower( (string) $attributes['tagName'] ) : 'h1';
+	$tag_name     = in_array( $tag_name, $allowed_tags, true ) ? $tag_name : 'h1';
+
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
 		'<%1$s %2$s>%3$s</%1$s>',
-		esc_attr( $attributes['tagName'] ),
+		$tag_name,
 		$wrapper_attributes,
 		$content
 	);

--- a/source/wp-content/themes/wporg-developer-2023/src/command-content/block.php
+++ b/source/wp-content/themes/wporg-developer-2023/src/command-content/block.php
@@ -46,7 +46,8 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$repo_slug = str_replace( 'https://github.com/', '', $repo_url );
-	$command = get_the_title( $post_ID );
+	// Title flows into HTML that do_blocks() re-parses, so escape it.
+	$command = esc_html( get_the_title( $post_ID ) );
 	$installing_instructions = sprintf(
 		'<!-- wp:heading {"level":3} --><h3 class="wp-block-heading">%1$s</h3><!-- /wp:heading -->',
 		__( 'Installing', 'wporg' )


### PR DESCRIPTION
Tidies up output escaping in the Code Reference dynamic block render callbacks so each attribute and content value is escaped for the context it actually renders into, matching the values that are already handled correctly beside them.

- **code-comments** — render the "User Contributed Notes" heading directly instead of relying on a second block-parse pass, and drop stray block markup from the buffered notes output.
- **code-title** — restrict `tagName` to a known set of element names (with a matching `enum` in `block.json`) rather than passing it straight through.
- **code-table** — escape `className` into the `figure` class attribute and JSON-encode it in the block delimiter.
- **command-content** — escape the post title before it is interpolated into the install instructions.

No template markup or rendered output changes for existing content; the block signatures and callers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
