### PR TITLE
Escape unresolved references in the doclink expander

### DIFF
--- a/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
+++ b/source/wp-content/themes/wporg-developer-2023/inc/formatting.php
@@ -170,7 +170,10 @@ class DevHub_Formatting {
 
 				// Link to an internal resource.
 				else {
-					$link = self::link_internal_element( $link );
+					$internal = self::link_internal_element( $link );
+
+					// Escape an unlinked value: unchanged input is untrusted (possibly decoded) text, not generated markup.
+					$link = ( $internal === $link ) ? esc_html( $link ) : $internal;
 				}
 
 				return $link;


### PR DESCRIPTION
`DevHub_Formatting::make_doclink_clickable()` expands `{@link}` / `{@see}` references on `the_content`. When a reference resolves to a real link, `link_internal_element()` returns generated anchor markup (already escaped via `generate_link()`); when it does not resolve, it returns the reference string unchanged.

This makes the non-resolving path return the value as escaped text instead of raw output, so only generated link markup is ever emitted as HTML. Resolved references are unaffected — the escape is applied only when `link_internal_element()` hands the input back untouched.

Verified against all six supported reference forms (external with/without text, class, method, function, hook, class variable): links still render correctly, and unresolved references render as inert text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)