### PR TITLE
Refine shortcode handling and escaping in Code Reference

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
@@ -862,6 +862,8 @@ class DevHub_Formatting {
 		$lang = in_array( $attr['lang'] ?? '', $lang_list ) ? $attr['lang'] ?? '': 'php';
 
 		$content = self::_trim_code( $content );
+		// do_blocks() re-parses this content, so neutralize any block delimiter in it.
+		$content = preg_replace( '/<!--(\s*\/?wp:)/', '&lt;!--$1', $content );
 		// Hides numbers if <= 4 lines of code (last line has no linebreak).
 		$show_line_numbers = substr_count( $content, "\n" ) > 3;
 

--- a/source/wp-content/themes/wporg-developer-2023/inc/import-playground.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/import-playground.php
@@ -368,6 +368,11 @@ class DevHub_Playground_Importer extends DevHub_Docs_Importer {
 	 * @return string
 	 */
 	public function render_php_code_snippet( $attributes ) {
+		// This embed carries raw HTML, so only render it on its own imported handbook.
+		if ( get_post_type() !== $this->get_post_type() ) {
+			return '';
+		}
+
 		$attributes = shortcode_atts( array( 'encoded' => '' ), $attributes );
 		$html       = base64_decode( $attributes['encoded'], true );
 

--- a/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
@@ -49,9 +49,9 @@ add_shortcode(
 		$post = get_post();
 		$markdown_source = get_markdown_edit_link( $post->ID ?? 0 );
 		// If this is a github page, use the edit URL to generate the
-		// commit history URL
+		// commit history URL. wporg_markdown_source is unescaped post meta, so escape the URL.
 		if ( str_contains( $markdown_source, 'github.com' ) ) {
-			return str_replace( '/edit/', '/commits/', $markdown_source );
+			return esc_url( str_replace( '/edit/', '/commits/', $markdown_source ) );
 		}
 		return '#';
 	}

--- a/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/shortcodes.php
@@ -46,14 +46,16 @@ add_shortcode(
 add_shortcode(
 	'article_changelog_link',
 	function() {
-		$post = get_post();
+		$url             = '';
+		$post            = get_post();
 		$markdown_source = get_markdown_edit_link( $post->ID ?? 0 );
-		// If this is a github page, use the edit URL to generate the
-		// commit history URL. wporg_markdown_source is unescaped post meta, so escape the URL.
+
+		// Rewrite the GitHub edit URL to a commit-history URL; esc_url() the unescaped meta and fall back to '#'.
 		if ( str_contains( $markdown_source, 'github.com' ) ) {
-			return esc_url( str_replace( '/edit/', '/commits/', $markdown_source ) );
+			$url = esc_url( str_replace( '/edit/', '/commits/', $markdown_source ) );
 		}
-		return '#';
+
+		return $url ? $url : '#';
 	}
 );
 

--- a/source/wp-content/themes/wporg-developer-2023/inc/user-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/user-content.php
@@ -34,8 +34,8 @@ class DevHub_User_Submitted_Content {
 		// Force comment registration to be true
 		add_filter( 'pre_option_comment_registration', '__return_true' );
 
-		// Force comment moderation to be true
-		add_filter( 'pre_option_comment_moderation',   '__return_true' );
+		// Force comment moderation to be true. check_comment() compares against the string '1'.
+		add_filter( 'pre_option_comment_moderation',   array( __CLASS__, 'hold_comments_for_moderation' ) );
 
 		// Remove reply to link
 		add_filter( 'comment_reply_link',              '__return_empty_string' );
@@ -49,8 +49,8 @@ class DevHub_User_Submitted_Content {
 		// Disable capital_P_dangit
 		remove_filter( 'comment_text',                 'capital_P_dangit',   31 );
 
-		// Enable shortcodes for comments
-		add_filter( 'comment_text',                    'do_shortcode' );
+		// Allow only formatting shortcodes in notes; anything else stays opt-in.
+		add_filter( 'comment_text', array( __CLASS__, 'do_note_shortcodes' ) );
 
 		// Customize allowed tags
 		add_filter( 'wp_kses_allowed_html',            array( __CLASS__, 'wp_kses_allowed_html' ), 10, 2 );
@@ -69,6 +69,38 @@ class DevHub_User_Submitted_Content {
 
 		// Disable moderation emails to post author.
 		add_filter( 'comment_notification_recipients', array( __CLASS__, 'disable_comment_notifications' ), 10, 2 );
+	}
+
+	/**
+	 * Forces every note into the moderation queue.
+	 *
+	 * @return string
+	 */
+	public static function hold_comments_for_moderation() {
+		return '1';
+	}
+
+	/**
+	 * Expands only the formatting shortcodes over comment text.
+	 *
+	 * @param string $text Comment text.
+	 * @return string Comment text with the formatting shortcodes expanded.
+	 */
+	public static function do_note_shortcodes( $text ) {
+		$allowed = array( 'code', 'php', 'js', 'css' );
+		$removed = array_diff_key( $GLOBALS['shortcode_tags'], array_flip( $allowed ) );
+
+		foreach ( array_keys( $removed ) as $tag ) {
+			remove_shortcode( $tag );
+		}
+
+		$text = do_shortcode( $text );
+
+		foreach ( $removed as $tag => $callback ) {
+			add_shortcode( $tag, $callback );
+		}
+
+		return $text;
 	}
 
 	/**


### PR DESCRIPTION
Tidies up how the Code Reference handles shortcodes in user notes and a few shortcode outputs, so each value is scoped and escaped for the context it renders into.

- **User notes** (`inc/user-content.php`) — expand only the formatting shortcodes (`code`, `php`, `js`, `css`) over note text rather than every registered shortcode, and return the option value `check_comment()` actually compares against so notes are held for moderation as intended.
- **Code shortcode** (`inc/formatting.php`) — neutralize block delimiters in `[code]`/`[php]`/`[js]`/`[css]` content before it is handed back to the block parser.
- **Playground snippet** (`inc/import-playground.php`) — render the `[playground_php_snippet]` embed only on its own imported handbook post type, where it originates.
- **Changelog link** (`inc/shortcodes.php`) — escape the returned URL, matching the neighboring `[article_edit_link]` shortcode.

No template markup or callers change; existing handbook and reference content renders the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
