### PR TITLE
Escape the attached Trac ticket title

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
@@ -222,7 +222,7 @@ class WPORG_Edit_Parsed_Content {
 			update_post_meta( $post_id, 'wporg_ticket_number', $ticket_no );
 			update_post_meta( $post_id, 'wporg_ticket_title', $title );
 
-			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), esc_html( $title ) );
+			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), esc_html( apply_filters( 'the_title', $title ) ) );
 
 			// Can haz success.
 			wp_send_json_success( array(

--- a/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
@@ -222,7 +222,7 @@ class WPORG_Edit_Parsed_Content {
 			update_post_meta( $post_id, 'wporg_ticket_number', $ticket_no );
 			update_post_meta( $post_id, 'wporg_ticket_title', $title );
 
-			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), apply_filters( 'the_title', $title ) );
+			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), esc_html( $title ) );
 
 			// Can haz success.
 			wp_send_json_success( array(

--- a/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
@@ -182,6 +182,15 @@ class WPORG_Edit_Parsed_Content {
 	public function attach_ticket() {
 		check_ajax_referer( 'wporg-attach-ticket', 'nonce' );
 
+		$post_id = empty( $_REQUEST['post_id'] ) ? 0 : absint( $_REQUEST['post_id'] );
+
+		if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+			wp_send_json_error( array(
+				'message'   => __( 'Insufficient permissions.', 'wporg' ),
+				'new_nonce' => wp_create_nonce( 'wporg-attach-ticket' ),
+			) );
+		}
+
 		$ticket_no  = empty( $_REQUEST['ticket'] ) ? 0 : absint( $_REQUEST['ticket'] );
 		$ticket_url = "https://core.trac.wordpress.org/ticket/{$ticket_no}";
 
@@ -210,16 +219,10 @@ class WPORG_Edit_Parsed_Content {
 				die( -1 );
 			}
 
-			$post_id = empty( $_REQUEST['post_id'] ) ? 0 : absint( $_REQUEST['post_id'] );
-
-			if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
-				wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'wporg' ) ) );
-			}
-
 			update_post_meta( $post_id, 'wporg_ticket_number', $ticket_no );
 			update_post_meta( $post_id, 'wporg_ticket_title', $title );
 
-			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), esc_html( apply_filters( 'the_title', $title ) ) );
+			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), apply_filters( 'the_title', $title ) );
 
 			// Can haz success.
 			wp_send_json_success( array(

--- a/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/parsed-content.php
@@ -200,7 +200,9 @@ class WPORG_Edit_Parsed_Content {
 				@$doc->loadHTML( $body );
 
 				$nodes = $doc->getElementsByTagName( 'title' );
-				$title = $nodes->item( 0 )->nodeValue;
+
+				// nodeValue is decoded text; treat it as untrusted and guard the missing title.
+				$title = $nodes->item( 0 ) ? sanitize_text_field( $nodes->item( 0 )->nodeValue ) : '';
 
 				// Strip off the site name.
 				$title = str_ireplace( ' – WordPress Trac', '', $title );
@@ -210,10 +212,14 @@ class WPORG_Edit_Parsed_Content {
 
 			$post_id = empty( $_REQUEST['post_id'] ) ? 0 : absint( $_REQUEST['post_id'] );
 
+			if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+				wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'wporg' ) ) );
+			}
+
 			update_post_meta( $post_id, 'wporg_ticket_number', $ticket_no );
 			update_post_meta( $post_id, 'wporg_ticket_title', $title );
 
-			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), apply_filters( 'the_title', $title ) );
+			$link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $ticket_url ), esc_html( apply_filters( 'the_title', $title ) ) );
 
 			// Can haz success.
 			wp_send_json_success( array(


### PR DESCRIPTION
Tightens the "Attach Ticket" AJAX handler so the Trac ticket title is handled safely for the response it goes into.

- Escape the title in the JSON `message` — `js/parsed-content.js` inserts it with jQuery `.html()`.
- Sanitize the `DOMDocument` `nodeValue` where it is read (it comes back HTML-decoded), and guard the case where the page has no `<title>` (currently a fatal on `->nodeValue`).
- Check `edit_post` on the target post before writing the ticket meta, rather than relying on the nonce alone.

No change to the stored value (its registered `sanitize_text_field` already ran); this only affects the returned string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
