### PR TITLE
Respect password-protected posts in descriptions

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/head.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/head.php
@@ -134,7 +134,8 @@ class DevHub_Head {
 			$desc = get_the_excerpt();
 		} elseif ( is_singular() ) {
 			$post = get_queried_object();
-			if ( $post ) {
+			// Reading post_content directly bypasses the password gate get_the_content() applies.
+			if ( $post && ! post_password_required( $post ) ) {
 				$desc = $post->post_content;
 			}
 		}

--- a/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/template-tags.php
@@ -1690,6 +1690,11 @@ namespace DevHub {
 	function get_summary( $post = null ) {
 		$post = get_post( $post );
 
+		// Reading the raw excerpt column bypasses the password gate; withhold it when protected.
+		if ( post_password_required( $post ) ) {
+			return '';
+		}
+
 		$summary = $post->post_excerpt;
 
 		if ( $summary ) {
@@ -1733,6 +1738,11 @@ namespace DevHub {
 	 */
 	function get_description( $post = null ) {
 		$post = get_post( $post );
+
+		// Reading the raw content column bypasses the password gate; withhold it when protected.
+		if ( post_password_required( $post ) ) {
+			return '';
+		}
 
 		$description = $post->post_content;
 


### PR DESCRIPTION
Makes the theme's own description rendering honor post password protection, matching what WordPress's content and excerpt accessors already do.

- **Meta description** (`inc/head.php`) — the singular branch reads `post_content` off the post object directly; skip it for a password-protected post, the same way the neighboring branches already use `get_the_excerpt()`.
- **Code Reference summary & description** (`inc/template-tags.php`) — `get_summary()` and `get_description()` read the raw excerpt/content columns, so they return empty for a protected post. The summary and description blocks already treat empty content as "render nothing," so a protected entry shows no summary or description. Fixing it in the two helpers means every consumer (both blocks and the Related/Uses listings) inherits the behavior.

No change for ordinary posts: `post_password_required()` is `false`, so rendering is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
